### PR TITLE
Fix broken checkout version in release workflow

### DIFF
--- a/.github/workflows/naim-production-release.yml
+++ b/.github/workflows/naim-production-release.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 180
     needs: hpc1-pull
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 30
     needs: hpc1-build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -88,7 +88,7 @@ jobs:
     timeout-minutes: 180
     needs: hpc1-knowledge-vault-release-gate
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -121,7 +121,7 @@ jobs:
     timeout-minutes: 10
     needs: hpc1-build-push-harbor
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -160,7 +160,7 @@ jobs:
     timeout-minutes: 60
     needs: main-register-release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -203,7 +203,7 @@ jobs:
     timeout-minutes: 10
     needs: main-redeploy-migrate
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}


### PR DESCRIPTION
## Summary
- replace invalid `actions/checkout@v6` references with `actions/checkout@v4`

## Why
The production release workflow currently references a non-existent checkout action version, which breaks CI before any deployment logic starts.

## Validation
- updated all checkout steps in `.github/workflows/naim-production-release.yml`
- verified no `actions/checkout@v6` references remain
- `git diff --check` passes
