### PR TITLE
Fix Knowledge Vault release gate deploy

### DIFF
--- a/.github/workflows/naim-production-release.yml
+++ b/.github/workflows/naim-production-release.yml
@@ -79,7 +79,7 @@ jobs:
           set -euo pipefail
           repo_q="$(printf '%q' "${NAIM_HPC1_REPO_PATH}")"
           ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
-            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' bash scripts/ci/knowledge-vault-release-gate.sh '${NAIM_BUILD_TYPE}'"
+            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' bash scripts/ci/knowledge-vault-release-gate.sh"
 
   hpc1-build-push-harbor:
     name: 3. hpc1 build containers and push Harbor

--- a/scripts/ci/knowledge-vault-release-gate.py
+++ b/scripts/ci/knowledge-vault-release-gate.py
@@ -311,7 +311,10 @@ def create_backup(store_path, backup_path):
 def restore_backup(backup_path, restore_root):
     restore_root.mkdir(parents=True, exist_ok=True)
     with tarfile.open(backup_path, "r:gz") as archive:
-        archive.extractall(restore_root)
+        try:
+            archive.extractall(restore_root, filter="data")
+        except TypeError:
+            archive.extractall(restore_root)
     return restore_root / "store"
 
 

--- a/scripts/ci/knowledge-vault-release-gate.sh
+++ b/scripts/ci/knowledge-vault-release-gate.sh
@@ -3,12 +3,15 @@ set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+source "${repo_root}/scripts/build-context.sh"
+
 build_dir="${NAIM_BUILD_DIR:-}"
 artifact_dir="${NAIM_KNOWLEDGE_GATE_ARTIFACT_DIR:-${repo_root}/var/knowledge-vault-release-gate}"
 work_root="${NAIM_KNOWLEDGE_GATE_WORK_ROOT:-${repo_root}/var/knowledge-vault-release-gate-work}"
 benchmark_output="${NAIM_KNOWLEDGE_BENCHMARK_OUTPUT:-${artifact_dir}/knowledge-vault-benchmark-baseline.json}"
 report_path="${NAIM_KNOWLEDGE_GATE_REPORT:-${artifact_dir}/knowledge-vault-release-gate.json}"
 benchmark_items="${NAIM_KNOWLEDGE_BENCHMARK_ITEMS:-25}"
+target_args=("$@")
 
 if [[ -n "${NAIM_RELEASE_SHA:-}" ]]; then
   current_sha="$(git -C "${repo_root}" rev-parse HEAD)"
@@ -19,7 +22,10 @@ if [[ -n "${NAIM_RELEASE_SHA:-}" ]]; then
 fi
 
 if [[ -z "${build_dir}" ]]; then
-  build_dir="$("${repo_root}/scripts/print-build-dir.sh" "$@")"
+  if [[ ${#target_args[@]} -eq 1 ]] && naim_is_build_type "${target_args[0]}"; then
+    target_args=()
+  fi
+  build_dir="$("${repo_root}/scripts/print-build-dir.sh" "${target_args[@]}")"
 fi
 
 mkdir -p "${artifact_dir}" "${work_root}"


### PR DESCRIPTION
## Summary\n- fix production release workflow so Knowledge Vault gate is invoked without a positional build-type argument\n- keep the gate script backward-compatible with accidental single build-type arguments\n- make backup restore extraction explicit for newer Python tarfile behavior\n\n## Verification\n- scripts/ci/knowledge-vault-release-gate.sh\n- scripts/ci/knowledge-vault-release-gate.sh Release\n- hpc1 run: Knowledge Vault release gate passed for merge commit ab3bc08930578cb4e7742e7790d931ba4f9044b3 when invoked without the bad positional argument\n\nFixes the failed production release run 24793379095 at stage 2a.