### PR TITLE
Fix hpc1 TurboQuant build failures

### DIFF
--- a/scripts/ci/hpc1-build.sh
+++ b/scripts/ci/hpc1-build.sh
@@ -37,6 +37,6 @@ ensure_writable_dir var/turboquant
 
 export NAIM_BUILD_TYPE
 "$(pwd)/scripts/build-target.sh" "${NAIM_BUILD_TYPE}"
-"$(pwd)/scripts/build-turboquant-runtime.sh" linux x64 "${NAIM_BUILD_TYPE}"
+bash "$(pwd)/scripts/build-turboquant-runtime.sh" linux x64 "${NAIM_BUILD_TYPE}"
 
 echo "hpc1 build completed for ${current_sha}"

--- a/scripts/ci/hpc1-build.sh
+++ b/scripts/ci/hpc1-build.sh
@@ -35,6 +35,14 @@ ensure_writable_dir build
 ensure_writable_dir build-turboquant
 ensure_writable_dir var/turboquant
 
+vcpkg_root="$("$(pwd)/scripts/find-vcpkg.sh" --root)"
+for relative_path in buildtrees packages installed; do
+  candidate_path="${vcpkg_root}/${relative_path}"
+  if [[ -e "${candidate_path}" ]]; then
+    ensure_writable_dir "$(realpath -e "${candidate_path}")"
+  fi
+done
+
 export NAIM_BUILD_TYPE
 "$(pwd)/scripts/build-target.sh" "${NAIM_BUILD_TYPE}"
 bash "$(pwd)/scripts/build-turboquant-runtime.sh" linux x64 "${NAIM_BUILD_TYPE}"


### PR DESCRIPTION
## Summary
- invoke the TurboQuant helper through bash so hpc1 does not depend on the execute bit
- normalize ownership of mutable vcpkg cache directories before the TurboQuant build

## Validation
- bash -n scripts/ci/hpc1-build.sh
- git diff --check
- manual hpc1 TurboQuant build progressed past the previous vcpkg configure failure after cache ownership normalization
