### PR TITLE
Stabilize CUDA build and infer doctor path

### DIFF
--- a/.github/workflows/naim-production-release.yml
+++ b/.github/workflows/naim-production-release.yml
@@ -23,6 +23,7 @@ env:
   NAIM_REGISTRY_USERNAME: ${{ secrets.NAIM_REGISTRY_USERNAME || vars.NAIM_REGISTRY_USERNAME || 'admin' }}
   NAIM_BUILD_TYPE: ${{ vars.NAIM_BUILD_TYPE || 'Release' }}
   NAIM_CUDA_ARCHITECTURES: ${{ vars.NAIM_CUDA_ARCHITECTURES || '' }}
+  NAIM_CUDA_NVCC_JOBS: ${{ vars.NAIM_CUDA_NVCC_JOBS || '1' }}
   NAIM_CMAKE_ARGS: ${{ vars.NAIM_CMAKE_ARGS || '' }}
   NAIM_MIGRATION_TIMEOUT_SEC: ${{ vars.NAIM_MIGRATION_TIMEOUT_SEC || '600' }}
 
@@ -61,7 +62,7 @@ jobs:
           set -euo pipefail
           repo_q="$(printf '%q' "${NAIM_HPC1_REPO_PATH}")"
           ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
-            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build.sh"
+            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build.sh"
 
   hpc1-knowledge-vault-release-gate:
     name: 2a. hpc1 Knowledge Vault release gate

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.22)
 
 option(NAIM_SKIP_VCPKG_TOOLCHAIN "Skip automatic vcpkg toolchain detection" OFF)
-set(NAIM_CUDA_NVCC_JOBS "2" CACHE STRING
+set(NAIM_CUDA_NVCC_JOBS "1" CACHE STRING
     "Maximum number of concurrent nvcc compile jobs for ggml-cuda when using Ninja")
 option(NAIM_CONTROLLER_BUILD_LLAMA_QUANTIZE
        "Build llama-quantize before naim-controller for local model conversion tooling"

--- a/runtime/infer/src/app/infer_status_support.cpp
+++ b/runtime/infer/src/app/infer_status_support.cpp
@@ -136,7 +136,7 @@ std::optional<std::string> ValidateTurboQuantSupport(const RuntimeConfig& config
   const std::string cache_type_k = active_model.value("active_cache_type_k", std::string{});
   const std::string cache_type_v = active_model.value("active_cache_type_v", std::string{});
   const std::string llama_server =
-      ResolveExecutablePath("COMET_LLAMA_SERVER_BIN", "/runtime/infer/bin/llama-server");
+      ResolveExecutablePath("NAIM_LLAMA_SERVER_BIN", "/runtime/bin/llama-server");
   const auto help_output =
       CaptureCommandOutput(ShellQuote(llama_server) + " --help 2>&1");
   if (!help_output.has_value()) {

--- a/scripts/configure-build.sh
+++ b/scripts/configure-build.sh
@@ -6,6 +6,19 @@ source "${script_dir}/build-context.sh"
 
 naim_resolve_build_context "${script_dir}" "$@"
 
+if [[ "${TARGET_OS}" == "linux" && "${REPO_DIR}" == /mnt/* ]] \
+  && grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null \
+  && [[ "${NAIM_ALLOW_WSL_MOUNT_BUILD:-}" != "1" ]]; then
+  cat >&2 <<EOF
+error: refusing to configure from a Windows-mounted WSL path: ${REPO_DIR}
+
+The llama.cpp/CUDA configure step can hang in uninterruptible p9_client_rpc I/O
+when the source tree is under /mnt/*. Clone or mirror the repository into the
+WSL Linux filesystem, or set NAIM_ALLOW_WSL_MOUNT_BUILD=1 to bypass this guard.
+EOF
+  exit 2
+fi
+
 cuda_root=""
 cuda_nvcc=""
 openmp_root=""
@@ -13,6 +26,7 @@ openmp_include_dir=""
 openmp_library=""
 : "${NAIM_CUDA_NATIVE:=OFF}"
 : "${NAIM_CUDA_ARCHITECTURES:=}"
+: "${NAIM_CUDA_NVCC_JOBS:=1}"
 
 detect_cuda_root() {
   local candidate=""
@@ -167,6 +181,10 @@ if [[ -f "${cache_path}" ]]; then
       && ! grep -Fq "NAIM_CUDA_ARCHITECTURES:UNINITIALIZED=${NAIM_CUDA_ARCHITECTURES}" "${cache_path}"; then
       needs_clean_reconfigure=1
     fi
+    if ! grep -Fq "NAIM_CUDA_NVCC_JOBS:STRING=${NAIM_CUDA_NVCC_JOBS}" "${cache_path}" \
+      && ! grep -Fq "NAIM_CUDA_NVCC_JOBS:UNINITIALIZED=${NAIM_CUDA_NVCC_JOBS}" "${cache_path}"; then
+      needs_clean_reconfigure=1
+    fi
   else
     if grep -Eq '^CUDAToolkit_ROOT:(UNINITIALIZED|PATH|STRING)=' "${cache_path}" \
       || grep -Eq '^CMAKE_CUDA_COMPILER:(FILEPATH|UNINITIALIZED|STRING)=' "${cache_path}" \
@@ -227,6 +245,7 @@ cmake_args+=("-DCUDAToolkit_ROOT=${cuda_root}")
 cmake_args+=("-DCMAKE_CUDA_COMPILER=${cuda_nvcc}")
 cmake_args+=("-DNAIM_CUDA_NATIVE=${NAIM_CUDA_NATIVE}")
 cmake_args+=("-DNAIM_CUDA_ARCHITECTURES=${NAIM_CUDA_ARCHITECTURES}")
+cmake_args+=("-DNAIM_CUDA_NVCC_JOBS=${NAIM_CUDA_NVCC_JOBS}")
 if [[ -n "${openmp_root}" ]]; then
   cmake_args+=(
     "-DOpenMP_ROOT=${openmp_root}"


### PR DESCRIPTION
## Summary
- align infer runtime doctor with the same llama-server path/env used by the launcher
- serialize ggml-cuda nvcc compilation by default through NAIM_CUDA_NVCC_JOBS=1
- pass NAIM_CUDA_NVCC_JOBS through the production release workflow
- fail fast for WSL builds from Windows-mounted /mnt/* source trees to avoid p9_client_rpc hangs

## Verification
- bash -n scripts/configure-build.sh scripts/build-target.sh scripts/ci/hpc1-build.sh
- git diff --check
- ./scripts/configure-build.sh linux x64 Debug returns rc=2 on WSL /mnt/e with the expected guard message