### PR TITLE
Fix plane creation modal layout

### DIFF
--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -1183,44 +1183,65 @@ export function PlaneEditorDialog({
           </button>
         </div>
         <p className="editor-copy">{editorCopy}</p>
-        {dialog.error ? <div className="error-banner">{dialog.error}</div> : null}
-        {formValidation.errors.length > 0 ? (
-          <div className="error-banner">
-            <strong>Form validation</strong>
-            <ul className="banner-list">
-              {formValidation.errors.map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-        {formValidation.warnings.length > 0 ? (
-          <div className="warning-banner">
-            <strong>Warnings</strong>
-            <ul className="banner-list">
-              {formValidation.warnings.map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-        {showFormBuilder ? (
-          <PlaneV2FormBuilder
-            dialog={dialog}
-            setDialog={setDialog}
-            languageOptions={CHAT_LANGUAGE_OPTIONS}
-            modelLibraryItems={modelLibraryItems || []}
-            hostdHosts={hostdHosts || []}
-            peerLinks={peerLinks || null}
-            skillsFactoryItems={skillsFactoryItems || []}
-            skillsFactoryGroups={skillsFactoryGroups || []}
-            onResetLtCypherDeployment={onResetLtCypherDeployment}
-          />
-        ) : null}
-        {showFormBuilder ? (
-          <details className="plane-advanced-section">
-            <summary className="plane-advanced-summary">Generated JSON</summary>
-            <div className="plane-advanced-body">
+        <div className="plane-editor-scroll">
+          {dialog.error ? <div className="error-banner">{dialog.error}</div> : null}
+          {formValidation.errors.length > 0 ? (
+            <div className="error-banner">
+              <strong>Form validation</strong>
+              <ul className="banner-list">
+                {formValidation.errors.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {formValidation.warnings.length > 0 ? (
+            <div className="warning-banner">
+              <strong>Warnings</strong>
+              <ul className="banner-list">
+                {formValidation.warnings.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {showFormBuilder ? (
+            <PlaneV2FormBuilder
+              dialog={dialog}
+              setDialog={setDialog}
+              languageOptions={CHAT_LANGUAGE_OPTIONS}
+              modelLibraryItems={modelLibraryItems || []}
+              hostdHosts={hostdHosts || []}
+              peerLinks={peerLinks || null}
+              skillsFactoryItems={skillsFactoryItems || []}
+              skillsFactoryGroups={skillsFactoryGroups || []}
+              onResetLtCypherDeployment={onResetLtCypherDeployment}
+            />
+          ) : null}
+          {showFormBuilder ? (
+            <details className="plane-advanced-section">
+              <summary className="plane-advanced-summary">Generated JSON</summary>
+              <div className="plane-advanced-body">
+                <label className="field-label" htmlFor="plane-editor-json">
+                  {desiredStateLabel}
+                </label>
+                <textarea
+                  id="plane-editor-json"
+                  className="editor-textarea"
+                  value={dialog.text}
+                  onChange={(event) =>
+                    setDialog((current) => ({
+                      ...current,
+                      text: event.target.value,
+                    }))
+                  }
+                  readOnly
+                  spellCheck="false"
+                />
+              </div>
+            </details>
+          ) : (
+            <>
               <label className="field-label" htmlFor="plane-editor-json">
                 {desiredStateLabel}
               </label>
@@ -1234,31 +1255,12 @@ export function PlaneEditorDialog({
                     text: event.target.value,
                   }))
                 }
-                readOnly
+                readOnly={readOnly || showFormBuilder}
                 spellCheck="false"
               />
-            </div>
-          </details>
-        ) : (
-          <>
-            <label className="field-label" htmlFor="plane-editor-json">
-              {desiredStateLabel}
-            </label>
-            <textarea
-              id="plane-editor-json"
-              className="editor-textarea"
-              value={dialog.text}
-              onChange={(event) =>
-                setDialog((current) => ({
-                  ...current,
-                  text: event.target.value,
-                }))
-              }
-              readOnly={readOnly || showFormBuilder}
-              spellCheck="false"
-            />
-          </>
-        )}
+            </>
+          )}
+        </div>
         <div className="toolbar">
           {readOnly ? (
             <button

--- a/ui/operator-react/src/styles.css
+++ b/ui/operator-react/src/styles.css
@@ -2236,20 +2236,43 @@ body {
 }
 
 .plane-editor-modal {
-  width: min(1180px, calc(100vw - 48px));
-  display: grid;
+  width: min(1480px, calc(100vw - 48px));
+  display: flex;
+  flex-direction: column;
   gap: 14px;
   min-width: 0;
-  grid-template-rows: auto auto minmax(0, 1fr) auto auto;
+  overflow: hidden;
 }
 
-.plane-editor-modal > .plane-form-builder {
+.plane-editor-scroll {
+  display: grid;
+  gap: 14px;
   min-height: 0;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.plane-editor-scroll > .plane-form-builder {
+  min-height: 0;
+  margin-bottom: 0;
+}
+
+@media (min-width: 761px) {
+  .plane-editor-modal .plane-form-grid {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+  }
+
+  .plane-editor-modal .plane-form-grid-wide {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+  }
+
+  .plane-editor-modal .plane-features-grid {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 160px), 1fr));
+  }
 }
 
 .plane-editor-modal > .toolbar:last-child {
-  position: sticky;
-  bottom: -20px;
+  flex: 0 0 auto;
   z-index: 2;
   margin: 0 -20px -20px;
   padding: 14px 20px 20px;


### PR DESCRIPTION
## Summary\n- make the plane editor modal use a stable flex layout with an internal scroll body\n- widen the modal so the create/edit form has room on desktop\n- keep plane editor grids multi-column on tablet/notebook widths while preserving single-column mobile layout\n\n## Verification\n- npm test\n- npm run build\n- Playwright smoke with mocked API at 1366x900, 1024x768, and 390x844