### PR TITLE
Follow up plane editor layout and Knowledge Vault skills

### DIFF
--- a/controller/include/skills/knowledge_vault_common_skills.h
+++ b/controller/include/skills/knowledge_vault_common_skills.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "naim/state/models.h"
+#include "naim/state/sqlite_store.h"
+
+namespace naim::controller {
+
+struct KnowledgeVaultCommonSkillDefinition {
+  const char* id;
+  const char* name;
+  const char* description;
+  const char* content;
+  std::vector<std::string> match_terms;
+};
+
+inline const std::vector<KnowledgeVaultCommonSkillDefinition>&
+KnowledgeVaultCommonSkillDefinitions() {
+  static const std::vector<KnowledgeVaultCommonSkillDefinition> definitions{
+      {
+          "knowledge-vault-replica-search",
+          "Knowledge Vault replica search",
+          "Search the current plane's Knowledge Vault replica for relevant project knowledge.",
+          "Use this skill when the user asks to find, recall, inspect, or search knowledge, "
+          "documentation, memory, notes, or facts that should exist in the current plane's "
+          "Knowledge Vault replica. Use only Knowledge Base context injected by naim-node for "
+          "the current plane. Do not use global SkillsFactory data or another plane's replica. "
+          "If no relevant Knowledge Vault context is available, say that the current plane's "
+          "Knowledge Vault does not contain enough information.",
+          {
+              "knowledge vault",
+              "vault",
+              "kb",
+              "knowledge base",
+              "docs",
+              "documentation",
+              "memory",
+              "replica",
+              "search knowledge",
+              "find in docs",
+              "найди",
+              "знания",
+              "документация",
+              "память",
+              "реплика",
+              "что известно",
+          },
+      },
+      {
+          "knowledge-vault-replica-answer-with-citations",
+          "Knowledge Vault grounded answer",
+          "Answer using current-plane Knowledge Vault context and preserve citations.",
+          "Use this skill when the user asks a question that should be answered from the "
+          "current plane's Knowledge Vault replica. Ground the answer in the injected Knowledge "
+          "Base context. Cite the relevant knowledge_id and block_id when they are present. "
+          "Separate facts found in Knowledge Vault from your own reasoning. Do not invent "
+          "citations, source ids, or facts that are absent from the context.",
+          {
+              "knowledge vault",
+              "grounded answer",
+              "citation",
+              "citations",
+              "source",
+              "sources",
+              "provenance",
+              "knowledge_id",
+              "block_id",
+              "ответь по базе",
+              "с цитатами",
+              "источник",
+              "источники",
+              "обоснованный ответ",
+          },
+      },
+      {
+          "knowledge-vault-replica-gap-check",
+          "Knowledge Vault gap check",
+          "Check whether the current plane's Knowledge Vault has enough evidence to answer.",
+          "Use this skill when the user asks whether something is known, documented, confirmed, "
+          "or missing in the current plane's Knowledge Vault replica. Identify what the injected "
+          "Knowledge Base context supports, what remains uncertain, and what should be added to "
+          "Knowledge Vault if the answer cannot be fully grounded.",
+          {
+              "knowledge vault",
+              "gap",
+              "missing",
+              "unknown",
+              "uncertain",
+              "not documented",
+              "is documented",
+              "is known",
+              "проверить",
+              "неизвестно",
+              "не хватает",
+              "не задокументировано",
+              "известно ли",
+              "есть ли данные",
+          },
+      },
+  };
+  return definitions;
+}
+
+inline std::vector<std::string> KnowledgeVaultCommonSkillIds() {
+  std::vector<std::string> ids;
+  for (const auto& definition : KnowledgeVaultCommonSkillDefinitions()) {
+    ids.push_back(definition.id);
+  }
+  return ids;
+}
+
+inline bool IsKnowledgeVaultCommonSkillEligible(const naim::DesiredState& state) {
+  return state.plane_mode == naim::PlaneMode::Llm &&
+         state.skills.has_value() &&
+         state.skills->enabled &&
+         state.knowledge.has_value() &&
+         state.knowledge->enabled;
+}
+
+inline void EnsureKnowledgeVaultCommonSkillRecords(naim::ControllerStore& store) {
+  for (const auto& definition : KnowledgeVaultCommonSkillDefinitions()) {
+    store.UpsertSkillsFactorySkill(naim::SkillsFactorySkillRecord{
+        definition.id,
+        definition.name,
+        "",
+        definition.description,
+        definition.content,
+        definition.match_terms,
+        false,
+        "",
+        "",
+    });
+  }
+}
+
+inline bool AttachKnowledgeVaultCommonSkills(naim::DesiredState* state) {
+  if (state == nullptr || !IsKnowledgeVaultCommonSkillEligible(*state)) {
+    return false;
+  }
+
+  bool changed = false;
+  auto& skill_ids = state->skills->factory_skill_ids;
+  for (const auto& definition : KnowledgeVaultCommonSkillDefinitions()) {
+    if (std::find(skill_ids.begin(), skill_ids.end(), definition.id) !=
+        skill_ids.end()) {
+      continue;
+    }
+    skill_ids.push_back(definition.id);
+    changed = true;
+  }
+  return changed;
+}
+
+inline bool EnsureKnowledgeVaultCommonSkills(
+    naim::ControllerStore& store,
+    naim::DesiredState* state) {
+  EnsureKnowledgeVaultCommonSkillRecords(store);
+  return AttachKnowledgeVaultCommonSkills(state);
+}
+
+}  // namespace naim::controller

