### PR TITLE
Stabilize Knowledge Vault graph refresh

### DIFF
--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -41,7 +41,9 @@ import {
 } from "./skillsFactory.js";
 import { KnowledgeCubeGraph } from "./KnowledgeCubeGraph.jsx";
 import {
+  areKnowledgeGraphsEqual,
   buildKnowledgeGraphRequest,
+  KNOWLEDGE_GRAPH_LIMIT,
   normalizeKnowledgeResults,
   summarizeKnowledgeGraph,
 } from "./knowledgeVault.js";
@@ -2186,13 +2188,16 @@ function App() {
         body: JSON.stringify({
           query: "",
           list_all: true,
-          limit: 100,
+          limit: KNOWLEDGE_GRAPH_LIMIT,
         }),
       });
       const results = normalizeKnowledgeResults(searchPayload?.results);
-      const graphRequest = buildKnowledgeGraphRequest(results, [], 100);
+      const graphRequest = buildKnowledgeGraphRequest(results, [], KNOWLEDGE_GRAPH_LIMIT);
       if (graphRequest.knowledge_ids.length === 0) {
-        setKnowledgeVaultGraph({ nodes: [], edges: [], warnings: [] });
+        const emptyGraph = { nodes: [], edges: [], warnings: [] };
+        setKnowledgeVaultGraph((current) =>
+          areKnowledgeGraphsEqual(current, emptyGraph) ? current : emptyGraph,
+        );
         return;
       }
       const graphPayload = await fetchJson(knowledgeVaultPath("graph-neighborhood"), {
@@ -2202,18 +2207,24 @@ function App() {
         },
         body: JSON.stringify(graphRequest),
       });
-      setKnowledgeVaultGraph({
+      const nextGraph = {
         nodes: Array.isArray(graphPayload?.nodes) ? graphPayload.nodes : [],
         edges: Array.isArray(graphPayload?.edges) ? graphPayload.edges : [],
         warnings: Array.isArray(graphPayload?.warnings) ? graphPayload.warnings : [],
-      });
+      };
+      setKnowledgeVaultGraph((current) =>
+        areKnowledgeGraphsEqual(current, nextGraph) ? current : nextGraph,
+      );
     } catch (error) {
       if (error?.status === 401) {
         handleUnauthorized();
         return;
       }
       setKnowledgeVaultGraphError(error.message || String(error));
-      setKnowledgeVaultGraph({ nodes: [], edges: [], warnings: [] });
+      const emptyGraph = { nodes: [], edges: [], warnings: [] };
+      setKnowledgeVaultGraph((current) =>
+        areKnowledgeGraphsEqual(current, emptyGraph) ? current : emptyGraph,
+      );
     } finally {
       setKnowledgeVaultGraphBusy(false);
     }

--- a/ui/operator-react/src/KnowledgeBaseSelectorModal.jsx
+++ b/ui/operator-react/src/KnowledgeBaseSelectorModal.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { KnowledgeCubeGraph } from "./KnowledgeCubeGraph.jsx";
 import {
   buildKnowledgeGraphRequest,
+  KNOWLEDGE_GRAPH_LIMIT,
   knowledgeIdFromItem,
   normalizeKnowledgeResults,
 } from "./knowledgeVault.js";
@@ -46,7 +47,7 @@ export function KnowledgeBaseSelectorModal({
           body: JSON.stringify({
             query,
             list_all: !query.trim(),
-            limit: 100,
+            limit: KNOWLEDGE_GRAPH_LIMIT,
           }),
           signal: controller.signal,
         });
