### PR TITLE
Add controller-side context compression feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -684,6 +684,18 @@ target_link_libraries(
 naim_enable_strict_warnings(naim-interaction-conversation-payload-builder-tests)
 
 add_executable(
+  naim-interaction-context-compression-service-tests
+  controller/src/interaction/interaction_context_compression_service.cpp
+  controller/src/interaction/interaction_conversation_payload_builder.cpp
+  controller/src/interaction/interaction_context_compression_service_tests.cpp
+)
+target_include_directories(
+  naim-interaction-context-compression-service-tests PRIVATE common/include controller/include)
+target_link_libraries(
+  naim-interaction-context-compression-service-tests PRIVATE naim-common)
+naim_enable_strict_warnings(naim-interaction-context-compression-service-tests)
+
+add_executable(
   naim-interaction-conversation-record-builder-tests
   controller/src/interaction/interaction_conversation_payload_builder.cpp
   controller/src/interaction/interaction_conversation_record_builder.cpp
@@ -759,6 +771,7 @@ add_executable(
   controller/src/http/controller_http_transport.cpp
   controller/src/infra/controller_network_manager.cpp
   controller/src/interaction/interaction_completion_policy_support.cpp
+  controller/src/interaction/interaction_context_compression_service.cpp
   controller/src/interaction/interaction_conversation_archive_service.cpp
   controller/src/interaction/interaction_conversation_payload_builder.cpp
   controller/src/interaction/interaction_conversation_record_builder.cpp
@@ -1248,6 +1261,7 @@ add_executable(
   controller/src/interaction/interaction_conversation_payload_builder.cpp
   controller/src/interaction/interaction_conversation_record_builder.cpp
   controller/src/interaction/interaction_completion_policy_support.cpp
+  controller/src/interaction/interaction_context_compression_service.cpp
   controller/src/interaction/interaction_contract_responder.cpp
   controller/src/interaction/interaction_conversation_service.cpp
   controller/src/interaction/interaction_http_service.cpp

--- a/common/include/naim/state/models.h
+++ b/common/include/naim/state/models.h
@@ -320,6 +320,13 @@ struct TurboQuantFeatureSpec {
   std::optional<std::string> cache_type_v;
 };
 
+struct ContextCompressionFeatureSpec {
+  bool enabled = false;
+  std::string mode = "auto";
+  std::string target = "dialog_and_knowledge";
+  std::string memory_priority = "balanced";
+};
+
 using WebGatewayPolicySettings = BrowsingPolicySettings;
 using WebGatewaySettings = BrowsingSettings;
 
@@ -344,6 +351,7 @@ struct DesiredState {
   std::optional<BrowsingSettings> browsing;
   std::optional<KnowledgeSettings> knowledge;
   std::optional<TurboQuantFeatureSpec> turboquant;
+  std::optional<ContextCompressionFeatureSpec> context_compression;
   std::optional<ExternalAppHostConfig> app_host;
   InferenceRuntimeSettings inference;
   WorkerGroupSpec worker_group;

--- a/common/src/state/desired_state_v2_projector.cpp
+++ b/common/src/state/desired_state_v2_projector.cpp
@@ -106,21 +106,31 @@ void DesiredStateV2Projector::ProjectPlacement() {
 }
 
 void DesiredStateV2Projector::ProjectFeatures() {
-  if (!state_.turboquant.has_value()) {
+  if (!state_.turboquant.has_value() && !state_.context_compression.has_value()) {
     return;
   }
-  nlohmann::json turboquant = {
-      {"enabled", state_.turboquant->enabled},
-  };
-  if (state_.turboquant->cache_type_k.has_value()) {
-    turboquant["cache_type_k"] = *state_.turboquant->cache_type_k;
+  nlohmann::json features = nlohmann::json::object();
+  if (state_.turboquant.has_value()) {
+    nlohmann::json turboquant = {
+        {"enabled", state_.turboquant->enabled},
+    };
+    if (state_.turboquant->cache_type_k.has_value()) {
+      turboquant["cache_type_k"] = *state_.turboquant->cache_type_k;
+    }
+    if (state_.turboquant->cache_type_v.has_value()) {
+      turboquant["cache_type_v"] = *state_.turboquant->cache_type_v;
+    }
+    features["turboquant"] = std::move(turboquant);
   }
-  if (state_.turboquant->cache_type_v.has_value()) {
-    turboquant["cache_type_v"] = *state_.turboquant->cache_type_v;
+  if (state_.context_compression.has_value()) {
+    features["context_compression"] = {
+        {"enabled", state_.context_compression->enabled},
+        {"mode", state_.context_compression->mode},
+        {"target", state_.context_compression->target},
+        {"memory_priority", state_.context_compression->memory_priority},
+    };
   }
-  value_["features"] = {
-      {"turboquant", std::move(turboquant)},
-  };
+  value_["features"] = std::move(features);
 }
 
 void DesiredStateV2Projector::ProjectKnowledge() {

--- a/common/src/state/desired_state_v2_projector_tests.cpp
+++ b/common/src/state/desired_state_v2_projector_tests.cpp
@@ -136,6 +136,20 @@ void ExpectRoundTrip(const json& source, const std::string& name) {
     Expect(rerendered.turboquant->cache_type_v == rendered.turboquant->cache_type_v,
            name + ": turboquant.cache_type_v mismatch");
   }
+  if (rendered.context_compression.has_value()) {
+    Expect(rerendered.context_compression.has_value(),
+           name + ": context_compression missing after rerender");
+    Expect(rerendered.context_compression->enabled == rendered.context_compression->enabled,
+           name + ": context_compression.enabled mismatch");
+    Expect(rerendered.context_compression->mode == rendered.context_compression->mode,
+           name + ": context_compression.mode mismatch");
+    Expect(rerendered.context_compression->target == rendered.context_compression->target,
+           name + ": context_compression.target mismatch");
+    Expect(
+        rerendered.context_compression->memory_priority ==
+            rendered.context_compression->memory_priority,
+        name + ": context_compression.memory_priority mismatch");
+  }
   if (source.contains("features") && source.at("features").contains("turboquant")) {
     Expect(projected.contains("features"), name + ": features block missing after projection");
     Expect(projected.at("features").contains("turboquant"),
@@ -153,6 +167,14 @@ void ExpectRoundTrip(const json& source, const std::string& name) {
       Expect(projected_turboquant.at("cache_type_v") == source_turboquant.at("cache_type_v"),
              name + ": turboquant.cache_type_v mismatch");
     }
+  }
+  if (source.contains("features") && source.at("features").contains("context_compression")) {
+    Expect(projected.contains("features"), name + ": features block missing after projection");
+    Expect(projected.at("features").contains("context_compression"),
+           name + ": context_compression block missing after projection");
+    Expect(projected.at("features").at("context_compression") ==
+               source.at("features").at("context_compression"),
+           name + ": context_compression projection mismatch");
   }
   if (source.contains("skills")) {
     Expect(projected.contains("skills"), name + ": skills block missing after projection");
@@ -302,6 +324,56 @@ int main() {
             {"app", {{"enabled", false}}},
         },
         "turboquant-enabled");
+
+    ExpectRoundTrip(
+        json{
+            {"version", 2},
+            {"plane_name", "context-compression-enabled"},
+            {"plane_mode", "llm"},
+            {"model",
+             {
+                 {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+                 {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+                 {"served_model_name", "qwen-context-compression"},
+             }},
+            {"features",
+             {{"context_compression",
+               {{"enabled", true},
+                {"mode", "auto"},
+                {"target", "dialog_and_knowledge"},
+                {"memory_priority", "balanced"}}}}},
+            {"runtime",
+             {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+            {"infer", {{"replicas", 1}}},
+            {"app", {{"enabled", false}}},
+        },
+        "context-compression-enabled");
+
+    ExpectRoundTrip(
+        json{
+            {"version", 2},
+            {"plane_name", "combined-features"},
+            {"plane_mode", "llm"},
+            {"model",
+             {
+                 {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+                 {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+                 {"served_model_name", "qwen-combined"},
+             }},
+            {"features",
+             {{"context_compression",
+               {{"enabled", true},
+                {"mode", "auto"},
+                {"target", "dialog_and_knowledge"},
+                {"memory_priority", "balanced"}}},
+              {"turboquant",
+               {{"enabled", true}, {"cache_type_k", "turbo4"}, {"cache_type_v", "turbo4"}}}}},
+            {"runtime",
+             {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+            {"infer", {{"replicas", 1}}},
+            {"app", {{"enabled", false}}},
+        },
+        "combined-features");
 
     ExpectRoundTrip(
         json{

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -234,23 +234,39 @@ void DesiredStateV2Renderer::RenderPlacement() {
 }
 
 void DesiredStateV2Renderer::RenderFeatures() {
-  if (!features_json_.contains("turboquant") ||
-      !features_json_.at("turboquant").is_object()) {
-    return;
+  if (features_json_.contains("turboquant") &&
+      features_json_.at("turboquant").is_object()) {
+    const auto& turboquant_json = features_json_.at("turboquant");
+    if (turboquant_json.value("enabled", false)) {
+      TurboQuantFeatureSpec turboquant;
+      turboquant.enabled = true;
+      turboquant.cache_type_k = turboquant_json.value(
+          "cache_type_k",
+          std::string(kTurboQuantDefaultCacheTypeK));
+      turboquant.cache_type_v = turboquant_json.value(
+          "cache_type_v",
+          std::string(kTurboQuantDefaultCacheTypeV));
+      state_.turboquant = std::move(turboquant);
+    }
   }
-  const auto& turboquant_json = features_json_.at("turboquant");
-  if (!turboquant_json.value("enabled", false)) {
-    return;
+  if (features_json_.contains("context_compression") &&
+      features_json_.at("context_compression").is_object()) {
+    const auto& context_compression_json = features_json_.at("context_compression");
+    if (context_compression_json.value("enabled", false)) {
+      ContextCompressionFeatureSpec context_compression;
+      context_compression.enabled = true;
+      context_compression.mode = context_compression_json.value(
+          "mode",
+          context_compression.mode);
+      context_compression.target = context_compression_json.value(
+          "target",
+          context_compression.target);
+      context_compression.memory_priority = context_compression_json.value(
+          "memory_priority",
+          context_compression.memory_priority);
+      state_.context_compression = std::move(context_compression);
+    }
   }
-  TurboQuantFeatureSpec turboquant;
-  turboquant.enabled = true;
-  turboquant.cache_type_k = turboquant_json.value(
-      "cache_type_k",
-      std::string(kTurboQuantDefaultCacheTypeK));
-  turboquant.cache_type_v = turboquant_json.value(
-      "cache_type_v",
-      std::string(kTurboQuantDefaultCacheTypeV));
-  state_.turboquant = std::move(turboquant);
 }
 
 void DesiredStateV2Renderer::RenderHooks() {

--- a/common/src/state/desired_state_v2_validator.cpp
+++ b/common/src/state/desired_state_v2_validator.cpp
@@ -223,51 +223,97 @@ void DesiredStateV2Validator::ValidateFeatures() const {
   }
   RequireObject("features");
   const auto& features = value_.at("features");
-  if (!features.contains("turboquant")) {
-    return;
-  }
-  if (!features.at("turboquant").is_object()) {
-    throw std::runtime_error("desired-state v2 features.turboquant must be an object");
-  }
-  const auto& turboquant = features.at("turboquant");
-  const bool enabled = turboquant.value("enabled", false);
-  if (turboquant.contains("cache_type_k") && !turboquant.at("cache_type_k").is_string() &&
-      !turboquant.at("cache_type_k").is_null()) {
-    throw std::runtime_error(
-        "desired-state v2 features.turboquant.cache_type_k must be a string");
-  }
-  if (turboquant.contains("cache_type_v") && !turboquant.at("cache_type_v").is_string() &&
-      !turboquant.at("cache_type_v").is_null()) {
-    throw std::runtime_error(
-        "desired-state v2 features.turboquant.cache_type_v must be a string");
-  }
-  if (!enabled) {
-    return;
-  }
   const std::string plane_mode = value_.value("plane_mode", std::string("llm"));
-  const auto& runtime = value_.at("runtime");
-  const std::string engine = runtime.value("engine", std::string{});
-  const std::string distributed_backend =
-      runtime.value("distributed_backend", engine == "llama.cpp" ? std::string("llama_rpc")
-                                                                  : std::string("local"));
-  if (plane_mode != "llm" || engine != "llama.cpp" || distributed_backend != "llama_rpc") {
-    throw std::runtime_error(
-        "desired-state v2 features.turboquant requires plane_mode=llm with "
-        "runtime.engine=llama.cpp and runtime.distributed_backend=llama_rpc");
+  if (features.contains("turboquant")) {
+    if (!features.at("turboquant").is_object()) {
+      throw std::runtime_error("desired-state v2 features.turboquant must be an object");
+    }
+    const auto& turboquant = features.at("turboquant");
+    const bool enabled = turboquant.value("enabled", false);
+    if (turboquant.contains("cache_type_k") && !turboquant.at("cache_type_k").is_string() &&
+        !turboquant.at("cache_type_k").is_null()) {
+      throw std::runtime_error(
+          "desired-state v2 features.turboquant.cache_type_k must be a string");
+    }
+    if (turboquant.contains("cache_type_v") && !turboquant.at("cache_type_v").is_string() &&
+        !turboquant.at("cache_type_v").is_null()) {
+      throw std::runtime_error(
+          "desired-state v2 features.turboquant.cache_type_v must be a string");
+    }
+    if (enabled) {
+      const auto& runtime = value_.at("runtime");
+      const std::string engine = runtime.value("engine", std::string{});
+      const std::string distributed_backend =
+          runtime.value("distributed_backend", engine == "llama.cpp" ? std::string("llama_rpc")
+                                                                      : std::string("local"));
+      if (plane_mode != "llm" || engine != "llama.cpp" || distributed_backend != "llama_rpc") {
+        throw std::runtime_error(
+            "desired-state v2 features.turboquant requires plane_mode=llm with "
+            "runtime.engine=llama.cpp and runtime.distributed_backend=llama_rpc");
+      }
+      const std::string cache_type_k = turboquant.value(
+          "cache_type_k",
+          std::string(kTurboQuantDefaultCacheTypeK));
+      const std::string cache_type_v = turboquant.value(
+          "cache_type_v",
+          std::string(kTurboQuantDefaultCacheTypeV));
+      if (!IsSupportedTurboQuantCacheType(cache_type_k)) {
+        throw std::runtime_error(
+            "desired-state v2 features.turboquant.cache_type_k has unsupported value");
+      }
+      if (!IsSupportedTurboQuantCacheType(cache_type_v)) {
+        throw std::runtime_error(
+            "desired-state v2 features.turboquant.cache_type_v has unsupported value");
+      }
+    }
   }
-  const std::string cache_type_k = turboquant.value(
-      "cache_type_k",
-      std::string(kTurboQuantDefaultCacheTypeK));
-  const std::string cache_type_v = turboquant.value(
-      "cache_type_v",
-      std::string(kTurboQuantDefaultCacheTypeV));
-  if (!IsSupportedTurboQuantCacheType(cache_type_k)) {
-    throw std::runtime_error(
-        "desired-state v2 features.turboquant.cache_type_k has unsupported value");
-  }
-  if (!IsSupportedTurboQuantCacheType(cache_type_v)) {
-    throw std::runtime_error(
-        "desired-state v2 features.turboquant.cache_type_v has unsupported value");
+  if (features.contains("context_compression")) {
+    if (!features.at("context_compression").is_object()) {
+      throw std::runtime_error(
+          "desired-state v2 features.context_compression must be an object");
+    }
+    const auto& context_compression = features.at("context_compression");
+    const bool enabled = context_compression.value("enabled", false);
+    if (context_compression.contains("mode") &&
+        !context_compression.at("mode").is_string() &&
+        !context_compression.at("mode").is_null()) {
+      throw std::runtime_error(
+          "desired-state v2 features.context_compression.mode must be a string");
+    }
+    if (context_compression.contains("target") &&
+        !context_compression.at("target").is_string() &&
+        !context_compression.at("target").is_null()) {
+      throw std::runtime_error(
+          "desired-state v2 features.context_compression.target must be a string");
+    }
+    if (context_compression.contains("memory_priority") &&
+        !context_compression.at("memory_priority").is_string() &&
+        !context_compression.at("memory_priority").is_null()) {
+      throw std::runtime_error(
+          "desired-state v2 features.context_compression.memory_priority must be a string");
+    }
+    if (enabled && plane_mode != "llm") {
+      throw std::runtime_error(
+          "desired-state v2 features.context_compression requires plane_mode=llm");
+    }
+    const std::string mode =
+        context_compression.value("mode", std::string("auto"));
+    const std::string target =
+        context_compression.value("target", std::string("dialog_and_knowledge"));
+    const std::string memory_priority =
+        context_compression.value("memory_priority", std::string("balanced"));
+    if (mode != "auto") {
+      throw std::runtime_error(
+          "desired-state v2 features.context_compression.mode supports auto only");
+    }
+    if (target != "dialog_and_knowledge") {
+      throw std::runtime_error(
+          "desired-state v2 features.context_compression.target supports dialog_and_knowledge only");
+    }
+    if (memory_priority != "balanced") {
+      throw std::runtime_error(
+          "desired-state v2 features.context_compression.memory_priority supports balanced only");
+    }
   }
 }
 

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -228,6 +228,85 @@ int main() {
     }
 
     {
+      const json context_compression_defaults{
+          {"version", 2},
+          {"plane_name", "context-compression-defaults"},
+          {"plane_mode", "llm"},
+          {"model",
+           {
+               {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+               {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+               {"served_model_name", "qwen-context-compression"},
+           }},
+          {"features", {{"context_compression", {{"enabled", true}}}}},
+          {"runtime",
+           {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+          {"infer", {{"replicas", 1}}},
+          {"app", {{"enabled", false}}},
+      };
+      const auto state = RenderValid(
+          context_compression_defaults,
+          "context-compression-defaults");
+      Expect(
+          state.context_compression.has_value(),
+          "context-compression-defaults: context_compression missing");
+      Expect(
+          state.context_compression->enabled,
+          "context-compression-defaults: feature should be enabled");
+      Expect(
+          state.context_compression->mode == "auto",
+          "context-compression-defaults: mode should default to auto");
+      Expect(
+          state.context_compression->target == "dialog_and_knowledge",
+          "context-compression-defaults: target should default to dialog_and_knowledge");
+      Expect(
+          state.context_compression->memory_priority == "balanced",
+          "context-compression-defaults: memory_priority should default to balanced");
+      std::cout << "ok: context-compression-defaults" << '\n';
+    }
+
+    {
+      ExpectInvalid(
+          json{
+              {"version", 2},
+              {"plane_name", "context-compression-invalid-mode"},
+              {"plane_mode", "llm"},
+              {"model",
+               {
+                   {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+                   {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+                   {"served_model_name", "qwen-invalid-mode"},
+               }},
+              {"features",
+               {{"context_compression",
+                 {{"enabled", true},
+                  {"mode", "manual"},
+                  {"target", "dialog_and_knowledge"},
+                  {"memory_priority", "balanced"}}}}},
+              {"runtime",
+               {{"engine", "llama.cpp"},
+                {"distributed_backend", "llama_rpc"},
+                {"workers", 1}}},
+              {"infer", {{"replicas", 1}}},
+              {"app", {{"enabled", false}}},
+          },
+          "context-compression-invalid-mode");
+    }
+
+    {
+      ExpectInvalid(
+          json{
+              {"version", 2},
+              {"plane_name", "context-compression-compute"},
+              {"plane_mode", "compute"},
+              {"features", {{"context_compression", {{"enabled", true}}}}},
+              {"runtime", {{"engine", "custom"}, {"workers", 1}}},
+              {"app", {{"enabled", false}}},
+          },
+          "context-compression-compute");
+    }
+
+    {
       const json state_file_v2{
           {"version", 2},
           {"plane_name", "thinking-flag"},

--- a/common/src/state/state_json.cpp
+++ b/common/src/state/state_json.cpp
@@ -141,6 +141,15 @@ json ToJson(const TurboQuantFeatureSpec& turboquant) {
   return result;
 }
 
+json ToJson(const ContextCompressionFeatureSpec& context_compression) {
+  return {
+      {"enabled", context_compression.enabled},
+      {"mode", context_compression.mode},
+      {"target", context_compression.target},
+      {"memory_priority", context_compression.memory_priority},
+  };
+}
+
 json DesiredStateToJson(const DesiredState& state) {
   json result = {
       {"plane_name", state.plane_name},
@@ -213,10 +222,15 @@ json DesiredStateToJson(const DesiredState& state) {
   if (state.knowledge.has_value()) {
     result["knowledge"] = SettingsCodecs::ToJson(*state.knowledge);
   }
-  if (state.turboquant.has_value()) {
-    result["features"] = {
-        {"turboquant", ToJson(*state.turboquant)},
-    };
+  if (state.turboquant.has_value() || state.context_compression.has_value()) {
+    json features = json::object();
+    if (state.turboquant.has_value()) {
+      features["turboquant"] = ToJson(*state.turboquant);
+    }
+    if (state.context_compression.has_value()) {
+      features["context_compression"] = ToJson(*state.context_compression);
+    }
+    result["features"] = std::move(features);
   }
   if (state.app_host.has_value()) {
     result["app_host"] = SettingsCodecs::ToJson(*state.app_host);
@@ -294,6 +308,24 @@ DesiredState DesiredStateFromJson(const json& value) {
         turboquant.cache_type_v = turboquant_json.at("cache_type_v").get<std::string>();
       }
       state.turboquant = std::move(turboquant);
+    }
+    if (features.contains("context_compression") &&
+        features.at("context_compression").is_object()) {
+      ContextCompressionFeatureSpec context_compression;
+      const auto& context_compression_json = features.at("context_compression");
+      context_compression.enabled = context_compression_json.value(
+          "enabled",
+          context_compression.enabled);
+      context_compression.mode = context_compression_json.value(
+          "mode",
+          context_compression.mode);
+      context_compression.target = context_compression_json.value(
+          "target",
+          context_compression.target);
+      context_compression.memory_priority = context_compression_json.value(
+          "memory_priority",
+          context_compression.memory_priority);
+      state.context_compression = std::move(context_compression);
     }
   }
   if (value.contains("app_host") && value.at("app_host").is_object()) {
@@ -508,6 +540,7 @@ DesiredState SliceDesiredStateForNode(
   result.skills = state.skills;
   result.browsing = state.browsing;
   result.turboquant = state.turboquant;
+  result.context_compression = state.context_compression;
   result.app_host = state.app_host;
   result.inference = state.inference;
   result.worker_group = state.worker_group;

--- a/controller/include/interaction/interaction_context_compression_service.h
+++ b/controller/include/interaction/interaction_context_compression_service.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "interaction/interaction_types.h"
+
+namespace naim::controller {
+
+class InteractionContextCompressionService final {
+ public:
+  void Apply(
+      const PlaneInteractionResolution& resolution,
+      InteractionRequestContext* request_context) const;
+};
+
+}  // namespace naim::controller

--- a/controller/src/http/controller_http_router.cpp
+++ b/controller/src/http/controller_http_router.cpp
@@ -4,6 +4,7 @@
 
 #include "infra/controller_action.h"
 #include "http/controller_http_server_support.h"
+#include "interaction/interaction_context_compression_service.h"
 #include "interaction/interaction_conversation_service.h"
 #include "interaction/interaction_request_contract_support.h"
 #include "interaction/interaction_request_identity_support.h"
@@ -582,6 +583,7 @@ HttpResponse ControllerHttpRouter::HandlePlaneInteractionRequest(
             validation_error->retryable,
             validation_error->details);
       }
+      InteractionContextCompressionService().Apply(resolution, &request_context);
       try {
         const auto result =
             interaction_service_.ExecuteSession(resolution, request_context);

--- a/controller/src/interaction/interaction_context_compression_service.cpp
+++ b/controller/src/interaction/interaction_context_compression_service.cpp
@@ -1,0 +1,328 @@
+#include "interaction/interaction_context_compression_service.h"
+
+#include <algorithm>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "interaction/interaction_conversation_payload_builder.h"
+
+namespace naim::controller {
+
+namespace {
+
+using nlohmann::json;
+
+constexpr const char* kKnowledgeSystemInstructionPayloadKey =
+    "__naim_knowledge_system_instruction";
+constexpr const char* kKnowledgeContextPayloadKey = "__naim_knowledge_context";
+constexpr int kDialogRecentTailCount = 6;
+constexpr int kSummaryExcerptBytes = 200;
+constexpr int kKnowledgeExcerptBytes = 800;
+
+std::string TrimCopy(const std::string& value) {
+  const auto begin = value.find_first_not_of(" \t\r\n");
+  if (begin == std::string::npos) {
+    return "";
+  }
+  const auto end = value.find_last_not_of(" \t\r\n");
+  return value.substr(begin, end - begin + 1);
+}
+
+std::string JsonString(const json& value) {
+  return value.dump(-1, ' ', false, json::error_handler_t::replace);
+}
+
+std::string ExcerptText(const json& message, std::size_t max_bytes) {
+  std::string text;
+  if (message.is_object()) {
+    if (message.contains("content") && message.at("content").is_string()) {
+      text = message.at("content").get<std::string>();
+    } else if (message.contains("content")) {
+      text = JsonString(message.at("content"));
+    }
+  } else if (message.is_string()) {
+    text = message.get<std::string>();
+  } else {
+    text = JsonString(message);
+  }
+  text = TrimCopy(text);
+  if (text.size() > max_bytes) {
+    text.resize(max_bytes);
+    text += "...[truncated]";
+  }
+  return text;
+}
+
+std::string ItemIdentityKey(const json& item) {
+  if (!item.is_object()) {
+    return JsonString(item);
+  }
+  const std::string knowledge_id = item.value("knowledge_id", std::string{});
+  const std::string block_id = item.value("block_id", std::string{});
+  const std::string version_id = item.value("version_id", std::string{});
+  const std::string content_hash = item.value("content_hash", std::string{});
+  if (!knowledge_id.empty() || !block_id.empty() || !version_id.empty() || !content_hash.empty()) {
+    return knowledge_id + "|" + block_id + "|" + version_id + "|" + content_hash;
+  }
+  return item.value("title", std::string{}) + "|" + item.value("text", std::string{});
+}
+
+double ItemRank(const json& item) {
+  if (!item.is_object()) {
+    return 0.0;
+  }
+  double rank = 0.0;
+  if (item.contains("score") && item.at("score").is_number()) {
+    rank += item.at("score").get<double>() * 1000.0;
+  }
+  if (item.contains("relevance") && item.at("relevance").is_number()) {
+    rank += item.at("relevance").get<double>() * 100.0;
+  }
+  if (item.contains("confidence") && item.at("confidence").is_number()) {
+    rank += item.at("confidence").get<double>() * 10.0;
+  }
+  if (item.contains("relation_distance") && item.at("relation_distance").is_number_integer()) {
+    rank -= static_cast<double>(item.at("relation_distance").get<int>());
+  }
+  return rank;
+}
+
+json BuildDialogSummaryMessage(
+    const std::vector<json>& messages,
+    std::size_t max_items) {
+  std::ostringstream summary;
+  summary << "Context Compression summary of older dialog turns. Preserve decisions, stable facts, "
+             "and unresolved threads from this compressed history.";
+  std::size_t emitted = 0;
+  for (const auto& message : messages) {
+    if (!message.is_object()) {
+      continue;
+    }
+    const std::string role = message.value("role", std::string{});
+    if (role.empty() || role == "system") {
+      continue;
+    }
+    const std::string excerpt = ExcerptText(message, kSummaryExcerptBytes);
+    if (excerpt.empty()) {
+      continue;
+    }
+    summary << "\n- " << role << ": " << excerpt;
+    ++emitted;
+    if (emitted >= max_items) {
+      break;
+    }
+  }
+  return json{{"role", "system"}, {"content", summary.str()}};
+}
+
+std::string BuildKnowledgeInstruction(const json& context_payload) {
+  const auto context = context_payload.value("context", json::array());
+  if (!context.is_array() || context.empty()) {
+    return {};
+  }
+  std::string instruction =
+      "Knowledge Base context: use the following canonical knowledge snippets when "
+      "they are relevant. Preserve provenance and do not invent facts outside this context.";
+  int index = 1;
+  for (const auto& item : context) {
+    if (!item.is_object()) {
+      continue;
+    }
+    instruction += "\n\n[" + std::to_string(index) + "] ";
+    instruction += item.value("title", item.value("knowledge_id", std::string("knowledge")));
+    instruction += "\nknowledge_id: " + item.value("knowledge_id", std::string{});
+    instruction += "\nblock_id: " + item.value("block_id", std::string{});
+    instruction += "\ntext: " + item.value("text", std::string{});
+    ++index;
+  }
+  return instruction;
+}
+
+json EnsureObject(const json& value) {
+  return value.is_object() ? value : json::object();
+}
+
+}  // namespace
+
+void InteractionContextCompressionService::Apply(
+    const PlaneInteractionResolution& resolution,
+    InteractionRequestContext* request_context) const {
+  if (request_context == nullptr ||
+      !resolution.desired_state.context_compression.has_value() ||
+      !resolution.desired_state.context_compression->enabled) {
+    return;
+  }
+
+  const auto& feature = *resolution.desired_state.context_compression;
+  InteractionConversationPayloadBuilder payload_builder;
+  json context_state = request_context->payload.contains(kInteractionSessionContextStatePayloadKey) &&
+                               request_context->payload.at(kInteractionSessionContextStatePayloadKey)
+                                   .is_object()
+                           ? request_context->payload.at(kInteractionSessionContextStatePayloadKey)
+                           : request_context->session_context_state;
+  context_state = EnsureObject(context_state);
+
+  json compression_state = {
+      {"enabled", true},
+      {"mode", feature.mode},
+      {"target", feature.target},
+      {"memory_priority", feature.memory_priority},
+      {"compressor_id", "context-compression-v1"},
+      {"policy_version", "v1"},
+      {"warnings", json::array()},
+      {"status", "none"},
+  };
+
+  json messages =
+      request_context->payload.contains("messages") && request_context->payload.at("messages").is_array()
+          ? request_context->payload.at("messages")
+          : json::array();
+  const int dialog_estimate_before = payload_builder.EstimateTokensForJson(messages);
+  bool dialog_compressed = false;
+  bool dialog_fallback_truncated = false;
+
+  if (messages.is_array()) {
+    std::vector<json> system_messages;
+    std::vector<json> non_system_messages;
+    for (const auto& message : messages) {
+      if (message.is_object() && message.value("role", std::string{}) == "system") {
+        system_messages.push_back(message);
+      } else {
+        non_system_messages.push_back(message);
+      }
+    }
+
+    const int dialog_soft_limit =
+        std::max(256, (resolution.desired_state.inference.max_model_len * 55) / 100);
+    if (dialog_estimate_before > dialog_soft_limit &&
+        non_system_messages.size() > static_cast<std::size_t>(kDialogRecentTailCount)) {
+      const std::size_t older_count =
+          non_system_messages.size() - static_cast<std::size_t>(kDialogRecentTailCount);
+      std::vector<json> older_messages(
+          non_system_messages.begin(),
+          non_system_messages.begin() + static_cast<std::ptrdiff_t>(older_count));
+      std::vector<json> recent_messages(
+          non_system_messages.end() - static_cast<std::ptrdiff_t>(kDialogRecentTailCount),
+          non_system_messages.end());
+
+      json compressed_messages = json::array();
+      for (const auto& message : system_messages) {
+        compressed_messages.push_back(message);
+      }
+      compressed_messages.push_back(BuildDialogSummaryMessage(older_messages, 10));
+      for (const auto& message : recent_messages) {
+        compressed_messages.push_back(message);
+      }
+
+      const int compressed_estimate = payload_builder.EstimateTokensForJson(compressed_messages);
+      if (compressed_estimate < dialog_estimate_before) {
+        messages = std::move(compressed_messages);
+        dialog_compressed = true;
+      } else {
+        json fallback_messages = json::array();
+        for (const auto& message : system_messages) {
+          fallback_messages.push_back(message);
+        }
+        for (auto it = non_system_messages.end() - static_cast<std::ptrdiff_t>(std::min<std::size_t>(
+                 non_system_messages.size(),
+                 4));
+             it != non_system_messages.end();
+             ++it) {
+          fallback_messages.push_back(*it);
+        }
+        messages = std::move(fallback_messages);
+        dialog_fallback_truncated = true;
+        compression_state["warnings"].push_back(
+            "dialog context exceeded soft budget and used fallback truncation");
+      }
+    }
+  }
+
+  request_context->payload["messages"] = messages;
+  const int dialog_estimate_after = payload_builder.EstimateTokensForJson(messages);
+
+  json knowledge_context = request_context->payload.contains(kKnowledgeContextPayloadKey) &&
+                                   request_context->payload.at(kKnowledgeContextPayloadKey).is_object()
+                               ? request_context->payload.at(kKnowledgeContextPayloadKey)
+                               : json::object();
+  std::size_t knowledge_entries_before = 0;
+  std::size_t knowledge_entries_after = 0;
+  std::size_t knowledge_bytes_before = JsonString(knowledge_context).size();
+  std::size_t knowledge_bytes_after = knowledge_bytes_before;
+  bool knowledge_compressed = false;
+
+  if (knowledge_context.contains("context") && knowledge_context.at("context").is_array()) {
+    std::vector<json> entries;
+    for (const auto& item : knowledge_context.at("context")) {
+      if (item.is_object()) {
+        entries.push_back(item);
+      }
+    }
+    knowledge_entries_before = entries.size();
+    std::stable_sort(
+        entries.begin(),
+        entries.end(),
+        [](const json& left, const json& right) { return ItemRank(left) > ItemRank(right); });
+    std::set<std::string> seen_keys;
+    json trimmed_entries = json::array();
+    const int knowledge_token_budget = std::max(
+        256,
+        std::min(
+            resolution.desired_state.knowledge.has_value()
+                ? resolution.desired_state.knowledge->context_policy.token_budget
+                : 12000,
+            std::max(512, resolution.desired_state.inference.max_model_len / 3)));
+    int consumed_tokens = 0;
+    for (const auto& item : entries) {
+      const std::string identity_key = ItemIdentityKey(item);
+      if (!seen_keys.insert(identity_key).second) {
+        continue;
+      }
+      json trimmed = item;
+      if (trimmed.contains("text") && trimmed.at("text").is_string()) {
+        trimmed["text"] = ExcerptText(trimmed.at("text"), kKnowledgeExcerptBytes);
+      }
+      const int item_tokens = payload_builder.EstimateTokensForJson(trimmed);
+      if (!trimmed_entries.empty() && consumed_tokens + item_tokens > knowledge_token_budget) {
+        compression_state["warnings"].push_back(
+            "knowledge context trimmed to fit compression budget");
+        break;
+      }
+      consumed_tokens += item_tokens;
+      trimmed_entries.push_back(std::move(trimmed));
+    }
+    knowledge_entries_after = trimmed_entries.size();
+    knowledge_context["context"] = std::move(trimmed_entries);
+    request_context->payload[kKnowledgeContextPayloadKey] = knowledge_context;
+    request_context->payload[kKnowledgeSystemInstructionPayloadKey] =
+        BuildKnowledgeInstruction(knowledge_context);
+    knowledge_bytes_after = JsonString(knowledge_context).size();
+    knowledge_compressed = knowledge_entries_after < knowledge_entries_before ||
+                           knowledge_bytes_after < knowledge_bytes_before;
+  }
+
+  if (dialog_fallback_truncated) {
+    compression_state["status"] = "fallback_truncated";
+  } else if (dialog_compressed || knowledge_compressed) {
+    compression_state["status"] = "compressed";
+  }
+  compression_state["dialog_estimate_before"] = dialog_estimate_before;
+  compression_state["dialog_estimate_after"] = dialog_estimate_after;
+  compression_state["knowledge_entries_before"] = static_cast<int>(knowledge_entries_before);
+  compression_state["knowledge_entries_after"] = static_cast<int>(knowledge_entries_after);
+  compression_state["knowledge_bytes_before"] = static_cast<int>(knowledge_bytes_before);
+  compression_state["knowledge_bytes_after"] = static_cast<int>(knowledge_bytes_after);
+  compression_state["compression_ratio"] =
+      dialog_estimate_before > 0
+          ? static_cast<double>(dialog_estimate_after) /
+                static_cast<double>(dialog_estimate_before)
+          : 1.0;
+
+  context_state["context_compression"] = std::move(compression_state);
+  request_context->session_context_state = context_state;
+  request_context->payload[kInteractionSessionContextStatePayloadKey] = context_state;
+}
+
+}  // namespace naim::controller

--- a/controller/src/interaction/interaction_context_compression_service_tests.cpp
+++ b/controller/src/interaction/interaction_context_compression_service_tests.cpp
@@ -1,0 +1,136 @@
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "interaction/interaction_context_compression_service.h"
+
+namespace {
+
+using nlohmann::json;
+
+void Expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+naim::controller::PlaneInteractionResolution BuildResolution(bool enabled) {
+  naim::controller::PlaneInteractionResolution resolution;
+  resolution.desired_state.plane_name = "compression-plane";
+  resolution.desired_state.plane_mode = naim::PlaneMode::Llm;
+  resolution.desired_state.inference.max_model_len = 1024;
+  if (enabled) {
+    naim::ContextCompressionFeatureSpec feature;
+    feature.enabled = true;
+    resolution.desired_state.context_compression = feature;
+    naim::KnowledgeSettings knowledge;
+    knowledge.enabled = true;
+    knowledge.context_policy.token_budget = 512;
+    resolution.desired_state.knowledge = knowledge;
+  }
+  return resolution;
+}
+
+void TestDisabledFeatureNoops() {
+  auto resolution = BuildResolution(false);
+  naim::controller::InteractionRequestContext request_context;
+  request_context.payload["messages"] = json::array({
+      json{{"role", "user"}, {"content", "hello"}},
+  });
+
+  naim::controller::InteractionContextCompressionService().Apply(
+      resolution,
+      &request_context);
+
+  Expect(
+      !request_context.payload.contains(naim::controller::kInteractionSessionContextStatePayloadKey),
+      "disabled feature should not inject context state");
+  Expect(
+      request_context.payload.at("messages").size() == 1,
+      "disabled feature should preserve messages");
+  std::cout << "ok: interaction-context-compression-disabled-noop" << '\n';
+}
+
+void TestCompressesDialogAndKnowledge() {
+  auto resolution = BuildResolution(true);
+  naim::controller::InteractionRequestContext request_context;
+  json messages = json::array();
+  messages.push_back(json{{"role", "system"}, {"content", "base instruction"}});
+  for (int index = 0; index < 12; ++index) {
+    messages.push_back(json{
+        {"role", (index % 2 == 0) ? "user" : "assistant"},
+        {"content", "message-" + std::to_string(index) + " " + std::string(180, 'x')},
+    });
+  }
+  request_context.payload["messages"] = messages;
+  request_context.payload["__naim_knowledge_context"] = {
+      {"context",
+       json::array({
+           json{{"knowledge_id", "k1"},
+                {"block_id", "b1"},
+                {"version_id", "v1"},
+                {"title", "Alpha"},
+                {"text", std::string(1200, 'a')},
+                {"score", 0.9}},
+           json{{"knowledge_id", "k1"},
+                {"block_id", "b1"},
+                {"version_id", "v1"},
+                {"title", "Alpha duplicate"},
+                {"text", std::string(1200, 'b')},
+                {"score", 0.8}},
+           json{{"knowledge_id", "k2"},
+                {"block_id", "b2"},
+                {"version_id", "v1"},
+                {"title", "Beta"},
+                {"text", std::string(1200, 'c')},
+                {"score", 0.7}},
+       })},
+  };
+
+  naim::controller::InteractionContextCompressionService().Apply(
+      resolution,
+      &request_context);
+
+  const auto context_state = request_context.payload.at(
+      naim::controller::kInteractionSessionContextStatePayloadKey);
+  Expect(context_state.is_object(), "context state payload should be an object");
+  const auto compression = context_state.at("context_compression");
+  Expect(compression.at("enabled").get<bool>(), "compression metadata should be enabled");
+  Expect(
+      compression.at("dialog_estimate_after").get<int>() <
+          compression.at("dialog_estimate_before").get<int>(),
+      "dialog estimate should shrink");
+  Expect(
+      compression.at("knowledge_entries_after").get<int>() <
+          compression.at("knowledge_entries_before").get<int>(),
+      "knowledge entries should dedupe or trim");
+  Expect(
+      request_context.payload.at("messages").is_array() &&
+          request_context.payload.at("messages").size() < messages.size(),
+      "compressed messages should be shorter than original");
+  const auto knowledge_context = request_context.payload.at("__naim_knowledge_context");
+  Expect(
+      knowledge_context.at("context").size() < 3 &&
+          !knowledge_context.at("context").empty(),
+      "knowledge compression should trim to a bounded deduped set");
+  Expect(
+      request_context.payload.at("__naim_knowledge_system_instruction")
+              .get<std::string>()
+              .find("Knowledge Base context") != std::string::npos,
+      "knowledge instruction should be rebuilt");
+  std::cout << "ok: interaction-context-compression-compresses-dialog-and-knowledge" << '\n';
+}
+
+}  // namespace
+
+int main() {
+  try {
+    TestDisabledFeatureNoops();
+    TestCompressesDialogAndKnowledge();
+    return 0;
+  } catch (const std::exception& error) {
+    std::cerr << "interaction_context_compression_service_tests failed: "
+              << error.what() << '\n';
+    return 1;
+  }
+}

--- a/controller/src/interaction/interaction_conversation_payload_builder.cpp
+++ b/controller/src/interaction/interaction_conversation_payload_builder.cpp
@@ -158,6 +158,22 @@ json InteractionConversationPayloadBuilder::BuildSessionSummaryPayload(
        context_state.value("browsing_mode", std::string{"disabled"})},
       {"applied_skill_ids",
        context_state.value("applied_skill_ids", json::array())},
+      {"context_compression_enabled",
+       context_state.value("context_compression", json::object()).value("enabled", false)},
+      {"compression_mode",
+       context_state.value("context_compression", json::object())
+           .value("mode", std::string{})},
+      {"compression_target",
+       context_state.value("context_compression", json::object())
+           .value("target", std::string{})},
+      {"compression_warning_count",
+       static_cast<int>(
+           context_state.value("context_compression", json::object())
+               .value("warnings", json::array())
+               .size())},
+      {"last_compression_ratio",
+       context_state.value("context_compression", json::object())
+           .value("compression_ratio", 1.0)},
   };
 }
 
@@ -291,6 +307,12 @@ json InteractionConversationPayloadBuilder::BuildSummaryJson(
     applied_skill_ids = context_state.at("applied_skill_ids");
   }
 
+  json compression = json::object();
+  if (context_state.contains("context_compression") &&
+      context_state.at("context_compression").is_object()) {
+    compression = context_state.at("context_compression");
+  }
+
   return json{
       {"session_goal", session_goal},
       {"stable_facts", stable_facts},
@@ -300,6 +322,11 @@ json InteractionConversationPayloadBuilder::BuildSummaryJson(
       {"open_threads", open_threads},
       {"browsing_mode", context_state.value("browsing_mode", std::string{"disabled"})},
       {"applied_skill_ids", applied_skill_ids},
+      {"compressor_id", compression.value("compressor_id", std::string{})},
+      {"policy_version", compression.value("policy_version", std::string{})},
+      {"dialog_estimate_before", compression.value("dialog_estimate_before", 0)},
+      {"dialog_estimate_after", compression.value("dialog_estimate_after", 0)},
+      {"compression_ratio", compression.value("compression_ratio", 1.0)},
       {"turn_range",
        json{{"start", turn_range_start}, {"end", turn_range_end}}},
   };

--- a/controller/src/interaction/interaction_conversation_payload_builder_tests.cpp
+++ b/controller/src/interaction/interaction_conversation_payload_builder_tests.cpp
@@ -90,7 +90,7 @@ void TestBuildsSessionPayloads() {
   session.owner_kind = "user";
   session.owner_user_id = 7;
   session.context_state_json =
-      R"({"browsing_mode":"enabled","applied_skill_ids":["skill-a"]})";
+      R"({"browsing_mode":"enabled","applied_skill_ids":["skill-a"],"context_compression":{"enabled":true,"mode":"auto","target":"dialog_and_knowledge","warnings":["trimmed"],"compression_ratio":0.5}})";
   session.created_at = "2026-04-09 10:00:00";
   session.updated_at = "2026-04-09 10:01:00";
   session.last_used_at = "2026-04-09 10:01:00";
@@ -100,6 +100,16 @@ void TestBuildsSessionPayloads() {
          "session summary should expose browsing mode");
   Expect(summary_payload.at("applied_skill_ids").size() == 1,
          "session summary should expose applied skill ids");
+  Expect(summary_payload.at("context_compression_enabled").get<bool>(),
+         "session summary should expose context compression flag");
+  Expect(summary_payload.at("compression_mode").get<std::string>() == "auto",
+         "session summary should expose compression mode");
+  Expect(summary_payload.at("compression_target").get<std::string>() == "dialog_and_knowledge",
+         "session summary should expose compression target");
+  Expect(summary_payload.at("compression_warning_count").get<int>() == 1,
+         "session summary should expose warning count");
+  Expect(summary_payload.at("last_compression_ratio").get<double>() == 0.5,
+         "session summary should expose compression ratio");
 
   const std::vector<naim::InteractionMessageRecord> messages{
       naim::InteractionMessageRecord{

--- a/controller/src/interaction/interaction_conversation_service.cpp
+++ b/controller/src/interaction/interaction_conversation_service.cpp
@@ -235,7 +235,14 @@ std::optional<InteractionValidationError> InteractionConversationService::Persis
   updated.estimated_context_tokens =
       payload_builder.EstimateTokensForJson(
           context->payload.value("messages", json::array()));
-  updated.compression_state = summary_records.empty() ? "none" : "compressed";
+  const json compression = context_state.value("context_compression", json::object());
+  if (compression.is_object()) {
+    updated.compression_state = compression.value(
+        "status",
+        summary_records.empty() ? std::string("none") : std::string("compressed"));
+  } else {
+    updated.compression_state = summary_records.empty() ? "none" : "compressed";
+  }
   updated.version = session.has_value() ? session->version + 1 : 1;
   updated.created_at = session.has_value() ? session->created_at : now;
   updated.updated_at = now;

--- a/controller/src/interaction/interaction_stream_http_request_preparation_service.cpp
+++ b/controller/src/interaction/interaction_stream_http_request_preparation_service.cpp
@@ -3,6 +3,7 @@
 #include "app/controller_composition_support.h"
 #include "auth/auth_support_service.h"
 #include "interaction/interaction_completion_policy_support.h"
+#include "interaction/interaction_context_compression_service.h"
 #include "interaction/interaction_conversation_service.h"
 #include "interaction/interaction_request_contract_support.h"
 #include "interaction/interaction_stream_http_error_response_builder.h"
@@ -108,6 +109,7 @@ InteractionStreamHttpRequestPreparationService::Prepare(
           std::nullopt,
       };
     }
+    InteractionContextCompressionService().Apply(setup.resolution, &setup.request_context);
   } catch (const nlohmann::json::exception& error) {
     return InteractionStreamHttpRequestPreparationResult{
         error_response_builder.Build(

--- a/ui/operator-react/src/planeV2Form.jsx
+++ b/ui/operator-react/src/planeV2Form.jsx
@@ -16,6 +16,9 @@ const DEFAULT_SUPPORTED_RESPONSE_LANGUAGES = ["en", "de", "uk", "ru"];
 const TURBOQUANT_DEFAULT_CACHE_TYPE_K = "turbo4";
 const TURBOQUANT_DEFAULT_CACHE_TYPE_V = "turbo4";
 const TURBOQUANT_CACHE_TYPES = ["f16", "turbo3", "turbo4"];
+const CONTEXT_COMPRESSION_DEFAULT_MODE = "auto";
+const CONTEXT_COMPRESSION_DEFAULT_TARGET = "dialog_and_knowledge";
+const CONTEXT_COMPRESSION_DEFAULT_MEMORY_PRIORITY = "balanced";
 const LT_CYPHER_PLANE_NAME = "lt-cypher-ai";
 const LT_CYPHER_HARBOR_IMAGE_PREFIX = "chainzano.com/localtrade/lt-cypher-ai:";
 const LT_CYPHER_DEFAULT_IMAGE = `${LT_CYPHER_HARBOR_IMAGE_PREFIX}<git-sha>`;
@@ -76,6 +79,10 @@ const FIELD_INFO = {
   skillsEnabled: "Enable a dedicated plane-scoped Skills service for storing and resolving reusable skills.",
   browsingEnabled: "Enable a dedicated plane-scoped Isolated Browsing service for brokered web search, fetch, and approval-gated browser sessions.",
   knowledgeEnabled: "Attach selected canonical Knowledge Base records to this plane's chat context.",
+  contextCompressionEnabled: "Enable controller-side prompt compaction for dialog history and Knowledge Base context before the request reaches infer.",
+  contextCompressionMode: "Context Compression mode. V1 supports auto only.",
+  contextCompressionTarget: "Prompt segments compressed by Context Compression. V1 supports dialog and knowledge together only.",
+  contextCompressionMemoryPriority: "Budget policy used by Context Compression. V1 supports balanced only.",
   browserSessionEnabled: "Allow approval-gated browser session APIs for this plane. Search and sanitized fetch stay enabled when Isolated Browsing is on.",
   turboquantEnabled: "Enable KV-cache quantization for llama.cpp + llama_rpc planes. This requires a compatible turboquant-capable llama.cpp build.",
   turboquantCacheTypeK: "KV cache type used for K cache pages. Defaults to turbo4 when TurboQuant is enabled.",
@@ -461,6 +468,10 @@ export function buildNewPlaneFormState() {
     turboquantEnabled: false,
     turboquantCacheTypeK: TURBOQUANT_DEFAULT_CACHE_TYPE_K,
     turboquantCacheTypeV: TURBOQUANT_DEFAULT_CACHE_TYPE_V,
+    contextCompressionEnabled: false,
+    contextCompressionMode: CONTEXT_COMPRESSION_DEFAULT_MODE,
+    contextCompressionTarget: CONTEXT_COMPRESSION_DEFAULT_TARGET,
+    contextCompressionMemoryPriority: CONTEXT_COMPRESSION_DEFAULT_MEMORY_PRIORITY,
     planeMode: "llm",
     protectedPlane: false,
     factorySkillIds: [],
@@ -572,6 +583,7 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
   const workerStorage = worker?.storage || {};
   const appHost = value?.placement?.app_host || {};
   const turboquant = value?.features?.turboquant || {};
+  const contextCompression = value?.features?.context_compression || {};
   const planeName = value?.plane_name || defaults.planeName;
   const servedModelName = value?.model?.served_model_name || deriveServedModelName(planeName);
   const serverName = network.server_name || deriveServerName(planeName);
@@ -598,6 +610,14 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
       turboquant?.cache_type_v,
       TURBOQUANT_DEFAULT_CACHE_TYPE_V,
     ),
+    contextCompressionEnabled: Boolean(contextCompression?.enabled),
+    contextCompressionMode:
+      contextCompression?.mode || CONTEXT_COMPRESSION_DEFAULT_MODE,
+    contextCompressionTarget:
+      contextCompression?.target || CONTEXT_COMPRESSION_DEFAULT_TARGET,
+    contextCompressionMemoryPriority:
+      contextCompression?.memory_priority ||
+      CONTEXT_COMPRESSION_DEFAULT_MEMORY_PRIORITY,
     planeMode: value?.plane_mode || defaults.planeMode,
     protectedPlane: Boolean(value?.protected),
     factorySkillIds: Array.isArray(value?.skills?.factory_skill_ids)
@@ -923,20 +943,30 @@ export function buildDesiredStateV2FromForm(form) {
         },
       };
     }
+    const features = {};
     if (form.turboquantEnabled) {
-      desiredState.features = {
-        turboquant: {
-          enabled: true,
-          cache_type_k: normalizeTurboQuantCacheType(
-            form.turboquantCacheTypeK,
-            TURBOQUANT_DEFAULT_CACHE_TYPE_K,
-          ),
-          cache_type_v: normalizeTurboQuantCacheType(
-            form.turboquantCacheTypeV,
-            TURBOQUANT_DEFAULT_CACHE_TYPE_V,
-          ),
-        },
+      features.turboquant = {
+        enabled: true,
+        cache_type_k: normalizeTurboQuantCacheType(
+          form.turboquantCacheTypeK,
+          TURBOQUANT_DEFAULT_CACHE_TYPE_K,
+        ),
+        cache_type_v: normalizeTurboQuantCacheType(
+          form.turboquantCacheTypeV,
+          TURBOQUANT_DEFAULT_CACHE_TYPE_V,
+        ),
       };
+    }
+    if (form.contextCompressionEnabled) {
+      features.context_compression = {
+        enabled: true,
+        mode: CONTEXT_COMPRESSION_DEFAULT_MODE,
+        target: CONTEXT_COMPRESSION_DEFAULT_TARGET,
+        memory_priority: CONTEXT_COMPRESSION_DEFAULT_MEMORY_PRIORITY,
+      };
+    }
+    if (Object.keys(features).length > 0) {
+      desiredState.features = features;
     }
   }
 
@@ -2178,6 +2208,14 @@ export function PlaneV2FormBuilder({
           onToggle={toggleFeature("knowledgeEnabled")}
         />
         <FeatureToggle
+          title="Context Compression"
+          info={FIELD_INFO.contextCompressionEnabled}
+          active={form.planeMode === "llm" && form.contextCompressionEnabled}
+          disabled={form.planeMode !== "llm"}
+          disabledLabel="LLM only"
+          onToggle={toggleFeature("contextCompressionEnabled")}
+        />
+        <FeatureToggle
           title="TurboQuant"
           info={FIELD_INFO.turboquantEnabled}
           active={form.planeMode === "llm" && form.turboquantEnabled}
@@ -2293,6 +2331,51 @@ export function PlaneV2FormBuilder({
                   </option>
                 ))}
               </select>
+            </label>
+          </div>
+        </div>
+      ) : null}
+
+      {form.planeMode === "llm" && form.contextCompressionEnabled ? (
+        <div className="plane-form-toggle">
+          <div className="plane-form-section-header">
+            <InfoLabel info={FIELD_INFO.contextCompressionEnabled}>
+              Context Compression
+            </InfoLabel>
+            <p className="plane-form-section-copy">
+              Controller-side prompt compaction for dialog history and Knowledge Base context
+              before the request reaches infer.
+            </p>
+          </div>
+          <div className="plane-form-grid">
+            <label className="field-label">
+              <InfoLabel info={FIELD_INFO.contextCompressionMode}>Mode</InfoLabel>
+              <input
+                className="text-input"
+                value={form.contextCompressionMode}
+                onChange={bindText("contextCompressionMode")}
+                readOnly
+              />
+            </label>
+            <label className="field-label">
+              <InfoLabel info={FIELD_INFO.contextCompressionTarget}>Target</InfoLabel>
+              <input
+                className="text-input"
+                value={form.contextCompressionTarget}
+                onChange={bindText("contextCompressionTarget")}
+                readOnly
+              />
+            </label>
+            <label className="field-label">
+              <InfoLabel info={FIELD_INFO.contextCompressionMemoryPriority}>
+                Memory priority
+              </InfoLabel>
+              <input
+                className="text-input"
+                value={form.contextCompressionMemoryPriority}
+                onChange={bindText("contextCompressionMemoryPriority")}
+                readOnly
+              />
             </label>
           </div>
         </div>

--- a/ui/operator-react/src/skillsFactory.test.js
+++ b/ui/operator-react/src/skillsFactory.test.js
@@ -219,10 +219,65 @@ describe("planeV2Form SkillsFactory mapping", () => {
     expect(reparsed.turboquantCacheTypeV).toBe("turbo4");
   });
 
+  it("round-trips context compression capability through desired state v2", () => {
+    const form = buildNewPlaneFormState();
+    form.planeName = "compression-plane";
+    form.modelPath = "/models/qwen";
+    form.contextCompressionEnabled = true;
+
+    const desiredState = buildDesiredStateV2FromForm(form);
+    expect(desiredState.features).toEqual({
+      context_compression: {
+        enabled: true,
+        mode: "auto",
+        target: "dialog_and_knowledge",
+        memory_priority: "balanced",
+      },
+    });
+
+    const reparsed = buildPlaneFormStateFromDesiredStateV2(desiredState);
+    expect(reparsed.contextCompressionEnabled).toBe(true);
+    expect(reparsed.contextCompressionMode).toBe("auto");
+    expect(reparsed.contextCompressionTarget).toBe("dialog_and_knowledge");
+    expect(reparsed.contextCompressionMemoryPriority).toBe("balanced");
+  });
+
+  it("round-trips multiple feature toggles through desired state v2", () => {
+    const form = buildNewPlaneFormState();
+    form.planeName = "combined-feature-plane";
+    form.modelPath = "/models/qwen";
+    form.contextCompressionEnabled = true;
+    form.turboquantEnabled = true;
+
+    const desiredState = buildDesiredStateV2FromForm(form);
+    expect(desiredState.features).toEqual({
+      context_compression: {
+        enabled: true,
+        mode: "auto",
+        target: "dialog_and_knowledge",
+        memory_priority: "balanced",
+      },
+      turboquant: {
+        enabled: true,
+        cache_type_k: "turbo4",
+        cache_type_v: "turbo4",
+      },
+    });
+  });
+
   it("does not serialize turboquant for compute planes", () => {
     const form = buildNewPlaneFormState();
     form.planeMode = "compute";
     form.turboquantEnabled = true;
+
+    const desiredState = buildDesiredStateV2FromForm(form);
+    expect(desiredState.features).toBeUndefined();
+  });
+
+  it("does not serialize context compression for compute planes", () => {
+    const form = buildNewPlaneFormState();
+    form.planeMode = "compute";
+    form.contextCompressionEnabled = true;
 
     const desiredState = buildDesiredStateV2FromForm(form);
     expect(desiredState.features).toBeUndefined();
@@ -409,6 +464,7 @@ describe("PlaneEditorDialog", () => {
 
     expect(html).toContain("New plane");
     expect(html).toContain("Isolated Browsing");
+    expect(html).toContain("Context Compression");
     expect(html).toContain("TurboQuant");
     expect(html).toContain("Generated JSON");
     expect(html).not.toContain("Runtime engine");


### PR DESCRIPTION
## Summary
- add `features.context_compression` to desired-state v2 and legacy state JSON plumbing
- add Plane Editor support for Context Compression and keep it compatible with TurboQuant
- add controller-side context compression before infer execution for dialog history and Knowledge Base context
- persist compression metadata into interaction session state and expose it in session/summary payloads
- add targeted tests for state v2, UI round-trip, payload builder, and context compression service

## What changed
- desired-state model, renderer, projector, validator, and tests now support:
  - `features.context_compression.enabled`
  - `mode=auto`
  - `target=dialog_and_knowledge`
  - `memory_priority=balanced`
- operator UI now exposes a `Context Compression` feature toggle for LLM planes
- new `InteractionContextCompressionService` runs after request context resolution and before infer execution
- compression metadata is persisted in `interaction_sessions.context_state_json` and surfaced through session summary payloads
- generated conversation summaries now include compression metadata such as `compressor_id`, `policy_version`, and before/after token estimates

## Verification
- `npx vitest run src/skillsFactory.test.js` in `ui/operator-react`
- targeted local test binaries:
  - `interaction_context_compression_service_tests`
  - `interaction_conversation_payload_builder_tests`
- syntax-only compile checks for modified controller/state translation units
- sandbox verification on `hpc1`:
  - isolated sandbox build using sandbox-local `VCPKG_ROOT`
  - isolated controller + hostd startup
  - test plane `context-compression-smoke` reached `running`
  - long `/interaction/chat/completions` request succeeded
  - session persisted with:
    - `compression_state=compressed`
    - `compressor_id=context-compression-v1`
    - `policy_version=v1`
    - `dialog_estimate_before=2580`
    - `dialog_estimate_after=1426`
    - `compression_ratio=0.5527`
  - `interaction_summaries` row created with compression metadata in `summary_json`

## Notes
- full repo-wide `cmake --build` still re-enters the known `cmake --regenerate-during-build` stall path in this repository, so verification stayed targeted plus sandbox runtime validation.
- sandbox test also exposed a separate infrastructure issue on `hpc1`: shared mutable `vcpkg` cache ownership is unsafe for isolated builds. The feature itself was validated by switching the sandbox to a sandbox-local `VCPKG_ROOT`.
