### PR TITLE
Fix hostd install layout linkage in production CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1359,6 +1359,7 @@ add_executable(
   hostd/src/app/hostd_desired_state_path_support.cpp
   hostd/src/app/hostd_disk_runtime_support.cpp
   hostd/src/app/hostd_file_support.cpp
+  hostd/src/app/hostd_install_layout_support.cpp
   hostd/src/app/hostd_local_runtime_state_support.cpp
   hostd/src/app/hostd_local_state_path_support.cpp
   hostd/src/app/hostd_local_state_repository.cpp


### PR DESCRIPTION
## Summary
- add the missing `hostd_install_layout_support.cpp` source to the `naim-hostd` target
- keep the `hostd-self-update` compose-path fix from the previous merge linkable in production builds
- unblock the hpc1 build stage for the production release workflow

## Validation
- `git diff --check`
- observed failure from run `24832749693` and fixed the missing object linkage for `naim-hostd`
