### PR TITLE
Add Knowledge Vault graph page

### DIFF
--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -39,6 +39,12 @@ import {
   isBuiltinSkillsFactoryGroupPath,
   sortSkillsFactoryItems,
 } from "./skillsFactory.js";
+import { KnowledgeCubeGraph } from "./KnowledgeCubeGraph.jsx";
+import {
+  buildKnowledgeGraphRequest,
+  normalizeKnowledgeResults,
+  summarizeKnowledgeGraph,
+} from "./knowledgeVault.js";
 
 const REFRESH_DEBOUNCE_MS = 350;
 const AUTO_REFRESH_MS = 5000;
@@ -1857,7 +1863,7 @@ function App() {
   const [planes, setPlanes] = useState([]);
   const [selectedPlane, setSelectedPlane] = useState(initialPlane);
   const [selectedPage, setSelectedPage] = useState(
-    ["dashboard", "planes", "models", "skills-factory", "access"].includes(initialPage)
+    ["dashboard", "planes", "models", "knowledge-vault", "skills-factory", "access"].includes(initialPage)
       ? initialPage
       : "dashboard",
   );
@@ -1895,6 +1901,13 @@ function App() {
   const [events, setEvents] = useState([]);
   const [interactionStatus, setInteractionStatus] = useState(null);
   const [knowledgeVaultStatus, setKnowledgeVaultStatus] = useState(null);
+  const [knowledgeVaultGraph, setKnowledgeVaultGraph] = useState({
+    nodes: [],
+    edges: [],
+    warnings: [],
+  });
+  const [knowledgeVaultGraphBusy, setKnowledgeVaultGraphBusy] = useState(false);
+  const [knowledgeVaultGraphError, setKnowledgeVaultGraphError] = useState("");
   const [modelLibrary, setModelLibrary] = useState({ items: [], roots: [], jobs: [], nodes: [] });
   const [skillsFactory, setSkillsFactory] = useState({
     items: [],
@@ -1996,6 +2009,9 @@ function App() {
     setEvents([]);
     setInteractionStatus(null);
     setKnowledgeVaultStatus(null);
+    setKnowledgeVaultGraph({ nodes: [], edges: [], warnings: [] });
+    setKnowledgeVaultGraphBusy(false);
+    setKnowledgeVaultGraphError("");
     setModelLibrary({ items: [], roots: [], jobs: [], nodes: [] });
     setModelsTab("library");
     setSkillsFactory({
@@ -2155,6 +2171,51 @@ function App() {
         return;
       }
       throw error;
+    }
+  }
+
+  async function refreshKnowledgeVaultGraph() {
+    setKnowledgeVaultGraphBusy(true);
+    setKnowledgeVaultGraphError("");
+    try {
+      const searchPayload = await fetchJson(knowledgeVaultPath("search"), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          query: "",
+          list_all: true,
+          limit: 100,
+        }),
+      });
+      const results = normalizeKnowledgeResults(searchPayload?.results);
+      const graphRequest = buildKnowledgeGraphRequest(results, [], 100);
+      if (graphRequest.knowledge_ids.length === 0) {
+        setKnowledgeVaultGraph({ nodes: [], edges: [], warnings: [] });
+        return;
+      }
+      const graphPayload = await fetchJson(knowledgeVaultPath("graph-neighborhood"), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(graphRequest),
+      });
+      setKnowledgeVaultGraph({
+        nodes: Array.isArray(graphPayload?.nodes) ? graphPayload.nodes : [],
+        edges: Array.isArray(graphPayload?.edges) ? graphPayload.edges : [],
+        warnings: Array.isArray(graphPayload?.warnings) ? graphPayload.warnings : [],
+      });
+    } catch (error) {
+      if (error?.status === 401) {
+        handleUnauthorized();
+        return;
+      }
+      setKnowledgeVaultGraphError(error.message || String(error));
+      setKnowledgeVaultGraph({ nodes: [], edges: [], warnings: [] });
+    } finally {
+      setKnowledgeVaultGraphBusy(false);
     }
   }
 
@@ -3276,6 +3337,17 @@ function App() {
     return () => clearInterval(timer);
   }, [authState.authenticated, selectedPlane, selectedPage]);
 