--- a/controller/src/bundle/bundle_cli_service.cpp
+++ b/controller/src/bundle/bundle_cli_service.cpp
@@ -15,6 +15,7 @@
 #include "naim/planning/planner.h"
 #include "naim/planning/reconcile.h"
 #include "naim/state/state_json.h"
+#include "skills/knowledge_vault_common_skills.h"
 
 namespace naim::controller {
 
@@ -414,6 +415,7 @@ int BundleCliService::ApplyDesiredState(
       store, &effective_desired_state);
   desired_state_policy_service_.ResolveDesiredStateDynamicPlacements(
       store, &effective_desired_state);
+  EnsureKnowledgeVaultCommonSkills(store, &effective_desired_state);
   desired_state_policy_service_.ValidateDesiredStateForControllerAdmission(
       store,
       effective_desired_state);

--- a/controller/src/bundle/bundle_cli_service_tests.cpp
+++ b/controller/src/bundle/bundle_cli_service_tests.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -29,8 +30,8 @@ void Expect(bool condition, const std::string& message) {
   }
 }
 
-naim::DesiredState BuildRenderedState(int max_num_seqs) {
-  const json desired_state_v2{
+naim::DesiredState BuildRenderedState(int max_num_seqs, bool enable_knowledge_skills = false) {
+  json desired_state_v2{
       {"version", 2},
       {"plane_name", "apply-runtime-overrides"},
       {"plane_mode", "llm"},
@@ -63,6 +64,15 @@ naim::DesiredState BuildRenderedState(int max_num_seqs) {
              {{{"node", "gpu-hostd"}, {"gpu_device", "0"}}})}}},
       {"app", {{"enabled", false}}},
   };
+  if (enable_knowledge_skills) {
+    desired_state_v2["skills"] = {
+        {"enabled", true},
+        {"factory_skill_ids", json::array({"existing-skill"})},
+    };
+    desired_state_v2["knowledge"] = {
+        {"enabled", true},
+    };
+  }
   naim::DesiredStateV2Validator::ValidateOrThrow(desired_state_v2);
   return naim::DesiredStateV2Renderer::Render(desired_state_v2);
 }
