### PR TITLE
Fix Node 24 and TurboQuant release build in CI

### DIFF
--- a/.github/workflows/naim-production-release.yml
+++ b/.github/workflows/naim-production-release.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NAIM_RELEASE_SHA: ${{ github.sha }}
   NAIM_RELEASE_TAG: ${{ github.sha }}
   NAIM_RELEASE_BRANCH: main
@@ -33,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -52,7 +53,7 @@ jobs:
     timeout-minutes: 180
     needs: hpc1-pull
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -70,7 +71,7 @@ jobs:
     timeout-minutes: 30
     needs: hpc1-build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -88,7 +89,7 @@ jobs:
     timeout-minutes: 180
     needs: hpc1-knowledge-vault-release-gate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -121,7 +122,7 @@ jobs:
     timeout-minutes: 10
     needs: hpc1-build-push-harbor
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -160,7 +161,7 @@ jobs:
     timeout-minutes: 60
     needs: main-register-release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
@@ -203,7 +204,7 @@ jobs:
     timeout-minutes: 10
     needs: main-redeploy-migrate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
         with:
           ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}

--- a/scripts/ci/hpc1-build.sh
+++ b/scripts/ci/hpc1-build.sh
@@ -12,20 +12,31 @@ fi
 
 git config --global --add safe.directory "$(pwd)" >/dev/null 2>&1 || true
 
-if [[ -d build ]]; then
-  owner="$(stat -c '%u' build 2>/dev/null || true)"
-  if [[ "${owner}" != "$(id -u)" ]] || [[ ! -w build ]]; then
+ensure_writable_dir() {
+  local path="$1"
+  local owner=""
+  if [[ ! -d "${path}" ]]; then
+    return 0
+  fi
+
+  owner="$(stat -c '%u' "${path}" 2>/dev/null || true)"
+  if [[ "${owner}" != "$(id -u)" ]] || [[ ! -w "${path}" ]]; then
     if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-      sudo chown -R "$(id -u):$(id -g)" build
+      sudo chown -R "$(id -u):$(id -g)" "${path}"
     else
-      echo "error: build directory is not writable by $(id -un): $(pwd)/build" >&2
+      echo "error: directory is not writable by $(id -un): $(pwd)/${path}" >&2
       exit 1
     fi
   fi
-  chmod -R u+rwX build
-fi
+  chmod -R u+rwX "${path}"
+}
+
+ensure_writable_dir build
+ensure_writable_dir build-turboquant
+ensure_writable_dir var/turboquant
 
 export NAIM_BUILD_TYPE
 "$(pwd)/scripts/build-target.sh" "${NAIM_BUILD_TYPE}"
+"$(pwd)/scripts/build-turboquant-runtime.sh" linux x64 "${NAIM_BUILD_TYPE}"
 
 echo "hpc1 build completed for ${current_sha}"


### PR DESCRIPTION
## Summary
- force JavaScript actions to run on Node 24 in the production release workflow
- switch checkout steps to `actions/checkout@v6`
- make `hpc1-build` produce the TurboQuant runtime binaries before the image packaging step

## Why
The last production release run on `main` failed in `3. hpc1 build containers and push Harbor` because the workflow tried to package:
- `build-turboquant/linux/x64/bin/llama-server`
- `build-turboquant/linux/x64/bin/rpc-server`

but `hpc1-build.sh` only produced the main build tree.

The workflow also kept emitting Node 20 deprecation warnings on every checkout step.

## Validation
- `bash -n scripts/ci/hpc1-build.sh`
- `git diff --check`
- confirmed current failed run `24825269059` on commit `7c1e146...` still uses the old behavior and dies with:
  - `cp: cannot stat '/mnt/shared-storage/naim/repos/naim-node/build-turboquant/linux/x64/bin/llama-server'`