+  useEffect(() => {
+    if (!authState.authenticated || selectedPage !== "knowledge-vault") {
+      return undefined;
+    }
+    refreshKnowledgeVaultGraph();
+    const timer = setInterval(() => {
+      refreshKnowledgeVaultGraph();
+    }, AUTO_REFRESH_MS);
+    return () => clearInterval(timer);
+  }, [authState.authenticated, selectedPage]);
+
   const hasActiveModelJobsForPolling = Array.isArray(modelLibrary.jobs)
     ? modelLibrary.jobs.some((job) => {
         const status = String(job?.status || "").toLowerCase();
@@ -3628,6 +3700,19 @@ function App() {
   const modelsNavMeta = activeModelJobs > 0
     ? `${activeModelJobs} download job${activeModelJobs === 1 ? "" : "s"}`
     : `${activeModelCount} discovered model${activeModelCount === 1 ? "" : "s"}`;
+  const knowledgeGraphSummary = summarizeKnowledgeGraph(knowledgeVaultGraph);
+  const knowledgeVaultStatusText = String(knowledgeVaultStatus?.status || "inactive");
+  const knowledgeVaultStatusLower = knowledgeVaultStatusText.toLowerCase();
+  const knowledgeVaultNavClass = knowledgeVaultGraphError
+    ? "is-critical"
+    : knowledgeVaultGraphBusy
+      ? "is-warning"
+      : ["active", "ready", "running", "healthy"].includes(knowledgeVaultStatusLower)
+        ? "is-healthy"
+        : "is-booting";
+  const knowledgeVaultNavMeta = knowledgeVaultStatus?.node_name
+    ? `node ${knowledgeVaultStatus.node_name}`
+    : `${knowledgeGraphSummary.nodeCount} record${knowledgeGraphSummary.nodeCount === 1 ? "" : "s"}`;
   function handleModelLibraryScroll(event) {
     const node = event.currentTarget;
     if (!hasMoreModelItems) {
@@ -5405,6 +5490,73 @@ function App() {
     });
   }
 
+  function renderKnowledgeVaultPage() {
+    return (
+      <section className="panel page-panel knowledge-vault-page-panel">
+        <div className="panel-header">
+          <div>
+            <div className="section-label">Knowledge Vault</div>
+            <h2>Canonical Knowledge Vault</h2>
+          </div>
+          <div className="toolbar">
+            <span className={`tag ${knowledgeVaultNavClass}`}>
+              {statusDot(knowledgeVaultNavClass)}
+              <span>{knowledgeVaultStatusText}</span>
+            </span>
+            <button
+              className="ghost-button"
+              type="button"
+              onClick={refreshKnowledgeVaultGraph}
+              disabled={knowledgeVaultGraphBusy}
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        {knowledgeVaultGraphError ? (
+          <div className="error-banner">{knowledgeVaultGraphError}</div>
+        ) : null}
+
+        <div className="knowledge-vault-overview-grid">
+          <article className="summary-card">
+            <span>Active molecules</span>
+            <strong>{knowledgeGraphSummary.nodeCount}</strong>
+          </article>
+          <article className="summary-card">
+            <span>Relations</span>
+            <strong>{knowledgeGraphSummary.edgeCount}</strong>
+          </article>
+          <article className="summary-card">
+            <span>Service</span>
+            <strong>{knowledgeVaultStatusText}</strong>
+          </article>
+          <article className="summary-card">
+            <span>Node</span>
+            <strong>{knowledgeVaultStatus?.node_name || "unassigned"}</strong>
+          </article>
+        </div>
+
+        <div className="knowledge-vault-graph-panel">
+          <KnowledgeCubeGraph graph={knowledgeVaultGraph} variant="lattice" />
+          {knowledgeVaultGraphBusy ? (
+            <div className="knowledge-vault-graph-overlay">
+              <span>Loading</span>
+            </div>
+          ) : null}
+          {!knowledgeVaultGraphBusy && knowledgeGraphSummary.nodeCount === 0 ? (
+            <div className="knowledge-vault-graph-overlay">
+              <EmptyState
+                title="No active molecules"
+                detail="No canonical knowledge records are available."
+              />
+            </div>
+          ) : null}
+        </div>
+      </section>
+    );
+  }
+
   function renderModelsLibrary() {
     const detectedSourceFormat = detectModelSourceFormat(modelDownloadForm.sourceUrls);
     const renderLibraryCatalog = () => (
@@ -6895,6 +7047,20 @@ function App() {
               </span>
             </button>
             <button
+              className={`side-menu-item ${selectedPage === "knowledge-vault" ? "is-active" : ""}`}
+              type="button"
+              onClick={() => setSelectedPage("knowledge-vault")}
+            >
+              <div className="side-menu-copy">
+                <span className="side-menu-title">Knowledge Vault</span>
+                <span className="side-menu-meta">{knowledgeVaultNavMeta}</span>
+              </div>
+              <span className={`tag ${knowledgeVaultNavClass}`}>
+                {statusDot(knowledgeVaultNavClass)}
+                <span>{knowledgeGraphSummary.nodeCount} items</span>
+              </span>
+            </button>
+            <button
               className={`side-menu-item ${selectedPage === "skills-factory" ? "is-active" : ""}`}
               type="button"
               onClick={() => setSelectedPage("skills-factory")}
@@ -6930,6 +7096,8 @@ function App() {
           renderPlanesRegistry()
         ) : selectedPage === "models" ? (
           renderModelsLibrary()
+        ) : selectedPage === "knowledge-vault" ? (
+          renderKnowledgeVaultPage()
         ) : selectedPage === "skills-factory" ? (
           renderSkillsFactoryPage()
         ) : selectedPage === "access" ? (

--- a/ui/operator-react/src/KnowledgeBaseSelectorModal.jsx
+++ b/ui/operator-react/src/KnowledgeBaseSelectorModal.jsx
@@ -1,21 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { KnowledgeCubeGraph } from "./KnowledgeCubeGraph.jsx";
-
-function knowledgeIdFromItem(item) {
-  return item?.knowledge_id || item?.id || "";
-}
-
-function normalizeKnowledgeResults(items) {
-  const byKnowledgeId = new Map();
-  for (const item of Array.isArray(items) ? items : []) {
-    const knowledgeId = knowledgeIdFromItem(item);
-    if (!knowledgeId || byKnowledgeId.has(knowledgeId)) {
-      continue;
-    }
-    byKnowledgeId.set(knowledgeId, item);
-  }
-  return [...byKnowledgeId.values()];
-}
+import {
+  buildKnowledgeGraphRequest,
+  knowledgeIdFromItem,
+  normalizeKnowledgeResults,
+} from "./knowledgeVault.js";
 
 function InlineHint({ message, severity = "warning" }) {
   if (!message) {
@@ -86,13 +75,8 @@ export function KnowledgeBaseSelectorModal({
     if (!open) {
       return undefined;
     }
-    const knowledgeIds = [
-      ...new Set([
-        ...results.map(knowledgeIdFromItem).filter(Boolean),
-        ...selectedSet,
-      ]),
-    ].slice(0, 80);
-    if (knowledgeIds.length === 0) {
+    const graphRequest = buildKnowledgeGraphRequest(results, [...selectedSet], 80);
+    if (graphRequest.knowledge_ids.length === 0) {
       setGraph({ nodes: [], edges: [] });
       return undefined;
     }
@@ -105,10 +89,7 @@ export function KnowledgeBaseSelectorModal({
             Accept: "application/json",
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({
-            knowledge_ids: knowledgeIds,
-            depth: 1,
-          }),
+          body: JSON.stringify(graphRequest),
           signal: controller.signal,
         });
         const payload = await response.json().catch(() => ({}));

--- a/ui/operator-react/src/KnowledgeCubeGraph.jsx
+++ b/ui/operator-react/src/KnowledgeCubeGraph.jsx
@@ -1,5 +1,33 @@
 import React, { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
+import { knowledgeTitleFromItem } from "./knowledgeVault.js";
+
+const LATTICE_MIN_SIZE = 3;
+const LATTICE_MAX_SIZE = 7;
+const EMPTY_SELECTED_KNOWLEDGE_IDS = [];
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function nodeId(node) {
+  return node?.block_id || node?.knowledge_id || node?.id || "";
+}
+
+function knowledgeId(node) {
+  return node?.knowledge_id || node?.id || node?.block_id || "";
+}
+
+function endpointCandidates(edge, side) {
+  const prefix = side === "from" ? "from" : "to";
+  return [
+    edge?.[`${prefix}_block_id`],
+    edge?.[`${prefix}_knowledge_id`],
+    edge?.[`${prefix}_id`],
+    edge?.[side],
+    edge?.[side === "from" ? "source" : "target"],
+  ].filter(Boolean);
+}
 
 function stablePosition(index, total) {
   const phi = Math.acos(1 - (2 * (index + 0.5)) / Math.max(1, total));
@@ -12,120 +40,281 @@ function stablePosition(index, total) {
   );
 }
 
-function nodeId(node) {
-  return node?.block_id || node?.knowledge_id || node?.id || "";
+function buildLatticePositions(nodeCount) {
+  const dimension = clamp(
+    Math.ceil(Math.cbrt(Math.max(nodeCount, LATTICE_MIN_SIZE ** 3))),
+    LATTICE_MIN_SIZE,
+    LATTICE_MAX_SIZE,
+  );
+  const spacing = 0.78;
+  const offset = ((dimension - 1) * spacing) / 2;
+  const positions = [];
+  for (let z = 0; z < dimension; z += 1) {
+    for (let y = 0; y < dimension; y += 1) {
+      for (let x = 0; x < dimension; x += 1) {
+        positions.push(new THREE.Vector3(x * spacing - offset, y * spacing - offset, z * spacing - offset));
+      }
+    }
+  }
+  return positions;
 }
 
-export function KnowledgeCubeGraph({ graph, selectedKnowledgeIds = [], onSelect }) {
+function createLine(from, to, material) {
+  const geometry = new THREE.BufferGeometry().setFromPoints([from, to]);
+  return new THREE.Line(geometry, material);
+}
+
+function disposeObject(object) {
+  object.traverse((item) => {
+    if (item.geometry) {
+      item.geometry.dispose();
+    }
+    if (item.material) {
+      const materials = Array.isArray(item.material) ? item.material : [item.material];
+      materials.forEach((material) => material.dispose());
+    }
+  });
+}
+
+function resolveEndpointPosition(edge, side, positions) {
+  for (const candidate of endpointCandidates(edge, side)) {
+    const position = positions.get(candidate);
+    if (position) {
+      return position;
+    }
+  }
+  return null;
+}
+
+export function KnowledgeCubeGraph({
+  graph,
+  selectedKnowledgeIds = EMPTY_SELECTED_KNOWLEDGE_IDS,
+  onSelect,
+  variant = "selector",
+}) {
   const mountRef = useRef(null);
   const [renderError, setRenderError] = useState("");
-  const selectedSet = new Set(Array.isArray(selectedKnowledgeIds) ? selectedKnowledgeIds : []);
+  const [hoveredNode, setHoveredNode] = useState(null);
 
   useEffect(() => {
     const mount = mountRef.current;
     if (!mount) {
       return undefined;
     }
-    const width = mount.clientWidth || 640;
-    const height = mount.clientHeight || 360;
+
     const scene = new THREE.Scene();
     scene.background = new THREE.Color(0x071018);
-
-    const camera = new THREE.PerspectiveCamera(48, width / height, 0.1, 100);
-    camera.position.set(4, 4, 6);
+    const camera = new THREE.PerspectiveCamera(48, 1, 0.1, 100);
+    camera.position.set(4.8, 4.2, 7.2);
     camera.lookAt(0, 0, 0);
 
     let renderer;
     try {
-      renderer = new THREE.WebGLRenderer({ antialias: true });
+      renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        preserveDrawingBuffer: true,
+      });
       setRenderError("");
     } catch (error) {
       setRenderError(error?.message || "WebGL is unavailable.");
       return undefined;
     }
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
-    renderer.setSize(width, height);
     mount.appendChild(renderer.domElement);
 
     const group = new THREE.Group();
     scene.add(group);
-    group.add(new THREE.AmbientLight(0xffffff, 1.6));
-
-    const cube = new THREE.LineSegments(
-      new THREE.EdgesGeometry(new THREE.BoxGeometry(5, 5, 5)),
-      new THREE.LineBasicMaterial({ color: 0x5f7d92, transparent: true, opacity: 0.45 }),
-    );
-    group.add(cube);
+    const ambient = new THREE.AmbientLight(0xffffff, variant === "lattice" ? 1.35 : 1.6);
+    const keyLight = new THREE.PointLight(0x9fd8ff, 2.2, 14);
+    keyLight.position.set(3, 4, 6);
+    group.add(ambient);
+    group.add(keyLight);
 
     const nodes = Array.isArray(graph?.nodes) ? graph.nodes : [];
     const edges = Array.isArray(graph?.edges) ? graph.edges : [];
+    const selectedSet = new Set(Array.isArray(selectedKnowledgeIds) ? selectedKnowledgeIds : []);
     const positions = new Map();
     const pickables = [];
-    nodes.forEach((node, index) => {
-      const id = nodeId(node);
-      const position = stablePosition(index, nodes.length);
-      positions.set(id, position);
-      const knowledgeId = node?.knowledge_id || id;
-      const selected = selectedSet.has(knowledgeId);
-      const mesh = new THREE.Mesh(
-        new THREE.BoxGeometry(selected ? 0.26 : 0.18, selected ? 0.26 : 0.18, selected ? 0.26 : 0.18),
-        new THREE.MeshStandardMaterial({
-          color: selected ? 0x53d18f : 0x65a8ff,
-          roughness: 0.4,
-          metalness: 0.15,
-        }),
-      );
-      mesh.position.copy(position);
-      mesh.userData = { node };
-      group.add(mesh);
-      pickables.push(mesh);
-    });
 
-    edges.forEach((edge) => {
-      const from = positions.get(edge?.from_block_id);
-      const to = positions.get(edge?.to_block_id);
-      if (!from || !to) {
-        return;
-      }
-      const geometry = new THREE.BufferGeometry().setFromPoints([from, to]);
-      group.add(
-        new THREE.Line(
-          geometry,
-          new THREE.LineBasicMaterial({ color: 0x9fb4c7, transparent: true, opacity: 0.52 }),
-        ),
+    if (variant === "lattice") {
+      const latticePositions = buildLatticePositions(nodes.length);
+      const inactiveMaterial = new THREE.MeshBasicMaterial({
+        color: 0x27445b,
+        transparent: true,
+        opacity: 0.35,
+      });
+      const inactiveGeometry = new THREE.SphereGeometry(0.045, 12, 8);
+      latticePositions.forEach((position, index) => {
+        const mesh = new THREE.Mesh(inactiveGeometry, inactiveMaterial);
+        mesh.position.copy(position);
+        group.add(mesh);
+      });
+
+      const edgeMaterial = new THREE.LineBasicMaterial({
+        color: 0x8ce7ff,
+        transparent: true,
+        opacity: 0.9,
+      });
+      const activeGeometry = new THREE.SphereGeometry(0.13, 24, 16);
+      const activeMaterial = new THREE.MeshStandardMaterial({
+        color: 0x7ae6ff,
+        emissive: 0x39c8ff,
+        emissiveIntensity: 1.35,
+        roughness: 0.25,
+        metalness: 0.18,
+      });
+
+      nodes.forEach((node, index) => {
+        const id = nodeId(node);
+        const idKnowledge = knowledgeId(node);
+        const position = latticePositions[index] || stablePosition(index, nodes.length);
+        positions.set(id, position);
+        positions.set(idKnowledge, position);
+        const mesh = new THREE.Mesh(activeGeometry, activeMaterial);
+        mesh.position.copy(position);
+        mesh.userData = { node, active: true };
+        group.add(mesh);
+        pickables.push(mesh);
+      });
+
+      edges.forEach((edge) => {
+        const from = resolveEndpointPosition(edge, "from", positions);
+        const to = resolveEndpointPosition(edge, "to", positions);
+        if (from && to) {
+          group.add(createLine(from, to, edgeMaterial));
+        }
+      });
+
+      const cubeSize = Math.max(2.5, Math.cbrt(latticePositions.length) * 0.78);
+      const cube = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(cubeSize, cubeSize, cubeSize)),
+        new THREE.LineBasicMaterial({ color: 0x5f7d92, transparent: true, opacity: 0.4 }),
       );
-    });
+      group.add(cube);
+    } else {
+      const cube = new THREE.LineSegments(
+        new THREE.EdgesGeometry(new THREE.BoxGeometry(5, 5, 5)),
+        new THREE.LineBasicMaterial({ color: 0x5f7d92, transparent: true, opacity: 0.45 }),
+      );
+      group.add(cube);
+
+      nodes.forEach((node, index) => {
+        const id = nodeId(node);
+        const idKnowledge = knowledgeId(node);
+        const position = stablePosition(index, nodes.length);
+        positions.set(id, position);
+        positions.set(idKnowledge, position);
+        const selected = selectedSet.has(idKnowledge);
+        const mesh = new THREE.Mesh(
+          new THREE.BoxGeometry(
+            selected ? 0.26 : 0.18,
+            selected ? 0.26 : 0.18,
+            selected ? 0.26 : 0.18,
+          ),
+          new THREE.MeshStandardMaterial({
+            color: selected ? 0x53d18f : 0x65a8ff,
+            roughness: 0.4,
+            metalness: 0.15,
+          }),
+        );
+        mesh.position.copy(position);
+        mesh.userData = { node, active: true };
+        group.add(mesh);
+        pickables.push(mesh);
+      });
+
+      edges.forEach((edge) => {
+        const from = resolveEndpointPosition(edge, "from", positions);
+        const to = resolveEndpointPosition(edge, "to", positions);
+        if (from && to) {
+          group.add(
+            createLine(
+              from,
+              to,
+              new THREE.LineBasicMaterial({ color: 0x9fb4c7, transparent: true, opacity: 0.52 }),
+            ),
+          );
+        }
+      });
+    }
 
     let dragging = false;
     let previousX = 0;
     let previousY = 0;
+    let movedWhileDragging = false;
     const raycaster = new THREE.Raycaster();
     const pointer = new THREE.Vector2();
 
+    const resize = () => {
+      const width = Math.max(1, mount.clientWidth || 640);
+      const height = Math.max(1, mount.clientHeight || 360);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+      renderer.setSize(width, height, false);
+    };
+    resize();
+    const observer = window.ResizeObserver ? new ResizeObserver(resize) : null;
+    observer?.observe(mount);
+
+    const updateHover = (event) => {
+      const rect = renderer.domElement.getBoundingClientRect();
+      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+      raycaster.setFromCamera(pointer, camera);
+      const [hit] = raycaster.intersectObjects(pickables);
+      if (!hit?.object?.userData?.node) {
+        setHoveredNode(null);
+        return;
+      }
+      setHoveredNode({
+        title: knowledgeTitleFromItem(hit.object.userData.node),
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top,
+      });
+    };
+
     const onPointerDown = (event) => {
       dragging = true;
+      movedWhileDragging = false;
       previousX = event.clientX;
       previousY = event.clientY;
+      renderer.domElement.setPointerCapture?.(event.pointerId);
     };
     const onPointerMove = (event) => {
       if (!dragging) {
+        updateHover(event);
         return;
       }
       const dx = event.clientX - previousX;
       const dy = event.clientY - previousY;
+      if (Math.abs(dx) + Math.abs(dy) > 1) {
+        movedWhileDragging = true;
+      }
       group.rotation.y += dx * 0.008;
       group.rotation.x += dy * 0.008;
       previousX = event.clientX;
       previousY = event.clientY;
+      setHoveredNode(null);
     };
-    const onPointerUp = () => {
+    const onPointerUp = (event) => {
       dragging = false;
+      renderer.domElement.releasePointerCapture?.(event.pointerId);
+    };
+    const onPointerLeave = () => {
+      dragging = false;
+      setHoveredNode(null);
     };
     const onWheel = (event) => {
       event.preventDefault();
-      camera.position.z = Math.max(3, Math.min(12, camera.position.z + event.deltaY * 0.006));
+      const distance = clamp(camera.position.length() + event.deltaY * 0.008, 3, 13);
+      camera.position.setLength(distance);
+      camera.lookAt(0, 0, 0);
     };
     const onClick = (event) => {
+      if (movedWhileDragging) {
+        return;
+      }
+      updateHover(event);
       const rect = renderer.domElement.getBoundingClientRect();
       pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
       pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
@@ -139,33 +328,45 @@ export function KnowledgeCubeGraph({ graph, selectedKnowledgeIds = [], onSelect 
     renderer.domElement.addEventListener("pointerdown", onPointerDown);
     renderer.domElement.addEventListener("pointermove", onPointerMove);
     renderer.domElement.addEventListener("pointerup", onPointerUp);
-    renderer.domElement.addEventListener("pointerleave", onPointerUp);
+    renderer.domElement.addEventListener("pointerleave", onPointerLeave);
     renderer.domElement.addEventListener("wheel", onWheel, { passive: false });
     renderer.domElement.addEventListener("click", onClick);
 
     let frame = 0;
     const animate = () => {
       frame = requestAnimationFrame(animate);
-      group.rotation.y += 0.0012;
+      group.rotation.y += variant === "lattice" ? 0.0008 : 0.0012;
       renderer.render(scene, camera);
     };
     animate();
 
     return () => {
       cancelAnimationFrame(frame);
+      observer?.disconnect();
       renderer.domElement.removeEventListener("pointerdown", onPointerDown);
       renderer.domElement.removeEventListener("pointermove", onPointerMove);
       renderer.domElement.removeEventListener("pointerup", onPointerUp);
-      renderer.domElement.removeEventListener("pointerleave", onPointerUp);
+      renderer.domElement.removeEventListener("pointerleave", onPointerLeave);
       renderer.domElement.removeEventListener("wheel", onWheel);
       renderer.domElement.removeEventListener("click", onClick);
+      disposeObject(scene);
       renderer.dispose();
-      mount.removeChild(renderer.domElement);
+      if (mount.contains(renderer.domElement)) {
+        mount.removeChild(renderer.domElement);
+      }
     };
-  }, [graph, onSelect, selectedKnowledgeIds]);
+  }, [graph, onSelect, selectedKnowledgeIds, variant]);
 
   return (
-    <div className="knowledge-cube-graph" ref={mountRef}>
+    <div className={`knowledge-cube-graph ${variant === "lattice" ? "is-lattice" : ""}`} ref={mountRef}>
+      {hoveredNode ? (
+        <div
+          className="knowledge-cube-tooltip"
+          style={{ left: `${hoveredNode.x}px`, top: `${hoveredNode.y}px` }}
+        >
+          {hoveredNode.title}
+        </div>
+      ) : null}
       {renderError ? <div className="knowledge-cube-fallback">{renderError}</div> : null}
     </div>
   );

--- a/ui/operator-react/src/knowledgeVault.js
+++ b/ui/operator-react/src/knowledgeVault.js
@@ -1,0 +1,48 @@
+export function knowledgeIdFromItem(item) {
+  return item?.knowledge_id || item?.id || item?.block_id || "";
+}
+
+export function knowledgeTitleFromItem(item) {
+  return item?.title || item?.name || item?.knowledge_id || item?.block_id || item?.id || "Untitled";
+}
+
+export function normalizeKnowledgeResults(items) {
+  const byKnowledgeId = new Map();
+  for (const item of Array.isArray(items) ? items : []) {
+    const knowledgeId = knowledgeIdFromItem(item);
+    if (!knowledgeId || byKnowledgeId.has(knowledgeId)) {
+      continue;
+    }
+    byKnowledgeId.set(knowledgeId, item);
+  }
+  return [...byKnowledgeId.values()];
+}
+
+export function buildKnowledgeGraphRequest(items, extras = [], limit = 100) {
+  const knowledgeIds = [];
+  const seen = new Set();
+  for (const candidate of [...(Array.isArray(items) ? items : []), ...extras]) {
+    const knowledgeId = typeof candidate === "string" ? candidate : knowledgeIdFromItem(candidate);
+    if (!knowledgeId || seen.has(knowledgeId)) {
+      continue;
+    }
+    seen.add(knowledgeId);
+    knowledgeIds.push(knowledgeId);
+    if (knowledgeIds.length >= limit) {
+      break;
+    }
+  }
+  return {
+    knowledge_ids: knowledgeIds,
+    depth: 1,
+  };
+}
+
+export function summarizeKnowledgeGraph(graph) {
+  const nodes = Array.isArray(graph?.nodes) ? graph.nodes : [];
+  const edges = Array.isArray(graph?.edges) ? graph.edges : [];
+  return {
+    nodeCount: nodes.length,
+    edgeCount: edges.length,
+  };
+}

--- a/ui/operator-react/src/knowledgeVault.test.js
+++ b/ui/operator-react/src/knowledgeVault.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildKnowledgeGraphRequest,
+  knowledgeTitleFromItem,
+  normalizeKnowledgeResults,
+  summarizeKnowledgeGraph,
+} from "./knowledgeVault.js";
+
+describe("knowledgeVault utils", () => {
+  it("normalizes duplicate search results by canonical knowledge id", () => {
+    const results = normalizeKnowledgeResults([
+      { knowledge_id: "alpha", block_id: "alpha.v1", title: "Alpha" },
+      { knowledge_id: "alpha", block_id: "alpha.v2", title: "Alpha duplicate" },
+      { id: "beta", title: "Beta" },
+      { block_id: "gamma.v1", title: "Gamma" },
+      { title: "missing id" },
+    ]);
+
+    expect(results.map((item) => item.title)).toEqual(["Alpha", "Beta", "Gamma"]);
+  });
+
+  it("builds a bounded graph-neighborhood request", () => {
+    expect(
+      buildKnowledgeGraphRequest(
+        [{ knowledge_id: "alpha" }, { knowledge_id: "beta" }],
+        ["beta", "gamma"],
+        3,
+      ),
+    ).toEqual({
+      knowledge_ids: ["alpha", "beta", "gamma"],
+      depth: 1,
+    });
+  });
+
+  it("summarizes graph payloads and falls back to stable titles", () => {
+    expect(
+      summarizeKnowledgeGraph({
+        nodes: [{ knowledge_id: "alpha" }, { knowledge_id: "beta" }],
+        edges: [{ relation_id: "rel-1" }],
+      }),
+    ).toEqual({ nodeCount: 2, edgeCount: 1 });
+    expect(knowledgeTitleFromItem({ block_id: "block-1" })).toBe("block-1");
+  });
+});

--- a/ui/operator-react/src/styles.css
+++ b/ui/operator-react/src/styles.css
@@ -2157,14 +2157,36 @@ body {
 }
 
 .knowledge-cube-graph {
+  position: relative;
   min-height: 420px;
   width: 100%;
   height: 100%;
   overflow: hidden;
 }
 
+.knowledge-cube-graph.is-lattice {
+  min-height: clamp(520px, calc(100vh - 340px), 820px);
+}
+
 .knowledge-cube-graph canvas {
   display: block;
+}
+
+.knowledge-cube-tooltip {
+  position: absolute;
+  z-index: 3;
+  max-width: min(320px, calc(100% - 24px));
+  transform: translate(12px, -100%);
+  border: 1px solid rgba(120, 190, 255, 0.32);
+  border-radius: 6px;
+  background: rgba(5, 16, 32, 0.94);
+  color: var(--text);
+  font-size: 0.84rem;
+  line-height: 1.35;
+  padding: 7px 9px;
+  pointer-events: none;
+  overflow-wrap: anywhere;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.34);
 }
 
 .knowledge-cube-fallback {
@@ -2174,6 +2196,62 @@ body {
   color: var(--text-dim);
   padding: 16px;
   text-align: center;
+}
+
+.knowledge-vault-page-panel {
+  display: grid;
+  gap: 16px;
+  min-height: calc(100vh - 240px);
+}
+
+.knowledge-vault-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.knowledge-vault-overview-grid .summary-card {
+  gap: 8px;
+}
+
+.knowledge-vault-overview-grid .summary-card span {
+  color: var(--text-dim);
+  font-size: 0.84rem;
+  text-transform: uppercase;
+}
+
+.knowledge-vault-overview-grid .summary-card strong {
+  color: var(--text);
+  font-size: 1.2rem;
+  overflow-wrap: anywhere;
+}
+
+.knowledge-vault-graph-panel {
+  position: relative;
+  min-height: clamp(520px, calc(100vh - 340px), 820px);
+  border: 1px solid rgba(120, 190, 255, 0.16);
+  border-radius: 8px;
+  background: rgba(4, 15, 31, 0.58);
+  overflow: hidden;
+}
+
+.knowledge-vault-graph-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(4, 15, 31, 0.08), rgba(4, 15, 31, 0.42));
+}
+
+.knowledge-vault-graph-overlay > span {
+  border: 1px solid rgba(120, 190, 255, 0.24);
+  border-radius: 999px;
+  background: rgba(5, 16, 32, 0.82);
+  color: var(--text-dim);
+  font-size: 0.88rem;
+  padding: 8px 12px;
 }
 
 .plane-editor-modal {
@@ -2274,6 +2352,15 @@ body {
     min-height: 300px;
   }
 
+  .knowledge-cube-graph.is-lattice,
+  .knowledge-vault-graph-panel {
+    min-height: 420px;
+  }
+
+  .knowledge-vault-overview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .skills-factory-catalog-toolbar {
     grid-template-columns: 1fr;
   }
@@ -2328,6 +2415,10 @@ body {
 
   .summary-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .knowledge-vault-overview-grid {
+    grid-template-columns: 1fr;
   }
 
   .model-library-picker-head,


### PR DESCRIPTION
## Summary
- add a dedicated Knowledge Vault navigation page backed by controller APIs
- render canonical knowledge as a WebGL cubic crystal lattice with glowing active molecules and relation edges
- share Knowledge Vault normalization helpers with the plane editor selector and add unit coverage

## Verification
- npm test
- npm run build
- Playwright smoke with mocked controller APIs, WebGL screenshot and canvas pixel check