@@ -75,7 +76,7 @@ export function KnowledgeBaseSelectorModal({
     if (!open) {
       return undefined;
     }
-    const graphRequest = buildKnowledgeGraphRequest(results, [...selectedSet], 80);
+    const graphRequest = buildKnowledgeGraphRequest(results, [...selectedSet], KNOWLEDGE_GRAPH_LIMIT);
     if (graphRequest.knowledge_ids.length === 0) {
       setGraph({ nodes: [], edges: [] });
       return undefined;

--- a/ui/operator-react/src/KnowledgeCubeGraph.jsx
+++ b/ui/operator-react/src/KnowledgeCubeGraph.jsx
@@ -4,6 +4,7 @@ import { knowledgeTitleFromItem } from "./knowledgeVault.js";
 
 const LATTICE_MIN_SIZE = 3;
 const LATTICE_MAX_SIZE = 7;
+const LATTICE_VISIBLE_POINT_COUNT = 200;
 const EMPTY_SELECTED_KNOWLEDGE_IDS = [];
 
 function clamp(value, min, max) {
@@ -40,18 +41,18 @@ function stablePosition(index, total) {
   );
 }
 
-function buildLatticePositions(nodeCount) {
-  const dimension = clamp(
-    Math.ceil(Math.cbrt(Math.max(nodeCount, LATTICE_MIN_SIZE ** 3))),
-    LATTICE_MIN_SIZE,
-    LATTICE_MAX_SIZE,
-  );
+function buildLatticePositions(pointCount) {
+  const requestedPoints = Math.max(pointCount, LATTICE_MIN_SIZE ** 3);
+  const dimension = clamp(Math.ceil(Math.cbrt(requestedPoints)), LATTICE_MIN_SIZE, LATTICE_MAX_SIZE);
   const spacing = 0.78;
   const offset = ((dimension - 1) * spacing) / 2;
   const positions = [];
   for (let z = 0; z < dimension; z += 1) {
     for (let y = 0; y < dimension; y += 1) {
       for (let x = 0; x < dimension; x += 1) {
+        if (positions.length >= requestedPoints) {
+          return positions;
+        }
         positions.push(new THREE.Vector3(x * spacing - offset, y * spacing - offset, z * spacing - offset));
       }
     }
@@ -65,14 +66,26 @@ function createLine(from, to, material) {
 }
 
 function disposeObject(object) {
+  const geometries = new Set();
+  const materials = new Set();
   object.traverse((item) => {
     if (item.geometry) {
-      item.geometry.dispose();
+      geometries.add(item.geometry);
     }
     if (item.material) {
-      const materials = Array.isArray(item.material) ? item.material : [item.material];
-      materials.forEach((material) => material.dispose());
+      const itemMaterials = Array.isArray(item.material) ? item.material : [item.material];
+      itemMaterials.forEach((material) => materials.add(material));
     }
+  });
+  geometries.forEach((geometry) => geometry.dispose());
+  materials.forEach((material) => material.dispose());
+}
+
+function clearGroup(group) {
+  const children = [...group.children];
+  children.forEach((child) => {
+    group.remove(child);
+    disposeObject(child);
   });
 }
 
@@ -86,6 +99,121 @@ function resolveEndpointPosition(edge, side, positions) {
   return null;
 }
 
+function addLatticeGraph(contentGroup, nodes, edges, pickables) {
+  const latticePositions = buildLatticePositions(Math.max(LATTICE_VISIBLE_POINT_COUNT, nodes.length));
+  const inactiveMaterial = new THREE.MeshBasicMaterial({
+    color: 0x27445b,
+    transparent: true,
+    opacity: 0.35,
+  });
+  const inactiveGeometry = new THREE.SphereGeometry(0.045, 12, 8);
+
+  latticePositions.forEach((position) => {
+    const mesh = new THREE.Mesh(inactiveGeometry, inactiveMaterial);
+    mesh.position.copy(position);
+    contentGroup.add(mesh);
+  });
+
+  const positions = new Map();
+  const edgeMaterial = new THREE.LineBasicMaterial({
+    color: 0x8ce7ff,
+    transparent: true,
+    opacity: 0.9,
+  });
+  const activeGeometry = new THREE.SphereGeometry(0.13, 24, 16);
+  const activeMaterial = new THREE.MeshStandardMaterial({
+    color: 0x7ae6ff,
+    emissive: 0x39c8ff,
+    emissiveIntensity: 1.35,
+    roughness: 0.25,
+    metalness: 0.18,
+  });
+
+  nodes.forEach((node, index) => {
+    const id = nodeId(node);
+    const idKnowledge = knowledgeId(node);
+    const position = latticePositions[index] || stablePosition(index, nodes.length);
+    positions.set(id, position);
+    positions.set(idKnowledge, position);
+    const mesh = new THREE.Mesh(activeGeometry, activeMaterial);
+    mesh.position.copy(position);
+    mesh.userData = { node, active: true };
+    contentGroup.add(mesh);
+    pickables.push(mesh);
+  });
+
+  edges.forEach((edge) => {
+    const from = resolveEndpointPosition(edge, "from", positions);
+    const to = resolveEndpointPosition(edge, "to", positions);
+    if (from && to) {
+      contentGroup.add(createLine(from, to, edgeMaterial));
+    }
+  });
+}
+
+function addSelectorGraph(contentGroup, nodes, edges, selectedKnowledgeIds, pickables) {
+  const cube = new THREE.LineSegments(
+    new THREE.EdgesGeometry(new THREE.BoxGeometry(5, 5, 5)),
+    new THREE.LineBasicMaterial({ color: 0x5f7d92, transparent: true, opacity: 0.45 }),
+  );
+  contentGroup.add(cube);
+
+  const selectedSet = new Set(Array.isArray(selectedKnowledgeIds) ? selectedKnowledgeIds : []);
+  const positions = new Map();
+  nodes.forEach((node, index) => {
+    const id = nodeId(node);
+    const idKnowledge = knowledgeId(node);
+    const position = stablePosition(index, nodes.length);
+    positions.set(id, position);
+    positions.set(idKnowledge, position);
+    const selected = selectedSet.has(idKnowledge);
+    const mesh = new THREE.Mesh(
+      new THREE.BoxGeometry(
+        selected ? 0.26 : 0.18,
+        selected ? 0.26 : 0.18,
+        selected ? 0.26 : 0.18,
+      ),
+      new THREE.MeshStandardMaterial({
+        color: selected ? 0x53d18f : 0x65a8ff,
+        roughness: 0.4,
+        metalness: 0.15,
+      }),
+    );
+    mesh.position.copy(position);
+    mesh.userData = { node, active: true };
+    contentGroup.add(mesh);
+    pickables.push(mesh);
+  });
+
+  edges.forEach((edge) => {
+    const from = resolveEndpointPosition(edge, "from", positions);
+    const to = resolveEndpointPosition(edge, "to", positions);
+    if (from && to) {
+      contentGroup.add(
+        createLine(
+          from,
+          to,
+          new THREE.LineBasicMaterial({ color: 0x9fb4c7, transparent: true, opacity: 0.52 }),
+        ),
+      );
+    }
+  });
+}
+
+function populateGraphContent(sceneState, graph, selectedKnowledgeIds, variant) {
+  const nodes = Array.isArray(graph?.nodes) ? graph.nodes : [];
+  const edges = Array.isArray(graph?.edges) ? graph.edges : [];
+  const pickables = [];
+
+  clearGroup(sceneState.contentGroup);
+  if (variant === "lattice") {
+    addLatticeGraph(sceneState.contentGroup, nodes, edges, pickables);
+  } else {
+    addSelectorGraph(sceneState.contentGroup, nodes, edges, selectedKnowledgeIds, pickables);
+  }
+  sceneState.pickables = pickables;
+}
+
 export function KnowledgeCubeGraph({
   graph,
   selectedKnowledgeIds = EMPTY_SELECTED_KNOWLEDGE_IDS,
@@ -93,8 +221,14 @@ export function KnowledgeCubeGraph({
   variant = "selector",
 }) {
   const mountRef = useRef(null);
+  const sceneStateRef = useRef(null);
+  const onSelectRef = useRef(onSelect);
   const [renderError, setRenderError] = useState("");
   const [hoveredNode, setHoveredNode] = useState(null);
+
+  useEffect(() => {
+    onSelectRef.current = onSelect;
+  }, [onSelect]);
 
   useEffect(() => {
     const mount = mountRef.current;
@@ -119,117 +253,29 @@ export function KnowledgeCubeGraph({
       setRenderError(error?.message || "WebGL is unavailable.");
       return undefined;
     }
+
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     mount.appendChild(renderer.domElement);
 
-    const group = new THREE.Group();
-    scene.add(group);
+    const rootGroup = new THREE.Group();
+    const contentGroup = new THREE.Group();
     const ambient = new THREE.AmbientLight(0xffffff, variant === "lattice" ? 1.35 : 1.6);
     const keyLight = new THREE.PointLight(0x9fd8ff, 2.2, 14);
     keyLight.position.set(3, 4, 6);
-    group.add(ambient);
-    group.add(keyLight);
+    rootGroup.add(ambient);
+    rootGroup.add(keyLight);
+    rootGroup.add(contentGroup);
+    scene.add(rootGroup);
 
-    const nodes = Array.isArray(graph?.nodes) ? graph.nodes : [];
-    const edges = Array.isArray(graph?.edges) ? graph.edges : [];
-    const selectedSet = new Set(Array.isArray(selectedKnowledgeIds) ? selectedKnowledgeIds : []);
-    const positions = new Map();
-    const pickables = [];
-
-    if (variant === "lattice") {
-      const latticePositions = buildLatticePositions(nodes.length);
-      const inactiveMaterial = new THREE.MeshBasicMaterial({
-        color: 0x27445b,
-        transparent: true,
-        opacity: 0.35,
-      });
-      const inactiveGeometry = new THREE.SphereGeometry(0.045, 12, 8);
-      latticePositions.forEach((position, index) => {
-        const mesh = new THREE.Mesh(inactiveGeometry, inactiveMaterial);
-        mesh.position.copy(position);
-        group.add(mesh);
-      });
-
-      const edgeMaterial = new THREE.LineBasicMaterial({
-        color: 0x8ce7ff,
-        transparent: true,
-        opacity: 0.9,
-      });
-      const activeGeometry = new THREE.SphereGeometry(0.13, 24, 16);
-      const activeMaterial = new THREE.MeshStandardMaterial({
-        color: 0x7ae6ff,
-        emissive: 0x39c8ff,
-        emissiveIntensity: 1.35,
-        roughness: 0.25,
-        metalness: 0.18,
-      });
-
-      nodes.forEach((node, index) => {
-        const id = nodeId(node);
-        const idKnowledge = knowledgeId(node);
-        const position = latticePositions[index] || stablePosition(index, nodes.length);
-        positions.set(id, position);
-        positions.set(idKnowledge, position);
-        const mesh = new THREE.Mesh(activeGeometry, activeMaterial);
-        mesh.position.copy(position);
-        mesh.userData = { node, active: true };
-        group.add(mesh);
-        pickables.push(mesh);
-      });
-
-      edges.forEach((edge) => {
-        const from = resolveEndpointPosition(edge, "from", positions);
-        const to = resolveEndpointPosition(edge, "to", positions);
-        if (from && to) {
-          group.add(createLine(from, to, edgeMaterial));
-        }
-      });
-    } else {
-      const cube = new THREE.LineSegments(
-        new THREE.EdgesGeometry(new THREE.BoxGeometry(5, 5, 5)),
-        new THREE.LineBasicMaterial({ color: 0x5f7d92, transparent: true, opacity: 0.45 }),
-      );
-      group.add(cube);
-
-      nodes.forEach((node, index) => {
-        const id = nodeId(node);
-        const idKnowledge = knowledgeId(node);
-        const position = stablePosition(index, nodes.length);
-        positions.set(id, position);
-        positions.set(idKnowledge, position);
-        const selected = selectedSet.has(idKnowledge);
-        const mesh = new THREE.Mesh(
-          new THREE.BoxGeometry(
-            selected ? 0.26 : 0.18,
-            selected ? 0.26 : 0.18,
-            selected ? 0.26 : 0.18,
-          ),
-          new THREE.MeshStandardMaterial({
-            color: selected ? 0x53d18f : 0x65a8ff,
-            roughness: 0.4,
-            metalness: 0.15,
-          }),
-        );
-        mesh.position.copy(position);
-        mesh.userData = { node, active: true };
-        group.add(mesh);
-        pickables.push(mesh);
-      });
-
-      edges.forEach((edge) => {
-        const from = resolveEndpointPosition(edge, "from", positions);
-        const to = resolveEndpointPosition(edge, "to", positions);
-        if (from && to) {
-          group.add(
-            createLine(
-              from,
-              to,
-              new THREE.LineBasicMaterial({ color: 0x9fb4c7, transparent: true, opacity: 0.52 }),
-            ),
-          );
-        }
-      });
-    }
+    const sceneState = {
+      camera,
+      contentGroup,
+      pickables: [],
+      renderer,
+      rootGroup,
+      scene,
+    };
+    sceneStateRef.current = sceneState;
 
     let dragging = false;
     let previousX = 0;
@@ -254,16 +300,18 @@ export function KnowledgeCubeGraph({
       pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
       pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
       raycaster.setFromCamera(pointer, camera);
-      const [hit] = raycaster.intersectObjects(pickables);
+      const [hit] = raycaster.intersectObjects(sceneStateRef.current?.pickables || []);
       if (!hit?.object?.userData?.node) {
         setHoveredNode(null);
-        return;
+        return null;
       }
-      setHoveredNode({
+      const nextHoveredNode = {
         title: knowledgeTitleFromItem(hit.object.userData.node),
         x: event.clientX - rect.left,
         y: event.clientY - rect.top,
-      });
+      };
+      setHoveredNode(nextHoveredNode);
+      return hit.object.userData.node;
     };
 
     const onPointerDown = (event) => {
@@ -283,8 +331,8 @@ export function KnowledgeCubeGraph({
       if (Math.abs(dx) + Math.abs(dy) > 1) {
         movedWhileDragging = true;
       }
-      group.rotation.y += dx * 0.008;
-      group.rotation.x += dy * 0.008;
+      rootGroup.rotation.y += dx * 0.008;
+      rootGroup.rotation.x += dy * 0.008;
       previousX = event.clientX;
       previousY = event.clientY;
       setHoveredNode(null);
@@ -307,14 +355,9 @@ export function KnowledgeCubeGraph({
       if (movedWhileDragging) {
         return;
       }
-      updateHover(event);
-      const rect = renderer.domElement.getBoundingClientRect();
-      pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
-      pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
-      raycaster.setFromCamera(pointer, camera);
-      const [hit] = raycaster.intersectObjects(pickables);
-      if (hit?.object?.userData?.node && onSelect) {
-        onSelect(hit.object.userData.node);
+      const selectedNode = updateHover(event);
+      if (selectedNode && onSelectRef.current) {
+        onSelectRef.current(selectedNode);
       }
     };
 
@@ -328,7 +371,7 @@ export function KnowledgeCubeGraph({
     let frame = 0;
     const animate = () => {
       frame = requestAnimationFrame(animate);
-      group.rotation.y += variant === "lattice" ? 0.0008 : 0.0012;
+      rootGroup.rotation.y += variant === "lattice" ? 0.0008 : 0.0012;
       renderer.render(scene, camera);
     };
     animate();
@@ -342,13 +385,23 @@ export function KnowledgeCubeGraph({
       renderer.domElement.removeEventListener("pointerleave", onPointerLeave);
       renderer.domElement.removeEventListener("wheel", onWheel);
       renderer.domElement.removeEventListener("click", onClick);
+      sceneStateRef.current = null;
       disposeObject(scene);
       renderer.dispose();
       if (mount.contains(renderer.domElement)) {
         mount.removeChild(renderer.domElement);
       }
     };
-  }, [graph, onSelect, selectedKnowledgeIds, variant]);
+  }, [variant]);
+
+  useEffect(() => {
+    const sceneState = sceneStateRef.current;
+    if (!sceneState) {
+      return;
+    }
+    populateGraphContent(sceneState, graph, selectedKnowledgeIds, variant);
+    setHoveredNode(null);
+  }, [graph, selectedKnowledgeIds, variant]);
 
   return (
     <div className={`knowledge-cube-graph ${variant === "lattice" ? "is-lattice" : ""}`} ref={mountRef}>

--- a/ui/operator-react/src/knowledgeVault.js
+++ b/ui/operator-react/src/knowledgeVault.js
@@ -1,3 +1,5 @@
+export const KNOWLEDGE_GRAPH_LIMIT = 200;
+
 export function knowledgeIdFromItem(item) {
   return item?.knowledge_id || item?.id || item?.block_id || "";
 }
@@ -18,7 +20,7 @@ export function normalizeKnowledgeResults(items) {
   return [...byKnowledgeId.values()];
 }
 
-export function buildKnowledgeGraphRequest(items, extras = [], limit = 100) {
+export function buildKnowledgeGraphRequest(items, extras = [], limit = KNOWLEDGE_GRAPH_LIMIT) {
   const knowledgeIds = [];
   const seen = new Set();
   for (const candidate of [...(Array.isArray(items) ? items : []), ...extras]) {
@@ -36,6 +38,18 @@ export function buildKnowledgeGraphRequest(items, extras = [], limit = 100) {
     knowledge_ids: knowledgeIds,
     depth: 1,
   };
+}
+
+export function knowledgeGraphSignature(graph) {
+  return JSON.stringify({
+    nodes: Array.isArray(graph?.nodes) ? graph.nodes : [],
+    edges: Array.isArray(graph?.edges) ? graph.edges : [],
+    warnings: Array.isArray(graph?.warnings) ? graph.warnings : [],
+  });
+}
+
+export function areKnowledgeGraphsEqual(left, right) {
+  return knowledgeGraphSignature(left) === knowledgeGraphSignature(right);
 }
 
 export function summarizeKnowledgeGraph(graph) {

--- a/ui/operator-react/src/knowledgeVault.test.js
+++ b/ui/operator-react/src/knowledgeVault.test.js
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  areKnowledgeGraphsEqual,
   buildKnowledgeGraphRequest,
+  KNOWLEDGE_GRAPH_LIMIT,
   knowledgeTitleFromItem,
   normalizeKnowledgeResults,
   summarizeKnowledgeGraph,
@@ -33,6 +35,14 @@ describe("knowledgeVault utils", () => {
     });
   });
 
+  it("uses the 200 item Knowledge Vault graph limit by default", () => {
+    const items = Array.from({ length: KNOWLEDGE_GRAPH_LIMIT + 5 }, (_, index) => ({
+      knowledge_id: `item-${index}`,
+    }));
+
+    expect(buildKnowledgeGraphRequest(items).knowledge_ids).toHaveLength(KNOWLEDGE_GRAPH_LIMIT);
+  });
+
   it("summarizes graph payloads and falls back to stable titles", () => {
     expect(
       summarizeKnowledgeGraph({
@@ -41,5 +51,20 @@ describe("knowledgeVault utils", () => {
       }),
     ).toEqual({ nodeCount: 2, edgeCount: 1 });
     expect(knowledgeTitleFromItem({ block_id: "block-1" })).toBe("block-1");
+  });
+
+  it("compares graph payloads before replacing state", () => {
+    expect(
+      areKnowledgeGraphsEqual(
+        { nodes: [{ knowledge_id: "alpha" }], edges: [], warnings: [] },
+        { nodes: [{ knowledge_id: "alpha" }], edges: [], warnings: [] },
+      ),
+    ).toBe(true);
+    expect(
+      areKnowledgeGraphsEqual(
+        { nodes: [{ knowledge_id: "alpha" }], edges: [], warnings: [] },
+        { nodes: [{ knowledge_id: "beta" }], edges: [], warnings: [] },
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary\n- increase Knowledge Vault graph/search limit to 200 records\n- render 200 inactive lattice points behind active Knowledge Vault molecules\n- keep the WebGL scene, camera distance, and cube rotation alive across graph data refreshes\n- avoid replacing graph React state when the refreshed payload is unchanged\n\n## Verification\n- npm test\n- npm run build