### PR TITLE
Fix hpc1 TurboQuant CI invocation

### DIFF
--- a/scripts/ci/hpc1-build.sh
+++ b/scripts/ci/hpc1-build.sh
@@ -37,6 +37,6 @@ ensure_writable_dir var/turboquant
 
 export NAIM_BUILD_TYPE
 "$(pwd)/scripts/build-target.sh" "${NAIM_BUILD_TYPE}"
-"$(pwd)/scripts/build-turboquant-runtime.sh" linux x64 "${NAIM_BUILD_TYPE}"
+bash "$(pwd)/scripts/build-turboquant-runtime.sh" linux x64 "${NAIM_BUILD_TYPE}"
 
 echo "hpc1 build completed for ${current_sha}"


### PR DESCRIPTION
## Summary
- invoke the TurboQuant build helper through bash on hpc1
- avoid depending on the executable bit in the shared-storage checkout

## Validation
- bash -n scripts/ci/hpc1-build.sh
- git diff --check
