### PR TITLE
Fix host registry CI linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,6 +558,7 @@ add_executable(
   naim-host-registry-tests
   controller/src/app/controller_time_support.cpp
   controller/src/host/host_registry_service.cpp
+  controller/src/knowledge/knowledge_vault_service_repository.cpp
   controller/src/host/host_registry_service_tests.cpp
 )
 target_include_directories(


### PR DESCRIPTION
## Summary
- link `knowledge_vault_service_repository.cpp` into `naim-host-registry-tests`
- fix the production release build break introduced by the managed release rollout changes

## Why
`HostRegistryService` now depends on `KnowledgeVaultServiceRepository`, but the `naim-host-registry-tests` target did not include the repository translation unit. CI failed at `2. hpc1 build` with undefined references while linking that test target.

## Validation
- `git diff --check`
- `bash -n scripts/ci/main-bootstrap-controller-update.sh`
- `-fsyntax-only` checks for the changed host registry / knowledge vault translation units using `build/linux/x64/compile_commands.json`