### PR TITLE
Prevent skipped downstream release jobs

### DIFF
--- a/.github/workflows/naim-production-release.yml
+++ b/.github/workflows/naim-production-release.yml
@@ -177,6 +177,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: hpc1-build-push-harbor
+    if: >-
+      always() &&
+      needs.hpc1-build-push-harbor.result == 'success'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
@@ -206,6 +209,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: main-register-release
+    if: >-
+      always() &&
+      needs.main-register-release.result == 'success'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
@@ -241,6 +247,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: main-bootstrap-controller-update
+    if: >-
+      always() &&
+      needs.main-bootstrap-controller-update.result == 'success'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -937,6 +937,16 @@ target_link_libraries(naim-hostd-command-support-tests PRIVATE naim-common)
 naim_enable_strict_warnings(naim-hostd-command-support-tests)
 
 add_executable(
+  naim-hostd-install-layout-support-tests
+  hostd/src/app/hostd_install_layout_support.cpp
+  hostd/src/app/hostd_install_layout_support_tests.cpp
+)
+target_include_directories(
+  naim-hostd-install-layout-support-tests PRIVATE common/include hostd/include)
+target_link_libraries(naim-hostd-install-layout-support-tests PRIVATE naim-common)
+naim_enable_strict_warnings(naim-hostd-install-layout-support-tests)
+
+add_executable(
   naim-hostd-post-deploy-support-tests
   hostd/src/app/hostd_command_support.cpp
   hostd/src/app/hostd_local_state_path_support.cpp
@@ -1107,6 +1117,7 @@ add_executable(
   hostd/src/app/hostd_desired_state_path_support.cpp
   hostd/src/app/hostd_disk_runtime_support.cpp
   hostd/src/app/hostd_file_support.cpp
+  hostd/src/app/hostd_install_layout_support.cpp
   hostd/src/app/hostd_local_runtime_state_support.cpp
   hostd/src/app/hostd_local_state_path_support.cpp
   hostd/src/app/hostd_local_state_repository.cpp

--- a/hostd/include/app/hostd_app_assignment_support.h
+++ b/hostd/include/app/hostd_app_assignment_support.h
@@ -19,6 +19,7 @@
 #include "app/hostd_desired_state_path_support.h"
 #include "app/hostd_disk_runtime_support.h"
 #include "app/hostd_file_support.h"
+#include "app/hostd_install_layout_support.h"
 #include "app/hostd_local_runtime_state_support.h"
 #include "app/hostd_local_state_path_support.h"
 #include "app/hostd_local_state_repository.h"
@@ -155,6 +156,7 @@ class HostdAppAssignmentSupport final : public IHostdAssignmentSupport {
   HostdLocalRuntimeStateSupport local_runtime_state_support_;
   HostdCommandSupport command_support_;
   HostdFileSupport file_support_;
+  HostdInstallLayoutSupport install_layout_support_;
   HostdComposeRuntimeSupport compose_runtime_support_;
   HostdDiskRuntimeSupport disk_runtime_support_;
   HostdDesiredStateApplyPlanSupport apply_plan_support_;

--- a/hostd/include/app/hostd_install_layout_support.h
+++ b/hostd/include/app/hostd_install_layout_support.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <filesystem>
+
+namespace naim::hostd {
+
+class HostdInstallLayoutSupport final {
+ public:
+  std::filesystem::path ResolveHostdRootFromPrivateKeyPath(
+      const std::filesystem::path& host_private_key_path) const;
+};
+
+}  // namespace naim::hostd

--- a/hostd/src/app/hostd_app_assignment_support.cpp
+++ b/hostd/src/app/hostd_app_assignment_support.cpp
@@ -656,8 +656,8 @@ void HostdAppAssignmentSupport::ExecuteHostSelfUpdate(
     throw std::runtime_error("hostd-self-update payload must contain release_tag and hostd_image");
   }
 
-  const std::filesystem::path key_path(*host_private_key_path);
-  const std::filesystem::path hostd_root = key_path.parent_path().parent_path();
+  const std::filesystem::path hostd_root =
+      install_layout_support_.ResolveHostdRootFromPrivateKeyPath(*host_private_key_path);
   if (hostd_root.empty()) {
     throw std::runtime_error("failed to derive hostd root from host private key path");
   }

--- a/hostd/src/app/hostd_install_layout_support.cpp
+++ b/hostd/src/app/hostd_install_layout_support.cpp
@@ -1,0 +1,14 @@
+#include "app/hostd_install_layout_support.h"
+
+namespace naim::hostd {
+
+std::filesystem::path HostdInstallLayoutSupport::ResolveHostdRootFromPrivateKeyPath(
+    const std::filesystem::path& host_private_key_path) const {
+  const std::filesystem::path key_dir = host_private_key_path.parent_path();
+  if (key_dir.filename() == "keys" && key_dir.parent_path().filename() == "install-state") {
+    return key_dir.parent_path().parent_path();
+  }
+  return key_dir.parent_path();
+}
+
+}  // namespace naim::hostd

--- a/hostd/src/app/hostd_install_layout_support_tests.cpp
+++ b/hostd/src/app/hostd_install_layout_support_tests.cpp
@@ -1,0 +1,40 @@
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "app/hostd_install_layout_support.h"
+
+namespace {
+
+void Expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+}  // namespace
+
+int main() {
+  try {
+    const naim::hostd::HostdInstallLayoutSupport support;
+    namespace fs = std::filesystem;
+
+    Expect(
+        support.ResolveHostdRootFromPrivateKeyPath(
+            "/opt/naim/hostd/install-state/keys/hostd.key.b64") ==
+            fs::path("/opt/naim/hostd"),
+        "split install-state/keys layout should resolve hostd root");
+    Expect(
+        support.ResolveHostdRootFromPrivateKeyPath("/opt/naim/hostd/keys/hostd.key.b64") ==
+            fs::path("/opt/naim/hostd"),
+        "legacy keys layout should resolve hostd root");
+
+    std::cout << "ok: resolve-hostd-root-from-install-state-keys-layout\n";
+    std::cout << "ok: resolve-hostd-root-from-legacy-keys-layout\n";
+    return 0;
+  } catch (const std::exception& ex) {
+    std::cerr << ex.what() << '\n';
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary
- prevent release jobs `4-6` from being skipped when an ancestor job such as `2b` is intentionally `skipped`
- keep the bootstrap rollout hard-fail behavior from the previous commit on the same branch

## Why
GitHub Actions propagated `skipped` from `2b. hpc1 TurboQuant build` through the dependency graph. Job `3` already used `if: always()`, but jobs `4-6` did not, so they were skipped even when job `3` had succeeded.

## Validation
- workflow YAML parse via `python3` + `yaml.safe_load`
- `git diff --check`