### PR TITLE
Add dual-runtime TurboQuant integration

### DIFF
--- a/common/src/runtime/infer_runtime_config.cpp
+++ b/common/src/runtime/infer_runtime_config.cpp
@@ -351,6 +351,10 @@ std::string RenderInferRuntimeConfigJsonForInstance(
        {
            {"primary_infer_node", infer.node_name},
            {"runtime_engine", state.inference.runtime_engine},
+           {"runtime_flavor",
+            infer.environment.count("NAIM_LLAMA_RUNTIME_FLAVOR") == 0
+                ? std::string("default")
+                : infer.environment.at("NAIM_LLAMA_RUNTIME_FLAVOR")},
            {"data_parallel_mode", state.inference.data_parallel_mode},
            {"data_parallel_lb_mode", state.inference.data_parallel_lb_mode},
            {"api_server_count", state.inference.api_server_count},

--- a/common/src/state/desired_state_v2_projector_tests.cpp
+++ b/common/src/state/desired_state_v2_projector_tests.cpp
@@ -295,7 +295,7 @@ int main() {
              }},
             {"features",
              {{"turboquant",
-               {{"enabled", true}, {"cache_type_k", "planar3"}, {"cache_type_v", "f16"}}}}},
+               {{"enabled", true}, {"cache_type_k", "turbo4"}, {"cache_type_v", "turbo4"}}}}},
             {"runtime",
              {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
             {"infer", {{"replicas", 1}}},

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -28,8 +28,8 @@ constexpr int kSkillsPublishedPortSpan = 10000;
 constexpr int kWebGatewayContainerPort = 18130;
 constexpr int kWebGatewayPublishedPortBase = 34000;
 constexpr int kWebGatewayPublishedPortSpan = 10000;
-constexpr std::string_view kTurboQuantDefaultCacheTypeK = "planar3";
-constexpr std::string_view kTurboQuantDefaultCacheTypeV = "f16";
+constexpr std::string_view kTurboQuantDefaultCacheTypeK = "turbo4";
+constexpr std::string_view kTurboQuantDefaultCacheTypeV = "turbo4";
 
 bool HasExplicitPrivateStorage(
     const nlohmann::json& service_json,
@@ -37,6 +37,10 @@ bool HasExplicitPrivateStorage(
   return (service_json.contains("storage") && service_json.at("storage").is_object()) ||
          (service_json.contains(legacy_volume_key) && service_json.at(legacy_volume_key).is_array() &&
           !service_json.at(legacy_volume_key).empty());
+}
+
+std::string LlamaRuntimeFlavor(const DesiredState& state) {
+  return state.turboquant.has_value() && state.turboquant->enabled ? "turboquant" : "default";
 }
 
 std::string PlacementExecutionNodeName(const nlohmann::json& placement) {
@@ -541,6 +545,7 @@ void DesiredStateV2Renderer::RenderInferInstance() {
          infer_index == 0 && infer_count > 1 ? "aggregator" : "infer"},
         {"NAIM_NODE_NAME", infer.node_name},
         {"NAIM_INFER_RUNTIME_BACKEND", DefaultInferRuntimeBackend()},
+        {"NAIM_LLAMA_RUNTIME_FLAVOR", LlamaRuntimeFlavor(state_)},
         {"NAIM_CONTROLLER_URL", "http://controller.internal:18080"},
         {"NAIM_CONTROL_ROOT", state_.control_root},
         {"NAIM_INFER_RUNTIME_CONFIG",
@@ -638,6 +643,7 @@ void DesiredStateV2Renderer::RenderWorkerInstances() {
         {"NAIM_INFER_INSTANCE_NAME", InferInstanceNameForWorker(worker_index)},
         {"NAIM_CONTROL_ROOT", state_.control_root},
         {"NAIM_DISTRIBUTED_BACKEND", state_.inference.distributed_backend},
+        {"NAIM_LLAMA_RUNTIME_FLAVOR", LlamaRuntimeFlavor(state_)},
         {"NAIM_SHARED_DISK_PATH", "/naim/shared"},
         {"NAIM_PRIVATE_DISK_PATH", "/naim/private"},
         {"NAIM_WORKER_RUNTIME_STATUS_PATH", "/naim/private/worker-runtime-status.json"},

--- a/common/src/state/desired_state_v2_validator.cpp
+++ b/common/src/state/desired_state_v2_validator.cpp
@@ -15,18 +15,14 @@ bool FieldEnabledByDefault(const nlohmann::json& service_json, bool default_valu
   return service_json.value("enabled", default_value);
 }
 
-constexpr std::string_view kTurboQuantDefaultCacheTypeK = "planar3";
-constexpr std::string_view kTurboQuantDefaultCacheTypeV = "f16";
+constexpr std::string_view kTurboQuantDefaultCacheTypeK = "turbo4";
+constexpr std::string_view kTurboQuantDefaultCacheTypeV = "turbo4";
 
 bool IsSupportedTurboQuantCacheType(const std::string& value) {
   static const std::set<std::string> kSupportedTypes = {
       "f16",
       "turbo3",
       "turbo4",
-      "planar3",
-      "planar4",
-      "iso3",
-      "iso4",
   };
   return kSupportedTypes.find(value) != kSupportedTypes.end();
 }

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -170,11 +170,22 @@ int main() {
       Expect(state.turboquant.has_value(), "turboquant-defaults: turboquant missing");
       Expect(state.turboquant->enabled, "turboquant-defaults: turboquant should be enabled");
       Expect(
-          state.turboquant->cache_type_k == std::optional<std::string>("planar3"),
-          "turboquant-defaults: cache_type_k should default to planar3");
+          state.turboquant->cache_type_k == std::optional<std::string>("turbo4"),
+          "turboquant-defaults: cache_type_k should default to turbo4");
       Expect(
-          state.turboquant->cache_type_v == std::optional<std::string>("f16"),
-          "turboquant-defaults: cache_type_v should default to f16");
+          state.turboquant->cache_type_v == std::optional<std::string>("turbo4"),
+          "turboquant-defaults: cache_type_v should default to turbo4");
+      Expect(FindInstance(state, "infer-turboquant-defaults")
+                     .environment.at("NAIM_LLAMA_RUNTIME_FLAVOR") == "turboquant",
+             "turboquant-defaults: infer should use turboquant runtime flavor");
+      Expect(FindInstance(state, "worker-turboquant-defaults")
+                     .environment.at("NAIM_LLAMA_RUNTIME_FLAVOR") == "turboquant",
+             "turboquant-defaults: worker should use turboquant runtime flavor");
+      const auto runtime_config = json::parse(
+          naim::RenderInferRuntimeConfigJsonForInstance(state, "infer-turboquant-defaults"));
+      Expect(runtime_config.at("inference").at("runtime_flavor").get<std::string>() ==
+                 "turboquant",
+             "turboquant-defaults: infer runtime config should use turboquant flavor");
       std::cout << "ok: turboquant-defaults" << '\n';
     }
 
@@ -555,12 +566,18 @@ int main() {
                      .environment.at("NAIM_WORKER_BOOT_MODE") == "llama-rpc",
              "llama-rpc-backend: worker boot mode mismatch");
       Expect(FindInstance(state, "worker-llama-rpc-backend-a")
+                     .environment.at("NAIM_LLAMA_RUNTIME_FLAVOR") == "default",
+             "llama-rpc-backend: worker runtime flavor mismatch");
+      Expect(FindInstance(state, "worker-llama-rpc-backend-a")
                      .environment.at("NAIM_WORKER_RPC_PORT") ==
                  std::to_string(expected_rpc_port),
              "llama-rpc-backend: worker rpc env mismatch");
       Expect(FindInstance(state, "infer-llama-rpc-backend")
                      .environment.at("NAIM_INFER_RUNTIME_BACKEND") == "llama-rpc-head",
              "llama-rpc-backend: infer backend mismatch");
+      Expect(FindInstance(state, "infer-llama-rpc-backend")
+                     .environment.at("NAIM_LLAMA_RUNTIME_FLAVOR") == "default",
+             "llama-rpc-backend: infer runtime flavor mismatch");
       Expect(FindInstance(state, "infer-llama-rpc-backend")
                      .environment.at("NAIM_INSTANCE_SUBROLE") == "aggregator",
              "llama-rpc-backend: primary infer should be aggregator");

--- a/config/v2-llm-backend-only/desired-state.v2.json
+++ b/config/v2-llm-backend-only/desired-state.v2.json
@@ -25,8 +25,8 @@
   "features": {
     "turboquant": {
       "enabled": true,
-      "cache_type_k": "planar3",
-      "cache_type_v": "f16"
+      "cache_type_k": "turbo4",
+      "cache_type_v": "turbo4"
     }
   },
   "infer": {

--- a/controller/src/interaction/interaction_runtime_support_service.cpp
+++ b/controller/src/interaction/interaction_runtime_support_service.cpp
@@ -146,9 +146,9 @@ InteractionRuntimeSupportService::BuildPlaneScopedRuntimeStatus(
   if (desired_state.turboquant.has_value() && desired_state.turboquant->enabled) {
     runtime.turboquant_enabled = true;
     runtime.active_cache_type_k =
-        desired_state.turboquant->cache_type_k.value_or("planar3");
+        desired_state.turboquant->cache_type_k.value_or("turbo4");
     runtime.active_cache_type_v =
-        desired_state.turboquant->cache_type_v.value_or("f16");
+        desired_state.turboquant->cache_type_v.value_or("turbo4");
   }
   if (desired_state.bootstrap_model.has_value()) {
     runtime.active_model_id = desired_state.bootstrap_model->model_id;

--- a/controller/src/plane/dashboard_service_tests.cpp
+++ b/controller/src/plane/dashboard_service_tests.cpp
@@ -640,8 +640,8 @@ void TestRuntimePayloadIncludesKvCacheBytes() {
   runtime_status.launch_ready = true;
   runtime_status.kv_cache_bytes = 3ULL * 1024ULL * 1024ULL * 1024ULL;
   runtime_status.turboquant_enabled = true;
-  runtime_status.active_cache_type_k = "planar3";
-  runtime_status.active_cache_type_v = "f16";
+  runtime_status.active_cache_type_k = "turbo4";
+  runtime_status.active_cache_type_v = "turbo4";
   observation.runtime_status_json = naim::SerializeRuntimeStatusJson(runtime_status);
 
   std::map<std::string, naim::NodeInventory> dashboard_nodes;
@@ -701,9 +701,9 @@ void TestRuntimePayloadIncludesKvCacheBytes() {
       "runtime payload should expose aggregated kv_cache_bytes");
   Expect(runtime_payload.at("turboquant_enabled").get<bool>(),
          "runtime payload should expose turboquant_enabled");
-  Expect(runtime_payload.at("active_cache_type_k").get<std::string>() == "planar3",
+  Expect(runtime_payload.at("active_cache_type_k").get<std::string>() == "turbo4",
          "runtime payload should expose active_cache_type_k");
-  Expect(runtime_payload.at("active_cache_type_v").get<std::string>() == "f16",
+  Expect(runtime_payload.at("active_cache_type_v").get<std::string>() == "turbo4",
          "runtime payload should expose active_cache_type_v");
 
   std::cout << "ok: runtime-payload-includes-kv-cache-bytes" << '\n';

--- a/hostd/include/app/hostd_compose_runtime_support.h
+++ b/hostd/include/app/hostd_compose_runtime_support.h
@@ -36,6 +36,9 @@ class HostdComposeRuntimeSupport final {
   bool LocalRuntimeBinaryExists(
       const std::filesystem::path& repo_root,
       const std::string& image) const;
+  bool TurboQuantRuntimeBinaryExists(
+      const std::filesystem::path& repo_root,
+      const std::string& image) const;
   void EnsureLocalRuntimeBinary(
       const std::filesystem::path& repo_root,
       const std::string& image) const;

--- a/hostd/src/app/hostd_bootstrap_active_model_support.cpp
+++ b/hostd/src/app/hostd_bootstrap_active_model_support.cpp
@@ -14,8 +14,8 @@ using nlohmann::json;
 
 namespace {
 
-constexpr std::string_view kTurboQuantDefaultCacheTypeK = "planar3";
-constexpr std::string_view kTurboQuantDefaultCacheTypeV = "f16";
+constexpr std::string_view kTurboQuantDefaultCacheTypeK = "turbo4";
+constexpr std::string_view kTurboQuantDefaultCacheTypeV = "turbo4";
 
 }  // namespace
 

--- a/hostd/src/app/hostd_compose_runtime_support.cpp
+++ b/hostd/src/app/hostd_compose_runtime_support.cpp
@@ -108,16 +108,32 @@ bool HostdComposeRuntimeSupport::LocalRuntimeBinaryExists(
     const std::filesystem::path& repo_root,
     const std::string& image) const {
   if (image == "naim/infer-runtime:dev") {
-    return std::filesystem::exists(repo_root / "build" / "linux" / "x64" / "naim-inferctl");
+    return std::filesystem::exists(repo_root / "build" / "linux" / "x64" / "naim-inferctl") &&
+           TurboQuantRuntimeBinaryExists(repo_root, image);
   }
   if (image == "naim/worker-runtime:dev") {
-    return std::filesystem::exists(repo_root / "build" / "linux" / "x64" / "naim-workerd");
+    return std::filesystem::exists(repo_root / "build" / "linux" / "x64" / "naim-workerd") &&
+           TurboQuantRuntimeBinaryExists(repo_root, image);
   }
   if (image == "naim/skills-runtime:dev") {
     return std::filesystem::exists(repo_root / "build" / "linux" / "x64" / "naim-skillsd");
   }
   if (image == "naim/webgateway-runtime:dev") {
     return std::filesystem::exists(repo_root / "build" / "linux" / "x64" / "naim-webgatewayd");
+  }
+  return true;
+}
+
+bool HostdComposeRuntimeSupport::TurboQuantRuntimeBinaryExists(
+    const std::filesystem::path& repo_root,
+    const std::string& image) const {
+  if (image == "naim/infer-runtime:dev") {
+    return std::filesystem::exists(
+        repo_root / "build-turboquant" / "linux" / "x64" / "bin" / "llama-server");
+  }
+  if (image == "naim/worker-runtime:dev") {
+    return std::filesystem::exists(
+        repo_root / "build-turboquant" / "linux" / "x64" / "bin" / "rpc-server");
   }
   return true;
 }
@@ -141,6 +157,22 @@ void HostdComposeRuntimeSupport::EnsureLocalRuntimeBinary(
   if (!command_support_.RunCommandOk(command)) {
     throw std::runtime_error(
         "failed to auto-build local naim binaries required for " + image);
+  }
+
+  if (!TurboQuantRuntimeBinaryExists(repo_root, image)) {
+    const std::filesystem::path turboquant_script =
+        repo_root / "scripts" / "build-turboquant-runtime.sh";
+    if (!std::filesystem::exists(turboquant_script)) {
+      throw std::runtime_error(
+          "runtime image requires turboquant binary, but build-turboquant-runtime.sh is unavailable");
+    }
+    const std::string turboquant_command =
+        "cd " + command_support_.ShellQuote(repo_root.string()) +
+        " && " + command_support_.ShellQuote(turboquant_script.string()) + " linux x64 Debug";
+    if (!command_support_.RunCommandOk(turboquant_command)) {
+      throw std::runtime_error(
+          "failed to auto-build local turboquant binaries required for " + image);
+    }
   }
 
   if (!LocalRuntimeBinaryExists(repo_root, image)) {

--- a/runtime/infer/Dockerfile
+++ b/runtime/infer/Dockerfile
@@ -6,13 +6,15 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       libgomp1 \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /runtime/bin/turboquant
 
 COPY runtime/infer /runtime/infer
 COPY build/linux/x64/naim-inferctl /runtime/bin/naim-inferctl
 COPY build/linux/x64/bin/llama-server /runtime/bin/llama-server
+COPY build-turboquant/linux/x64/bin/llama-server /runtime/bin/turboquant/llama-server
 
-RUN chmod +x /runtime/infer/entrypoint.sh /runtime/infer/inferctl.sh /runtime/bin/naim-inferctl /runtime/bin/llama-server \
+RUN chmod +x /runtime/infer/entrypoint.sh /runtime/infer/inferctl.sh /runtime/bin/naim-inferctl /runtime/bin/llama-server /runtime/bin/turboquant/llama-server \
     && ldconfig
 
 WORKDIR /runtime

--- a/runtime/infer/include/runtime/infer_runtime_types.h
+++ b/runtime/infer/include/runtime/infer_runtime_types.h
@@ -15,6 +15,7 @@ struct RuntimeConfig {
   std::string controller_url;
   std::string primary_infer_node;
   std::string runtime_engine = "llama.cpp";
+  std::string runtime_flavor = "default";
   std::string distributed_backend = "local";
   std::string data_parallel_mode = "off";
   std::string data_parallel_lb_mode = "external";

--- a/runtime/infer/src/app/infer_status_support.cpp
+++ b/runtime/infer/src/app/infer_status_support.cpp
@@ -72,12 +72,15 @@ std::vector<std::string> SplitCsv(const std::string& value) {
   return parts;
 }
 
-std::string ResolveExecutablePath(const char* env_name, const char* fallback) {
-  const char* value = std::getenv(env_name);
-  if (value != nullptr && *value != '\0') {
-    return value;
+std::string ResolveLlamaServerPath(const RuntimeConfig& config) {
+  const char* override_path = std::getenv("NAIM_LLAMA_SERVER_BIN");
+  if (override_path != nullptr && *override_path != '\0') {
+    return override_path;
   }
-  return fallback;
+  if (config.runtime_flavor == "turboquant") {
+    return "/runtime/bin/turboquant/llama-server";
+  }
+  return "/runtime/bin/llama-server";
 }
 
 bool CommandExists(const std::string& command) {
@@ -135,8 +138,7 @@ std::optional<std::string> ValidateTurboQuantSupport(const RuntimeConfig& config
   }
   const std::string cache_type_k = active_model.value("active_cache_type_k", std::string{});
   const std::string cache_type_v = active_model.value("active_cache_type_v", std::string{});
-  const std::string llama_server =
-      ResolveExecutablePath("NAIM_LLAMA_SERVER_BIN", "/runtime/bin/llama-server");
+  const std::string llama_server = ResolveLlamaServerPath(config);
   const auto help_output =
       CaptureCommandOutput(ShellQuote(llama_server) + " --help 2>&1");
   if (!help_output.has_value()) {

--- a/runtime/infer/src/infer_app.cpp
+++ b/runtime/infer/src/infer_app.cpp
@@ -281,6 +281,8 @@ RuntimeConfig LoadRuntimeConfig(const std::string& path_str) {
       Require<std::string>(inference, "primary_infer_node", "inference");
   config.runtime_engine =
       inference.value("runtime_engine", config.runtime_engine);
+  config.runtime_flavor =
+      inference.value("runtime_flavor", config.runtime_flavor);
   config.distributed_backend =
       inference.value("distributed_backend", config.distributed_backend);
   config.data_parallel_mode =

--- a/runtime/infer/src/runtime/llama_rpc_runtime.cpp
+++ b/runtime/infer/src/runtime/llama_rpc_runtime.cpp
@@ -104,12 +104,15 @@ std::vector<std::string> SplitCommaSeparated(std::string_view text) {
   return result;
 }
 
-std::string ResolveExecutablePath(const char* env_name, const char* fallback) {
-  const char* value = std::getenv(env_name);
-  if (value != nullptr && *value != '\0') {
-    return value;
+std::string ResolveLlamaServerPath(const RuntimeConfig& config) {
+  const char* override_path = std::getenv("NAIM_LLAMA_SERVER_BIN");
+  if (override_path != nullptr && *override_path != '\0') {
+    return override_path;
   }
-  return fallback;
+  if (config.runtime_flavor == "turboquant") {
+    return "/runtime/bin/turboquant/llama-server";
+  }
+  return "/runtime/bin/llama-server";
 }
 
 std::string Trim(std::string value) {
@@ -279,7 +282,7 @@ int LlamaRpcRuntime::Run() {
       model_identity.cached_runtime_model_path = model_path;
     }
     std::vector<std::string> args = {
-        ResolveExecutablePath("NAIM_LLAMA_SERVER_BIN", "/runtime/bin/llama-server"),
+        ResolveLlamaServerPath(config_),
         "--host",
         "127.0.0.1",
         "--port",

--- a/runtime/worker/Dockerfile
+++ b/runtime/worker/Dockerfile
@@ -6,13 +6,15 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       libgomp1 \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /runtime/bin/turboquant
 
 COPY runtime/worker /runtime/worker
 COPY build/linux/x64/naim-workerd /runtime/bin/naim-workerd
 COPY build/linux/x64/bin/rpc-server /runtime/bin/rpc-server
+COPY build-turboquant/linux/x64/bin/rpc-server /runtime/bin/turboquant/rpc-server
 
-RUN chmod +x /runtime/worker/entrypoint.sh /runtime/bin/naim-workerd /runtime/bin/rpc-server \
+RUN chmod +x /runtime/worker/entrypoint.sh /runtime/bin/naim-workerd /runtime/bin/rpc-server /runtime/bin/turboquant/rpc-server \
     && ldconfig
 
 WORKDIR /runtime

--- a/runtime/worker/include/worker_config.h
+++ b/runtime/worker/include/worker_config.h
@@ -16,6 +16,7 @@ struct WorkerConfig {
   std::string model_path;
   std::string gpu_device;
   std::string boot_mode = "llama-idle";
+  std::string llama_runtime_flavor = "default";
   std::string distributed_backend = "local";
   std::string rpc_host = "0.0.0.0";
   std::string rpc_endpoint;

--- a/runtime/worker/src/worker_config_loader.cpp
+++ b/runtime/worker/src/worker_config_loader.cpp
@@ -88,6 +88,7 @@ WorkerConfig WorkerConfigLoader::Load() const {
     config.gpu_device = ResolveGpuDeviceFromNvidiaSmi();
   }
   config.boot_mode = GetEnvOr("NAIM_WORKER_BOOT_MODE", "llama-idle");
+  config.llama_runtime_flavor = GetEnvOr("NAIM_LLAMA_RUNTIME_FLAVOR", "default");
   config.distributed_backend = GetEnvOr("NAIM_DISTRIBUTED_BACKEND", "local");
   config.rpc_host = GetEnvOr("NAIM_WORKER_RPC_HOST", "0.0.0.0");
   config.rpc_port = GetEnvIntOr("NAIM_WORKER_RPC_PORT", 50052);

--- a/runtime/worker/src/worker_engine_host.cpp
+++ b/runtime/worker/src/worker_engine_host.cpp
@@ -22,12 +22,15 @@ namespace fs = std::filesystem;
 
 namespace {
 
-std::string ResolveExecutablePath(const char* env_name, const char* fallback) {
-  const char* value = std::getenv(env_name);
-  if (value != nullptr && *value != '\0') {
-    return value;
+std::string ResolveRpcServerPath(const naim::worker::WorkerConfig& config) {
+  const char* override_path = std::getenv("NAIM_RPC_SERVER_BIN");
+  if (override_path != nullptr && *override_path != '\0') {
+    return override_path;
   }
-  return fallback;
+  if (config.llama_runtime_flavor == "turboquant") {
+    return "/runtime/bin/turboquant/rpc-server";
+  }
+  return "/runtime/bin/rpc-server";
 }
 
 std::string ResolveRpcDevice(const naim::worker::WorkerConfig& config) {
@@ -117,7 +120,7 @@ int WorkerEngineHost::RunRpcWorker() {
 
   if (child == 0) {
     std::vector<std::string> args = {
-        ResolveExecutablePath("NAIM_RPC_SERVER_BIN", "/runtime/bin/rpc-server"),
+        ResolveRpcServerPath(config_),
         "--host",
         config_.rpc_host,
         "--port",

--- a/scripts/build-runtime-images.sh
+++ b/scripts/build-runtime-images.sh
@@ -46,6 +46,7 @@ hostd_tag="${8:-naim/hostd:dev}"
 knowledge_tag="${9:-naim/knowledge-runtime:dev}"
 
 build_dir="$("${script_dir}/print-build-dir.sh")"
+turboquant_build_dir="${NAIM_TURBOQUANT_BUILD_DIR:-${repo_root}/build-turboquant/linux/x64}"
 mkdir -p "${repo_root}/var"
 image_context="$(mktemp -d "${repo_root}/var/runtime-image-context.XXXXXX")"
 cleanup_image_context() {
@@ -54,6 +55,7 @@ cleanup_image_context() {
 trap cleanup_image_context EXIT
 
 mkdir -p "${image_context}/build/linux/x64/bin"
+mkdir -p "${image_context}/build-turboquant/linux/x64/bin"
 cp -R "${repo_root}/runtime" "${image_context}/runtime"
 mkdir -p "${image_context}/ui/operator-react/scripts"
 cp "${repo_root}/ui/operator-react/package.json" \
@@ -66,6 +68,10 @@ for binary in naim-controller naim-hostd naim-node naim-inferctl naim-workerd na
 done
 cp "${build_dir}/bin/llama-server" "${image_context}/build/linux/x64/bin/llama-server"
 cp "${build_dir}/bin/rpc-server" "${image_context}/build/linux/x64/bin/rpc-server"
+cp "${turboquant_build_dir}/bin/llama-server" \
+  "${image_context}/build-turboquant/linux/x64/bin/llama-server"
+cp "${turboquant_build_dir}/bin/rpc-server" \
+  "${image_context}/build-turboquant/linux/x64/bin/rpc-server"
 
 build_web_ui_image() {
   local temp_root
@@ -167,6 +173,7 @@ fi
 
 echo "runtime images ready"
 echo "  base=${base_tag}"
+echo "  turboquant_build=${turboquant_build_dir}"
 echo "  controller=${controller_tag}"
 echo "  hostd=${hostd_tag}"
 echo "  infer=${infer_tag}"

--- a/scripts/build-turboquant-runtime.sh
+++ b/scripts/build-turboquant-runtime.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+source "${script_dir}/build-context.sh"
+
+naim_resolve_build_context "${script_dir}" "$@"
+
+thetom_repo="${NAIM_TURBOQUANT_LLAMA_REPO:-https://github.com/TheTom/llama-cpp-turboquant.git}"
+thetom_ref="${NAIM_TURBOQUANT_LLAMA_REF:-9e3fb40e8bc0f873ad4d3d8329b17dacff28e4ca}"
+source_dir="${NAIM_TURBOQUANT_LLAMA_SOURCE_DIR:-${repo_root}/var/turboquant/llama-cpp-turboquant}"
+build_root="${NAIM_TURBOQUANT_BUILD_ROOT:-${repo_root}/build-turboquant}"
+jobs="${NAIM_TURBOQUANT_BUILD_JOBS:-6}"
+
+if [[ ! -d "${source_dir}/.git" ]]; then
+  mkdir -p "$(dirname -- "${source_dir}")"
+  git clone "${thetom_repo}" "${source_dir}"
+fi
+
+git -C "${source_dir}" fetch --tags origin
+git -C "${source_dir}" checkout --detach "${thetom_ref}"
+
+export NAIM_BUILD_ROOT="${build_root}"
+export NAIM_CMAKE_ARGS="${NAIM_CMAKE_ARGS:-} -DNAIM_LLAMA_CPP_SOURCE_DIR=${source_dir}"
+turboquant_build_dir="${build_root}/${TARGET_OS}/${TARGET_ARCH}"
+
+"${script_dir}/configure-build.sh" "${TARGET_OS}" "${TARGET_ARCH}" "${BUILD_TYPE}" >/dev/null
+"$("${script_dir}/find-cmake.sh")" --build "${turboquant_build_dir}" --target llama-server rpc-server -j "${jobs}"
+
+echo "turboquant runtime ready: ${turboquant_build_dir}"

--- a/ui/operator-react/src/planeV2Form.jsx
+++ b/ui/operator-react/src/planeV2Form.jsx
@@ -13,9 +13,9 @@ import {
 import { KnowledgeBaseSelectorModal } from "./KnowledgeBaseSelectorModal.jsx";
 
 const DEFAULT_SUPPORTED_RESPONSE_LANGUAGES = ["en", "de", "uk", "ru"];
-const TURBOQUANT_DEFAULT_CACHE_TYPE_K = "planar3";
-const TURBOQUANT_DEFAULT_CACHE_TYPE_V = "f16";
-const TURBOQUANT_CACHE_TYPES = ["f16", "turbo3", "turbo4", "planar3", "planar4", "iso3", "iso4"];
+const TURBOQUANT_DEFAULT_CACHE_TYPE_K = "turbo4";
+const TURBOQUANT_DEFAULT_CACHE_TYPE_V = "turbo4";
+const TURBOQUANT_CACHE_TYPES = ["f16", "turbo3", "turbo4"];
 const LT_CYPHER_PLANE_NAME = "lt-cypher-ai";
 const LT_CYPHER_HARBOR_IMAGE_PREFIX = "chainzano.com/localtrade/lt-cypher-ai:";
 const LT_CYPHER_DEFAULT_IMAGE = `${LT_CYPHER_HARBOR_IMAGE_PREFIX}<git-sha>`;
@@ -33,6 +33,11 @@ const LT_CYPHER_SKILL_IDS = [
   "lt-jex-market-forecast",
   "lt-jex-market-source-mix",
 ];
+
+function normalizeTurboQuantCacheType(value, fallback) {
+  const normalized = String(value || "").trim();
+  return TURBOQUANT_CACHE_TYPES.includes(normalized) ? normalized : fallback;
+}
 const LT_CYPHER_SYSTEM_PROMPT = `Ты — Jex AI, AI-ассистент торговой платформы LocalTrade.
 
 Правила роли:
@@ -73,8 +78,8 @@ const FIELD_INFO = {
   knowledgeEnabled: "Attach selected canonical Knowledge Base records to this plane's chat context.",
   browserSessionEnabled: "Allow approval-gated browser session APIs for this plane. Search and sanitized fetch stay enabled when Isolated Browsing is on.",
   turboquantEnabled: "Enable KV-cache quantization for llama.cpp + llama_rpc planes. This requires a compatible turboquant-capable llama.cpp build.",
-  turboquantCacheTypeK: "KV cache type used for K cache pages. Defaults to planar3 when TurboQuant is enabled.",
-  turboquantCacheTypeV: "KV cache type used for V cache pages. Defaults to f16 when TurboQuant is enabled.",
+  turboquantCacheTypeK: "KV cache type used for K cache pages. Defaults to turbo4 when TurboQuant is enabled.",
+  turboquantCacheTypeV: "KV cache type used for V cache pages. Defaults to turbo4 when TurboQuant is enabled.",
   planeMode: "Choose llm for model serving planes or compute for custom GPU workloads without chat interaction.",
   protectedPlane: "Protected planes require an explicit confirmation before destructive actions such as delete.",
   factorySkillIds: "Select global Skills Factory records that should be copied into this plane when the rollout is applied.",
@@ -585,8 +590,14 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
       : [],
     browserSessionEnabled: Boolean(value?.browsing?.policy?.browser_session_enabled),
     turboquantEnabled: Boolean(turboquant?.enabled),
-    turboquantCacheTypeK: turboquant?.cache_type_k || TURBOQUANT_DEFAULT_CACHE_TYPE_K,
-    turboquantCacheTypeV: turboquant?.cache_type_v || TURBOQUANT_DEFAULT_CACHE_TYPE_V,
+    turboquantCacheTypeK: normalizeTurboQuantCacheType(
+      turboquant?.cache_type_k,
+      TURBOQUANT_DEFAULT_CACHE_TYPE_K,
+    ),
+    turboquantCacheTypeV: normalizeTurboQuantCacheType(
+      turboquant?.cache_type_v,
+      TURBOQUANT_DEFAULT_CACHE_TYPE_V,
+    ),
     planeMode: value?.plane_mode || defaults.planeMode,
     protectedPlane: Boolean(value?.protected),
     factorySkillIds: Array.isArray(value?.skills?.factory_skill_ids)
@@ -916,8 +927,14 @@ export function buildDesiredStateV2FromForm(form) {
       desiredState.features = {
         turboquant: {
           enabled: true,
-          cache_type_k: String(form.turboquantCacheTypeK || TURBOQUANT_DEFAULT_CACHE_TYPE_K),
-          cache_type_v: String(form.turboquantCacheTypeV || TURBOQUANT_DEFAULT_CACHE_TYPE_V),
+          cache_type_k: normalizeTurboQuantCacheType(
+            form.turboquantCacheTypeK,
+            TURBOQUANT_DEFAULT_CACHE_TYPE_K,
+          ),
+          cache_type_v: normalizeTurboQuantCacheType(
+            form.turboquantCacheTypeV,
+            TURBOQUANT_DEFAULT_CACHE_TYPE_V,
+          ),
         },
       };
     }

--- a/ui/operator-react/src/skillsFactory.test.js
+++ b/ui/operator-react/src/skillsFactory.test.js
@@ -201,22 +201,22 @@ describe("planeV2Form SkillsFactory mapping", () => {
     form.planeName = "turboquant-plane";
     form.modelPath = "/models/qwen";
     form.turboquantEnabled = true;
-    form.turboquantCacheTypeK = "planar3";
-    form.turboquantCacheTypeV = "f16";
+    form.turboquantCacheTypeK = "turbo4";
+    form.turboquantCacheTypeV = "turbo4";
 
     const desiredState = buildDesiredStateV2FromForm(form);
     expect(desiredState.features).toEqual({
       turboquant: {
         enabled: true,
-        cache_type_k: "planar3",
-        cache_type_v: "f16",
+        cache_type_k: "turbo4",
+        cache_type_v: "turbo4",
       },
     });
 
     const reparsed = buildPlaneFormStateFromDesiredStateV2(desiredState);
     expect(reparsed.turboquantEnabled).toBe(true);
-    expect(reparsed.turboquantCacheTypeK).toBe("planar3");
-    expect(reparsed.turboquantCacheTypeV).toBe("f16");
+    expect(reparsed.turboquantCacheTypeK).toBe("turbo4");
+    expect(reparsed.turboquantCacheTypeV).toBe("turbo4");
   });
 
   it("does not serialize turboquant for compute planes", () => {


### PR DESCRIPTION
## Summary
- add dual-runtime selection for default `llama.cpp` and TheTom TurboQuant builds
- route infer and worker runtime binaries through runtime flavor instead of a single hardcoded path
- package both default and TurboQuant binaries into infer/worker images and add a dedicated TurboQuant build script
- align desired-state, controller fallbacks, and WebUI defaults to `turbo4/turbo4`

## Validation
- full CUDA `cmake --build` completed successfully on hpc1
- targeted desired-state/controller/hostd tests passed on hpc1
- TheTom TurboQuant runtime built successfully on hpc1 in isolated `build-turboquant/linux/x64`
- sandbox runtime images built successfully with both binary sets included
- direct runtime checks passed with Qwen3.5-9B Q8_0 for default and TurboQuant binaries
- isolated controller/hostd lifecycle sandbox on hpc1 successfully ran two planes side by side:
  - default plane using standard runtime
  - TurboQuant plane using `turbo4/turbo4`
- both planes served chat completions successfully through `/api/v1/planes/<plane>/interaction/chat/completions`
- infer container logs confirmed KV cache reduction in lifecycle mode:
  - default plane: `256 MiB` KV buffer, `f16/f16`
  - TurboQuant plane: `68 MiB` KV buffer, `turbo4/turbo4`