@@ -130,6 +140,29 @@ int main() {
     Expect(
         serialized_v2.at("runtime").at("max_num_seqs").get<int>() == 24,
         "projected desired-state.v2 should preserve updated max_num_seqs");
+
+    Expect(
+        bundle_cli_service.ApplyDesiredState(
+            db_path.string(),
+            BuildRenderedState(32, true),
+            artifacts_root.string(),
+            "test-knowledge-skills") == 0,
+        "knowledge skills apply should succeed");
+    const auto knowledge_state = store.LoadDesiredState("apply-runtime-overrides");
+    Expect(knowledge_state.has_value(), "knowledge desired state should exist");
+    Expect(
+        knowledge_state->skills.has_value() &&
+            knowledge_state->skills->factory_skill_ids ==
+                std::vector<std::string>({
+                    "existing-skill",
+                    "knowledge-vault-replica-search",
+                    "knowledge-vault-replica-answer-with-citations",
+                    "knowledge-vault-replica-gap-check",
+                }),
+        "Knowledge Vault common skills should auto-attach during apply");
+    Expect(
+        store.LoadSkillsFactorySkill("knowledge-vault-replica-search").has_value(),
+        "Knowledge Vault common skill should be seeded during apply");
 
     std::cout << "bundle_cli_service_tests passed\n";
     return 0;

--- a/controller/src/plane/plane_lifecycle_support.cpp
+++ b/controller/src/plane/plane_lifecycle_support.cpp
@@ -1,6 +1,7 @@
 #include "plane/plane_lifecycle_support.h"
 
 #include "app/controller_composition_support.h"
+#include "skills/knowledge_vault_common_skills.h"
 
 namespace naim::controller {
 
@@ -17,6 +18,7 @@ void ControllerPlaneLifecycleSupport::PrepareDesiredState(
     naim::DesiredState* desired_state) const {
   desired_state_policy_service_.ApplyRegisteredHostExecutionModes(store, desired_state);
   desired_state_policy_service_.ResolveDesiredStateDynamicPlacements(store, desired_state);
+  EnsureKnowledgeVaultCommonSkills(store, desired_state);
   desired_state_policy_service_.ValidateDesiredStateForControllerAdmission(
       store,
       *desired_state);

--- a/controller/src/skills/plane_skills_service_tests.cpp
+++ b/controller/src/skills/plane_skills_service_tests.cpp
@@ -1,5 +1,6 @@
 #include <filesystem>
 #include <iostream>
+#include <algorithm>
 #include <atomic>
 #include <cctype>
 #include <map>
@@ -20,6 +21,7 @@
 #include "interaction/interaction_service.h"
 #include "browsing/plane_browsing_service.h"
 #include "plane/plane_dashboard_skills_summary_service.h"
+#include "skills/knowledge_vault_common_skills.h"
 #include "skills/plane_skill_contextual_resolver_service.h"
 #include "skills/plane_skills_service.h"
 
@@ -2422,6 +2424,43 @@ int main() {
               selection.selected_skill_ids.front() == "code-agent-root-cause-debug",
           "resolver should use controller catalog entries when runtime skillsd is remote or unreachable");
       std::cout << "ok: contextual-resolver-uses-controller-catalog" << '\n';
+    }
+
+    {
+      const std::string db_path = MakeTempDbPath();
+      fs::remove(db_path);
+      naim::ControllerStore store(db_path);
+      store.Initialize();
+      auto desired_state = BuildDesiredState("knowledge-plane", {});
+      naim::KnowledgeSettings knowledge;
+      knowledge.enabled = true;
+      desired_state.knowledge = knowledge;
+      naim::controller::EnsureKnowledgeVaultCommonSkills(store, &desired_state);
+      store.ReplaceDesiredState(desired_state, 1);
+
+      naim::controller::PlaneInteractionResolution resolution;
+      resolution.db_path = db_path;
+      resolution.desired_state = desired_state;
+
+      const auto selection =
+          naim::controller::PlaneSkillContextualResolverService().Resolve(
+              db_path,
+              resolution,
+              json{{"messages",
+                    json::array(
+                        {json{{"role", "user"},
+                              {"content",
+                               "Найди в Knowledge Vault, что известно по реплике plane."}}})}});
+      Expect(
+          selection.mode == "contextual" &&
+              selection.candidate_count == 3 &&
+              std::find(
+                  selection.selected_skill_ids.begin(),
+                  selection.selected_skill_ids.end(),
+                  "knowledge-vault-replica-search") !=
+                  selection.selected_skill_ids.end(),
+          "resolver should select common Knowledge Vault search skill");
+      std::cout << "ok: contextual-resolver-selects-knowledge-vault-common-skill" << '\n';
     }
 
     {

--- a/controller/src/skills/skills_factory_service.cpp
+++ b/controller/src/skills/skills_factory_service.cpp
@@ -9,6 +9,7 @@
 
 #include "naim/state/sqlite_store.h"
 #include "naim/state/state_json.h"
+#include "skills/knowledge_vault_common_skills.h"
 
 namespace naim::controller {
 
@@ -254,6 +255,7 @@ nlohmann::json SkillsFactoryService::BuildSkillPayload(
 nlohmann::json SkillsFactoryService::BuildListPayload(const std::string& db_path) const {
   naim::ControllerStore store(db_path);
   store.Initialize();
+  EnsureKnowledgeVaultCommonSkillRecords(store);
   json items = json::array();
   for (const auto& skill : store.LoadSkillsFactorySkills()) {
     items.push_back(BuildSkillPayload(db_path, skill));
@@ -270,6 +272,7 @@ nlohmann::json SkillsFactoryService::BuildSkillPayload(
     const std::string& skill_id) const {
   naim::ControllerStore store(db_path);
   store.Initialize();
+  EnsureKnowledgeVaultCommonSkillRecords(store);
   const auto skill = store.LoadSkillsFactorySkill(skill_id);
   if (!skill.has_value()) {
     throw std::runtime_error("skill '" + skill_id + "' not found");

--- a/controller/src/skills/skills_factory_service_tests.cpp
+++ b/controller/src/skills/skills_factory_service_tests.cpp
@@ -10,6 +10,7 @@
 #include "naim/state/desired_state_v2_validator.h"
 #include "naim/state/sqlite_store.h"
 #include "plane/plane_mutation_service.h"
+#include "skills/knowledge_vault_common_skills.h"
 #include "skills/plane_skill_catalog_service.h"
 #include "skills/skills_factory_service.h"
 
@@ -80,6 +81,15 @@ void SeedDesiredState(
   Expect(plane.has_value(), "plane should exist after replacing desired state");
 }
 
+json FindSkillById(const json& skills, const std::string& skill_id) {
+  for (const auto& skill : skills) {
+    if (skill.value("id", std::string{}) == skill_id) {
+      return skill;
+    }
+  }
+  throw std::runtime_error("skill '" + skill_id + "' not found in payload");
+}
+
 }  // namespace
 
 int main() {
@@ -123,9 +133,9 @@ int main() {
             return fallback;
           });
       const auto payload = factory_service.BuildListPayload(db_path.string());
-      Expect(payload.at("skills").size() == 1, "factory list should contain one skill");
+      Expect(payload.at("skills").size() == 4, "factory list should contain seeded common skills");
       Expect(payload.at("groups").size() == 0, "factory list should start without explicit groups");
-      const auto& item = payload.at("skills").front();
+      const auto& item = FindSkillById(payload.at("skills"), "skill-alpha");
       Expect(item.at("id").get<std::string>() == "skill-alpha", "factory skill id mismatch");
       Expect(item.at("plane_count").get<int>() == 1, "factory skill plane_count mismatch");
       Expect(
@@ -140,6 +150,15 @@ int main() {
               std::vector<std::string>({"alpha", "core"}),
           "factory skill match_terms mismatch");
       Expect(item.at("internal").get<bool>(), "factory skill internal flag mismatch");
+
+      const auto& common_item =
+          FindSkillById(payload.at("skills"), "knowledge-vault-replica-search");
+      Expect(
+          common_item.at("group_path").get<std::string>().empty(),
+          "common Knowledge Vault skill should not belong to a group");
+      Expect(
+          !common_item.at("internal").get<bool>(),
+          "common Knowledge Vault skill should be user-visible");
 
       const auto deleted =
           factory_service.DeleteSkill(db_path.string(), "skill-alpha", temp_root.string());
@@ -158,6 +177,41 @@ int main() {
           next_state->skills.has_value() && next_state->skills->factory_skill_ids.empty(),
           "factory delete should detach skill id from plane desired state");
       std::cout << "ok: factory-delete-detaches-all-planes" << '\n';
+    }
+
+    {
+      naim::ControllerStore store(db_path.string());
+      store.Initialize();
+      auto desired_state = BuildDesiredState("knowledge-plane", {"existing-skill"});
+      naim::KnowledgeSettings knowledge;
+      knowledge.enabled = true;
+      desired_state.knowledge = knowledge;
+
+      const bool changed =
+          naim::controller::EnsureKnowledgeVaultCommonSkills(store, &desired_state);
+      Expect(changed, "Knowledge Vault common skills should be attached to eligible planes");
+      Expect(
+          desired_state.skills->factory_skill_ids ==
+              std::vector<std::string>({
+                  "existing-skill",
+                  "knowledge-vault-replica-search",
+                  "knowledge-vault-replica-answer-with-citations",
+                  "knowledge-vault-replica-gap-check",
+              }),
+          "Knowledge Vault common skills should append after existing ids");
+      Expect(
+          store.LoadSkillsFactorySkill("knowledge-vault-replica-search").has_value(),
+          "Knowledge Vault common skill records should be seeded");
+
+      auto non_knowledge_state = BuildDesiredState("no-knowledge-plane", {"existing-skill"});
+      const bool non_knowledge_changed =
+          naim::controller::AttachKnowledgeVaultCommonSkills(&non_knowledge_state);
+      Expect(
+          !non_knowledge_changed &&
+              non_knowledge_state.skills->factory_skill_ids ==
+                  std::vector<std::string>({"existing-skill"}),
+          "Knowledge Vault common skills should not attach without enabled knowledge");
+      std::cout << "ok: knowledge-vault-common-skills-auto-attach" << '\n';
     }
 
     {

--- a/docs/skills-factory.md
+++ b/docs/skills-factory.md
@@ -124,6 +124,21 @@ Debugging:
   - returns selected ids, selected records, candidate count, and compact rationale
   - uses only plane-local enabled skills
 
+### Common Knowledge Vault Skills
+
+`naim-node` seeds three built-in, ungrouped SkillsFactory records for read-only Knowledge Vault
+replica work:
+
+- `knowledge-vault-replica-search`
+- `knowledge-vault-replica-answer-with-citations`
+- `knowledge-vault-replica-gap-check`
+
+These records use an empty `group_path`, so the Operator UI displays them under `No group`.
+When an LLM plane has both `skills.enabled=true` and `knowledge.enabled=true`, controller
+desired-state preparation appends these ids to `skills.factory_skill_ids[]` if they are missing.
+The skills do not add a new tool-calling API; they steer the model to use the existing
+controller-injected Knowledge Vault context for the current plane only.
+
 ## Operator UI
 
 ### Sidebar

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -1219,7 +1219,7 @@ export function PlaneEditorDialog({
             />
           ) : null}
           {showFormBuilder ? (
-            <details className="plane-advanced-section">
+            <details className="plane-advanced-section plane-generated-json-section">
               <summary className="plane-advanced-summary">Generated JSON</summary>
               <div className="plane-advanced-body">
                 <label className="field-label" htmlFor="plane-editor-json">

--- a/ui/operator-react/src/styles.css
+++ b/ui/operator-react/src/styles.css
@@ -1184,6 +1184,7 @@ body {
 }
 
 .field-info-tooltip {
+  display: none;
   position: absolute;
   left: 50%;
   bottom: calc(100% + 10px);
@@ -1206,6 +1207,7 @@ body {
 .field-info:hover .field-info-tooltip,
 .field-info:focus .field-info-tooltip,
 .field-info:focus-visible .field-info-tooltip {
+  display: block;
   opacity: 1;
 }
 
@@ -2245,16 +2247,59 @@ body {
 }
 
 .plane-editor-scroll {
-  display: grid;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   gap: 14px;
   min-height: 0;
+  max-width: 100%;
   overflow: auto;
-  padding-right: 4px;
+  padding: 0 4px 4px 0;
+}
+
+.plane-editor-scroll > * {
+  flex: 0 0 auto;
 }
 
 .plane-editor-scroll > .plane-form-builder {
   min-height: 0;
   margin-bottom: 0;
+}
+
+.plane-editor-modal .plane-form-builder,
+.plane-editor-modal .plane-form-toggle,
+.plane-editor-modal .plane-advanced-section,
+.plane-editor-modal .plane-advanced-body,
+.plane-editor-modal .field-label,
+.plane-editor-modal .model-library-picker {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.plane-editor-modal .plane-advanced-body {
+  overflow: hidden;
+}
+
+.plane-generated-json-section {
+  align-self: stretch;
+}
+
+.plane-generated-json-section .editor-textarea {
+  min-height: 220px;
+  max-height: min(420px, 42vh);
+  overflow: auto;
+  white-space: pre;
+}
+
+.plane-editor-modal .model-library-picker-head,
+.plane-editor-modal .model-library-picker-row {
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 0.7fr) minmax(0, 1.6fr);
+}
+
+.plane-editor-modal .model-library-picker-head > *,
+.plane-editor-modal .model-library-picker-row > * {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 @media (min-width: 761px) {


### PR DESCRIPTION
## Summary
- keep generated plane JSON inside the plane editor modal layout without overlapping the form or model gallery
- add common Knowledge Vault skills wiring and tests

## Validation
- npm test in ui/operator-react
- npm run build in ui/operator-react
- browser smoke checked modal overflow at desktop, tablet, and mobile sizes