### PR TITLE
Add plane-local interaction runtime for context compression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1282,6 +1282,7 @@ add_executable(
   controller/src/interaction/interaction_text_post_processor.cpp
   controller/src/interaction/interaction_upstream_event_parser.cpp
   controller/src/interaction/interaction_utf8_payload_sanitizer.cpp
+  controller/src/interaction/interaction_runtime_request_codec.cpp
   controller/src/interaction/interaction_runtime_support_service.cpp
   controller/src/interaction/interaction_service.cpp
   controller/src/knowledge/knowledge_vault_http_service.cpp
@@ -1495,6 +1496,37 @@ if(NOT WIN32)
       unofficial::sqlite3::sqlite3
   )
   naim_enable_strict_warnings(naim-skillsd)
+
+  add_executable(
+    naim-interactiond
+    controller/src/app/controller_language_support.cpp
+    controller/src/http/controller_http_server_support.cpp
+    controller/src/http/controller_http_transport.cpp
+    controller/src/infra/controller_network_manager.cpp
+    controller/src/interaction/interaction_completion_policy_support.cpp
+    controller/src/interaction/interaction_context_compression_service.cpp
+    controller/src/interaction/interaction_conversation_payload_builder.cpp
+    controller/src/interaction/interaction_model_identity_builder.cpp
+    controller/src/interaction/interaction_payload_builder.cpp
+    controller/src/interaction/interaction_request_heuristics.cpp
+    controller/src/interaction/interaction_request_contract_support.cpp
+    controller/src/interaction/interaction_runtime_request_codec.cpp
+    controller/src/interaction/interaction_utf8_payload_sanitizer.cpp
+    runtime/interaction/src/interaction_runtime_server.cpp
+    runtime/interaction/src/main.cpp
+  )
+  target_include_directories(
+    naim-interactiond PRIVATE common/include controller/include runtime/interaction/include)
+  target_link_libraries(
+    naim-interactiond
+    PRIVATE
+      naim-common
+      Threads::Threads
+  )
+  if(WIN32)
+    target_link_libraries(naim-interactiond PRIVATE ws2_32)
+  endif()
+  naim_enable_strict_warnings(naim-interactiond)
 
   add_executable(
     naim-knowledged

--- a/common/include/naim/state/desired_state_v2_renderer.h
+++ b/common/include/naim/state/desired_state_v2_renderer.h
@@ -30,6 +30,7 @@ class DesiredStateV2Renderer final {
   void RenderAppInstance();
   void RenderSkillsInstance();
   void RenderWebGatewayInstance();
+  void RenderInteractionInstance();
 
   bool InferEnabled() const;
   int InferReplicaCount() const;
@@ -58,11 +59,13 @@ class DesiredStateV2Renderer final {
   std::string BuildAppInstanceName() const;
   std::string BuildSkillsInstanceName() const;
   std::string BuildWebGatewayInstanceName() const;
+  std::string BuildInteractionInstanceName() const;
   int BuildInferApiPort(int infer_index) const;
   int BuildInferGatewayPort(int infer_index) const;
   int BuildInferLlamaPort(int infer_index) const;
   int BuildSkillsHostPort() const;
   int BuildWebGatewayHostPort() const;
+  int BuildInteractionHostPort() const;
   std::string BuildReplicaUpstreams(const std::vector<InstanceSpec>& infer_instances) const;
   std::string InferInstanceNameForWorker(int worker_index) const;
   std::string BuildPlaneSharedHostPath() const;

--- a/common/include/naim/state/models.h
+++ b/common/include/naim/state/models.h
@@ -14,6 +14,7 @@ enum class InstanceRole {
   App,
   Skills,
   Browsing,
+  Interaction,
 };
 
 enum class DiskKind {
@@ -23,6 +24,7 @@ enum class DiskKind {
   AppPrivate,
   SkillsPrivate,
   BrowsingPrivate,
+  InteractionPrivate,
 };
 
 inline bool IsPrivateDiskKind(DiskKind kind) {
@@ -30,7 +32,8 @@ inline bool IsPrivateDiskKind(DiskKind kind) {
          kind == DiskKind::WorkerPrivate ||
          kind == DiskKind::AppPrivate ||
          kind == DiskKind::SkillsPrivate ||
-         kind == DiskKind::BrowsingPrivate;
+         kind == DiskKind::BrowsingPrivate ||
+         kind == DiskKind::InteractionPrivate;
 }
 
 inline bool IsNodeLocalDiskKind(DiskKind kind) {
@@ -47,7 +50,8 @@ inline bool InstanceNeedsPrivateDisk(InstanceRole role) {
   return role == InstanceRole::Worker ||
          role == InstanceRole::App ||
          role == InstanceRole::Skills ||
-         role == InstanceRole::Browsing;
+         role == InstanceRole::Browsing ||
+         role == InstanceRole::Interaction;
 }
 
 struct PublishedPort {

--- a/common/src/planning/planner.cpp
+++ b/common/src/planning/planner.cpp
@@ -368,6 +368,8 @@ std::string ToString(InstanceRole role) {
       return "skills";
     case InstanceRole::Browsing:
       return "webgateway";
+    case InstanceRole::Interaction:
+      return "interaction";
   }
   return "unknown";
 }
@@ -386,6 +388,8 @@ std::string ToString(DiskKind kind) {
       return "skills-private";
     case DiskKind::BrowsingPrivate:
       return "webgateway-private";
+    case DiskKind::InteractionPrivate:
+      return "interaction-private";
   }
   return "unknown";
 }

--- a/common/src/state/desired_state_sqlite_codec.cpp
+++ b/common/src/state/desired_state_sqlite_codec.cpp
@@ -437,6 +437,9 @@ DiskKind DesiredStateSqliteCodec::ParseDiskKind(const std::string& value) {
   if (value == "webgateway-private") {
     return DiskKind::BrowsingPrivate;
   }
+  if (value == "interaction-private") {
+    return DiskKind::InteractionPrivate;
+  }
   throw std::runtime_error("unknown disk kind '" + value + "'");
 }
 
@@ -458,6 +461,9 @@ InstanceRole DesiredStateSqliteCodec::ParseInstanceRole(const std::string& value
   }
   if (value == "webgateway") {
     return InstanceRole::Browsing;
+  }
+  if (value == "interaction") {
+    return InstanceRole::Interaction;
   }
   throw std::runtime_error("unknown instance role '" + value + "'");
 }

--- a/common/src/state/desired_state_v2_projector_support.cpp
+++ b/common/src/state/desired_state_v2_projector_support.cpp
@@ -43,6 +43,8 @@ nlohmann::json DesiredStateV2ProjectorSupport::ProjectServiceStorage(
                   ? disk->size_gb == kDefaultSkillsPrivateDiskSizeGb
                   : disk->kind == DiskKind::BrowsingPrivate
                       ? disk->size_gb == kDefaultWebGatewayPrivateDiskSizeGb
+                      : disk->kind == DiskKind::InteractionPrivate
+                          ? disk->size_gb == kDefaultAppPrivateDiskSizeGb
                       : disk->size_gb == kDefaultAppPrivateDiskSizeGb;
   const bool default_mount = disk->container_path == "/naim/private";
   if (default_size && default_mount) {

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -22,12 +22,16 @@ constexpr int kDefaultWorkerPrivateDiskSizeGb = 2;
 constexpr int kDefaultAppPrivateDiskSizeGb = 8;
 constexpr int kDefaultSkillsPrivateDiskSizeGb = 1;
 constexpr int kDefaultWebGatewayPrivateDiskSizeGb = 1;
+constexpr int kDefaultInteractionPrivateDiskSizeGb = 1;
 constexpr int kSkillsContainerPort = 18120;
 constexpr int kSkillsPublishedPortBase = 24000;
 constexpr int kSkillsPublishedPortSpan = 10000;
 constexpr int kWebGatewayContainerPort = 18130;
 constexpr int kWebGatewayPublishedPortBase = 34000;
 constexpr int kWebGatewayPublishedPortSpan = 10000;
+constexpr int kInteractionContainerPort = 18110;
+constexpr int kInteractionPublishedPortBase = 44000;
+constexpr int kInteractionPublishedPortSpan = 10000;
 constexpr std::string_view kTurboQuantDefaultCacheTypeK = "turbo4";
 constexpr std::string_view kTurboQuantDefaultCacheTypeV = "turbo4";
 
@@ -109,6 +113,7 @@ DesiredState DesiredStateV2Renderer::RenderState() {
   RenderAppInstance();
   RenderSkillsInstance();
   RenderWebGatewayInstance();
+  RenderInteractionInstance();
   return state_;
 }
 
@@ -966,6 +971,59 @@ void DesiredStateV2Renderer::RenderWebGatewayInstance() {
   state_.disks.push_back(std::move(browsing_private_disk));
 }
 
+void DesiredStateV2Renderer::RenderInteractionInstance() {
+  if (state_.plane_mode != PlaneMode::Llm) {
+    return;
+  }
+
+  InstanceSpec interaction;
+  interaction.name = BuildInteractionInstanceName();
+  interaction.role = InstanceRole::Interaction;
+  interaction.plane_name = state_.plane_name;
+  interaction.node_name = ResolveInferNodeName();
+  interaction.image = "naim/interaction-runtime:dev";
+  interaction.command = "/runtime/bin/naim-interactiond";
+  interaction.private_disk_name = interaction.name + "-private";
+  interaction.private_disk_size_gb = kDefaultInteractionPrivateDiskSizeGb;
+  interaction.depends_on.push_back(BuildInferInstanceName());
+  interaction.environment = {
+      {"NAIM_PLANE_NAME", state_.plane_name},
+      {"NAIM_INSTANCE_NAME", interaction.name},
+      {"NAIM_INSTANCE_ROLE", "interaction"},
+      {"NAIM_NODE_NAME", interaction.node_name},
+      {"NAIM_PRIVATE_DISK_PATH", "/naim/private"},
+      {"NAIM_INTERACTION_PORT", std::to_string(kInteractionContainerPort)},
+      {"NAIM_INTERACTION_RUNTIME_STATUS_PATH", "/naim/private/interaction-runtime-status.json"},
+      {"NAIM_INTERACTION_UPSTREAM_BASE",
+       "http://" + BuildInferInstanceName() + ":" +
+           std::to_string(state_.gateway.listen_port) + "/v1"},
+      {"NAIM_CONTROLLER_URL", "http://controller.internal:18080"},
+      {"NAIM_CONTROL_ROOT", state_.control_root},
+  };
+  interaction.labels = {
+      {"naim.plane", state_.plane_name},
+      {"naim.role", "interaction"},
+      {"naim.node", interaction.node_name},
+  };
+  interaction.published_ports.push_back(PublishedPort{
+      "127.0.0.1",
+      BuildInteractionHostPort(),
+      kInteractionContainerPort,
+  });
+  state_.instances.push_back(interaction);
+
+  DiskSpec interaction_private_disk;
+  interaction_private_disk.name = interaction.private_disk_name;
+  interaction_private_disk.kind = DiskKind::InteractionPrivate;
+  interaction_private_disk.plane_name = state_.plane_name;
+  interaction_private_disk.owner_name = interaction.name;
+  interaction_private_disk.node_name = interaction.node_name;
+  interaction_private_disk.host_path = BuildInstancePrivateHostPath(interaction.name);
+  interaction_private_disk.container_path = "/naim/private";
+  interaction_private_disk.size_gb = interaction.private_disk_size_gb;
+  state_.disks.push_back(std::move(interaction_private_disk));
+}
+
 bool DesiredStateV2Renderer::InferEnabled() const {
   return infer_json_.value(
       "enabled",
@@ -1207,6 +1265,10 @@ std::string DesiredStateV2Renderer::BuildWebGatewayInstanceName() const {
   return "webgateway-" + state_.plane_name;
 }
 
+std::string DesiredStateV2Renderer::BuildInteractionInstanceName() const {
+  return "interaction-" + state_.plane_name;
+}
+
 std::string DesiredStateV2Renderer::BuildPlaneSharedHostPath() const {
   return "/var/lib/naim/disks/planes/" + state_.plane_name + "/shared";
 }
@@ -1272,6 +1334,13 @@ int DesiredStateV2Renderer::BuildWebGatewayHostPort() const {
       StablePortHash(state_.plane_name + ":" + BuildWebGatewayInstanceName()) %
       kWebGatewayPublishedPortSpan;
   return kWebGatewayPublishedPortBase + static_cast<int>(offset);
+}
+
+int DesiredStateV2Renderer::BuildInteractionHostPort() const {
+  const uint32_t offset =
+      StablePortHash(state_.plane_name + ":" + BuildInteractionInstanceName()) %
+      kInteractionPublishedPortSpan;
+  return kInteractionPublishedPortBase + static_cast<int>(offset);
 }
 
 std::string DesiredStateV2Renderer::DefaultInferRuntimeBackend() const {

--- a/common/src/state/state_json_runtime_codecs.cpp
+++ b/common/src/state/state_json_runtime_codecs.cpp
@@ -32,6 +32,9 @@ DiskKind StateJsonRuntimeCodecs::ParseDiskKind(const std::string& value) {
   if (value == "webgateway-private") {
     return DiskKind::BrowsingPrivate;
   }
+  if (value == "interaction-private") {
+    return DiskKind::InteractionPrivate;
+  }
   throw std::runtime_error("unknown disk kind '" + value + "'");
 }
 
@@ -54,6 +57,9 @@ InstanceRole StateJsonRuntimeCodecs::ParseInstanceRole(
   }
   if (value == "webgateway") {
     return InstanceRole::Browsing;
+  }
+  if (value == "interaction") {
+    return InstanceRole::Interaction;
   }
   throw std::runtime_error("unknown instance role '" + value + "'");
 }

--- a/controller/include/interaction/interaction_http_support.h
+++ b/controller/include/interaction/interaction_http_support.h
@@ -41,6 +41,12 @@ class InteractionHttpSupport final {
       bool force_stream,
       const naim::controller::ResolvedInteractionPolicy& resolved_policy,
       bool structured_output_json) const;
+  std::string BuildInteractionRuntimeRequestBody(
+      const naim::controller::PlaneInteractionResolution& resolution,
+      nlohmann::json payload,
+      bool force_stream,
+      const naim::controller::ResolvedInteractionPolicy& resolved_policy,
+      bool structured_output_json) const;
   std::optional<std::string> FindInferInstanceName(const naim::DesiredState& desired_state) const;
   std::vector<naim::RuntimeProcessStatus> ParseInstanceRuntimeStatuses(
       const naim::HostObservation& observation) const;
@@ -53,6 +59,8 @@ class InteractionHttpSupport final {
   std::optional<naim::controller::ControllerEndpointTarget> ParseInteractionTarget(
       const std::string& gateway_listen,
       int fallback_port) const;
+  std::optional<naim::controller::ControllerEndpointTarget> ResolvePlaneLocalInteractionTarget(
+      const naim::DesiredState& desired_state) const;
   int CountReadyWorkerMembers(
       naim::ControllerStore& store,
       const naim::DesiredState& desired_state) const;

--- a/controller/include/interaction/interaction_runtime_request_codec.h
+++ b/controller/include/interaction/interaction_runtime_request_codec.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+#include "interaction/interaction_types.h"
+
+namespace naim::controller {
+
+class InteractionRuntimeRequestCodec final {
+ public:
+  std::string Serialize(const InteractionRuntimeExecutionRequest& request) const;
+  InteractionRuntimeExecutionRequest Deserialize(const std::string& json_text) const;
+};
+
+}  // namespace naim::controller

--- a/controller/include/interaction/interaction_runtime_support_service.h
+++ b/controller/include/interaction/interaction_runtime_support_service.h
@@ -19,7 +19,13 @@ class InteractionRuntimeSupportService {
       const std::string& gateway_listen,
       int fallback_port) const;
 
+  std::optional<ControllerEndpointTarget> ResolvePlaneLocalInteractionTarget(
+      const naim::DesiredState& desired_state) const;
+
   std::optional<std::string> FindInferInstanceName(
+      const naim::DesiredState& desired_state) const;
+
+  std::optional<std::string> FindInteractionInstanceName(
       const naim::DesiredState& desired_state) const;
 
   std::vector<std::string> FindWorkerInstanceNames(

--- a/controller/include/interaction/interaction_service.h
+++ b/controller/include/interaction/interaction_service.h
@@ -348,6 +348,8 @@ class InteractionPlaneResolver {
           const naim::DesiredState&, const naim::HostObservation&)>;
   using ParseInteractionTargetFn =
       std::function<std::optional<ControllerEndpointTarget>(const std::string&, int)>;
+  using ResolvePlaneLocalInteractionTargetFn =
+      std::function<std::optional<ControllerEndpointTarget>(const naim::DesiredState&)>;
   using CountReadyWorkerMembersFn =
       std::function<int(naim::ControllerStore&, const naim::DesiredState&)>;
   using ProbeControllerTargetOkFn =
@@ -361,6 +363,7 @@ class InteractionPlaneResolver {
       ObservationMatchesPlaneFn observation_matches_plane,
       BuildPlaneScopedRuntimeStatusFn build_plane_scoped_runtime_status,
       ParseInteractionTargetFn parse_interaction_target,
+      ResolvePlaneLocalInteractionTargetFn resolve_plane_local_interaction_target,
       CountReadyWorkerMembersFn count_ready_worker_members,
       ProbeControllerTargetOkFn probe_controller_target_ok,
       DescribeUnsupportedControllerLocalRuntimeFn
@@ -376,6 +379,7 @@ class InteractionPlaneResolver {
   ObservationMatchesPlaneFn observation_matches_plane_;
   BuildPlaneScopedRuntimeStatusFn build_plane_scoped_runtime_status_;
   ParseInteractionTargetFn parse_interaction_target_;
+  ResolvePlaneLocalInteractionTargetFn resolve_plane_local_interaction_target_;
   CountReadyWorkerMembersFn count_ready_worker_members_;
   ProbeControllerTargetOkFn probe_controller_target_ok_;
   DescribeUnsupportedControllerLocalRuntimeFn

--- a/controller/include/interaction/interaction_types.h
+++ b/controller/include/interaction/interaction_types.h
@@ -65,6 +65,15 @@ struct ResolvedInteractionPolicy {
   bool long_form = false;
 };
 
+struct InteractionRuntimeExecutionRequest {
+  naim::DesiredState desired_state;
+  nlohmann::json status_payload = nlohmann::json::object();
+  nlohmann::json payload = nlohmann::json::object();
+  ResolvedInteractionPolicy resolved_policy;
+  bool structured_output_json = false;
+  bool force_stream = false;
+};
+
 struct InteractionSegmentSummary {
   int index = 0;
   int continuation_index = 0;

--- a/controller/src/http/controller_http_router.cpp
+++ b/controller/src/http/controller_http_router.cpp
@@ -4,7 +4,6 @@
 
 #include "infra/controller_action.h"
 #include "http/controller_http_server_support.h"
-#include "interaction/interaction_context_compression_service.h"
 #include "interaction/interaction_conversation_service.h"
 #include "interaction/interaction_request_contract_support.h"
 #include "interaction/interaction_request_identity_support.h"
@@ -583,7 +582,6 @@ HttpResponse ControllerHttpRouter::HandlePlaneInteractionRequest(
             validation_error->retryable,
             validation_error->details);
       }
-      InteractionContextCompressionService().Apply(resolution, &request_context);
       try {
         const auto result =
             interaction_service_.ExecuteSession(resolution, request_context);

--- a/controller/src/http/controller_http_transport.cpp
+++ b/controller/src/http/controller_http_transport.cpp
@@ -260,8 +260,11 @@ OpenInteractionStreamRequest(
   };
 
   try {
+    const std::string request_path =
+        target.base_path.empty() ? "/v1/chat/completions"
+                                 : target.base_path + "/chat/completions";
     std::ostringstream upstream_request;
-    upstream_request << "POST /v1/chat/completions HTTP/1.1\r\n";
+    upstream_request << "POST " << request_path << " HTTP/1.1\r\n";
     upstream_request << "Host: " << target.host << ":" << target.port << "\r\n";
     upstream_request << "Connection: close\r\n";
     upstream_request << "Accept: text/event-stream\r\n";

--- a/controller/src/interaction/interaction_http_executor_factory.cpp
+++ b/controller/src/interaction/interaction_http_executor_factory.cpp
@@ -35,6 +35,9 @@ InteractionPlaneResolver InteractionHttpExecutorFactory::MakePlaneResolver() con
       [&](const std::string& gateway_listen, int fallback_port) {
         return support_.ParseInteractionTarget(gateway_listen, fallback_port);
       },
+      [&](const naim::DesiredState& desired_state) {
+        return support_.ResolvePlaneLocalInteractionTarget(desired_state);
+      },
       [&](naim::ControllerStore& store,
           const naim::DesiredState& desired_state) {
         return support_.CountReadyWorkerMembers(store, desired_state);
@@ -57,7 +60,7 @@ InteractionSessionExecutor InteractionHttpExecutorFactory::MakeSessionExecutor()
           bool force_stream,
           const ResolvedInteractionPolicy& resolved_policy,
           bool structured_output_json) {
-        return support_.BuildInteractionUpstreamBody(
+        return support_.BuildInteractionRuntimeRequestBody(
             resolution,
             std::move(payload),
             force_stream,
@@ -128,7 +131,7 @@ InteractionHttpExecutorFactory::MakeStreamSegmentExecutor() const {
           bool force_stream,
           const ResolvedInteractionPolicy& resolved_policy,
           bool structured_output_json) {
-        return support_.BuildInteractionUpstreamBody(
+        return support_.BuildInteractionRuntimeRequestBody(
             resolution,
             std::move(payload),
             force_stream,
@@ -183,7 +186,7 @@ InteractionProxyExecutor InteractionHttpExecutorFactory::MakeProxyExecutor(
           bool force_stream,
           const ResolvedInteractionPolicy& resolved_policy,
           bool structured_output_json) {
-        return support_.BuildInteractionUpstreamBody(
+        return support_.BuildInteractionRuntimeRequestBody(
             resolution,
             std::move(payload),
             force_stream,

--- a/controller/src/interaction/interaction_http_support.cpp
+++ b/controller/src/interaction/interaction_http_support.cpp
@@ -2,6 +2,7 @@
 
 #include "app/controller_composition_support.h"
 #include "interaction/interaction_payload_builder.h"
+#include "interaction/interaction_runtime_request_codec.h"
 #include "skills/plane_skills_service.h"
 
 using nlohmann::json;
@@ -32,6 +33,23 @@ std::string InteractionHttpSupport::BuildInteractionUpstreamBody(
     bool structured_output_json) const {
   return naim::controller::BuildInteractionUpstreamBodyPayload(
       resolution, std::move(payload), force_stream, resolved_policy, structured_output_json);
+}
+
+std::string InteractionHttpSupport::BuildInteractionRuntimeRequestBody(
+    const naim::controller::PlaneInteractionResolution& resolution,
+    json payload,
+    bool force_stream,
+    const naim::controller::ResolvedInteractionPolicy& resolved_policy,
+    bool structured_output_json) const {
+  return naim::controller::InteractionRuntimeRequestCodec{}.Serialize(
+      naim::controller::InteractionRuntimeExecutionRequest{
+          resolution.desired_state,
+          resolution.status_payload,
+          std::move(payload),
+          resolved_policy,
+          structured_output_json,
+          force_stream,
+      });
 }
 
 std::optional<std::string> InteractionHttpSupport::FindInferInstanceName(
@@ -68,6 +86,13 @@ InteractionHttpSupport::ParseInteractionTarget(
   return interaction_runtime_support_service_.ParseInteractionTarget(
       gateway_listen,
       fallback_port);
+}
+
+std::optional<naim::controller::ControllerEndpointTarget>
+InteractionHttpSupport::ResolvePlaneLocalInteractionTarget(
+    const naim::DesiredState& desired_state) const {
+  return interaction_runtime_support_service_.ResolvePlaneLocalInteractionTarget(
+      desired_state);
 }
 
 int InteractionHttpSupport::CountReadyWorkerMembers(

--- a/controller/src/interaction/interaction_runtime_request_codec.cpp
+++ b/controller/src/interaction/interaction_runtime_request_codec.cpp
@@ -1,0 +1,115 @@
+#include "interaction/interaction_runtime_request_codec.h"
+
+#include <stdexcept>
+
+#include "naim/state/state_json.h"
+
+namespace naim::controller {
+
+namespace {
+
+using nlohmann::json;
+
+json SerializePolicy(const InteractionCompletionPolicy& policy) {
+  json value = {
+      {"response_mode", policy.response_mode},
+      {"max_tokens", policy.max_tokens},
+      {"max_continuations", policy.max_continuations},
+      {"max_total_completion_tokens", policy.max_total_completion_tokens},
+      {"max_elapsed_time_ms", policy.max_elapsed_time_ms},
+      {"thinking_enabled", policy.thinking_enabled},
+      {"semantic_goal", policy.semantic_goal},
+      {"completion_marker", policy.completion_marker},
+      {"require_completion_marker", policy.require_completion_marker},
+  };
+  if (policy.target_completion_tokens.has_value()) {
+    value["target_completion_tokens"] = *policy.target_completion_tokens;
+  }
+  return value;
+}
+
+InteractionCompletionPolicy DeserializePolicy(const json& value) {
+  InteractionCompletionPolicy policy;
+  if (!value.is_object()) {
+    return policy;
+  }
+  policy.response_mode = value.value("response_mode", policy.response_mode);
+  policy.max_tokens = value.value("max_tokens", policy.max_tokens);
+  if (value.contains("target_completion_tokens") &&
+      !value.at("target_completion_tokens").is_null()) {
+    policy.target_completion_tokens = value.at("target_completion_tokens").get<int>();
+  }
+  policy.max_continuations =
+      value.value("max_continuations", policy.max_continuations);
+  policy.max_total_completion_tokens =
+      value.value("max_total_completion_tokens", policy.max_total_completion_tokens);
+  policy.max_elapsed_time_ms =
+      value.value("max_elapsed_time_ms", policy.max_elapsed_time_ms);
+  policy.thinking_enabled = value.value("thinking_enabled", policy.thinking_enabled);
+  policy.semantic_goal = value.value("semantic_goal", policy.semantic_goal);
+  policy.completion_marker =
+      value.value("completion_marker", policy.completion_marker);
+  policy.require_completion_marker =
+      value.value("require_completion_marker", policy.require_completion_marker);
+  return policy;
+}
+
+json SerializeResolvedPolicy(const ResolvedInteractionPolicy& policy) {
+  return json{
+      {"policy", SerializePolicy(policy.policy)},
+      {"mode", policy.mode},
+      {"repository_analysis", policy.repository_analysis},
+      {"long_form", policy.long_form},
+  };
+}
+
+ResolvedInteractionPolicy DeserializeResolvedPolicy(const json& value) {
+  ResolvedInteractionPolicy policy;
+  if (!value.is_object()) {
+    return policy;
+  }
+  policy.policy = DeserializePolicy(value.value("policy", json::object()));
+  policy.mode = value.value("mode", policy.mode);
+  policy.repository_analysis =
+      value.value("repository_analysis", policy.repository_analysis);
+  policy.long_form = value.value("long_form", policy.long_form);
+  return policy;
+}
+
+}  // namespace
+
+std::string InteractionRuntimeRequestCodec::Serialize(
+    const InteractionRuntimeExecutionRequest& request) const {
+  return json{
+      {"desired_state", json::parse(SerializeDesiredStateJson(request.desired_state))},
+      {"status_payload", request.status_payload},
+      {"payload", request.payload},
+      {"resolved_policy", SerializeResolvedPolicy(request.resolved_policy)},
+      {"structured_output_json", request.structured_output_json},
+      {"force_stream", request.force_stream},
+  }
+      .dump();
+}
+
+InteractionRuntimeExecutionRequest InteractionRuntimeRequestCodec::Deserialize(
+    const std::string& json_text) const {
+  const json value = json_text.empty() ? json::object() : json::parse(json_text);
+  if (!value.is_object()) {
+    throw std::runtime_error("interaction runtime request must be a JSON object");
+  }
+  InteractionRuntimeExecutionRequest request;
+  if (!value.contains("desired_state") || !value.at("desired_state").is_object()) {
+    throw std::runtime_error("interaction runtime request is missing desired_state");
+  }
+  request.desired_state = DeserializeDesiredStateJson(value.at("desired_state").dump());
+  request.status_payload = value.value("status_payload", json::object());
+  request.payload = value.value("payload", json::object());
+  request.resolved_policy =
+      DeserializeResolvedPolicy(value.value("resolved_policy", json::object()));
+  request.structured_output_json =
+      value.value("structured_output_json", false);
+  request.force_stream = value.value("force_stream", false);
+  return request;
+}
+
+}  // namespace naim::controller

--- a/controller/src/interaction/interaction_runtime_support_service.cpp
+++ b/controller/src/interaction/interaction_runtime_support_service.cpp
@@ -31,10 +31,52 @@ InteractionRuntimeSupportService::ParseInteractionTarget(
   return ParseControllerEndpointTarget(host + ":" + std::to_string(port));
 }
 
+std::optional<ControllerEndpointTarget>
+InteractionRuntimeSupportService::ResolvePlaneLocalInteractionTarget(
+    const naim::DesiredState& desired_state) const {
+  const auto interaction_instance_name = FindInteractionInstanceName(desired_state);
+  if (!interaction_instance_name.has_value()) {
+    return std::nullopt;
+  }
+  const auto instance_it = std::find_if(
+      desired_state.instances.begin(),
+      desired_state.instances.end(),
+      [&](const naim::InstanceSpec& instance) {
+        return instance.name == *interaction_instance_name &&
+               instance.role == naim::InstanceRole::Interaction;
+      });
+  if (instance_it == desired_state.instances.end()) {
+    return std::nullopt;
+  }
+  const auto published = std::find_if(
+      instance_it->published_ports.begin(),
+      instance_it->published_ports.end(),
+      [](const naim::PublishedPort& port) { return port.host_port > 0; });
+  if (published == instance_it->published_ports.end()) {
+    return std::nullopt;
+  }
+  ControllerEndpointTarget target;
+  target.host = NormalizeInteractionHost(published->host_ip);
+  target.port = published->host_port;
+  target.raw = "http://" + target.host + ":" + std::to_string(target.port);
+  return target;
+}
+
 std::optional<std::string> InteractionRuntimeSupportService::FindInferInstanceName(
     const naim::DesiredState& desired_state) const {
   for (const auto& instance : desired_state.instances) {
     if (instance.role == naim::InstanceRole::Infer &&
+        instance.plane_name == desired_state.plane_name) {
+      return instance.name;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<std::string> InteractionRuntimeSupportService::FindInteractionInstanceName(
+    const naim::DesiredState& desired_state) const {
+  for (const auto& instance : desired_state.instances) {
+    if (instance.role == naim::InstanceRole::Interaction &&
         instance.plane_name == desired_state.plane_name) {
       return instance.name;
     }

--- a/controller/src/interaction/interaction_service.cpp
+++ b/controller/src/interaction/interaction_service.cpp
@@ -1660,6 +1660,7 @@ InteractionPlaneResolver::InteractionPlaneResolver(
     ObservationMatchesPlaneFn observation_matches_plane,
     BuildPlaneScopedRuntimeStatusFn build_plane_scoped_runtime_status,
     ParseInteractionTargetFn parse_interaction_target,
+    ResolvePlaneLocalInteractionTargetFn resolve_plane_local_interaction_target,
     CountReadyWorkerMembersFn count_ready_worker_members,
     ProbeControllerTargetOkFn probe_controller_target_ok,
     DescribeUnsupportedControllerLocalRuntimeFn
@@ -1669,6 +1670,8 @@ InteractionPlaneResolver::InteractionPlaneResolver(
       observation_matches_plane_(std::move(observation_matches_plane)),
       build_plane_scoped_runtime_status_(std::move(build_plane_scoped_runtime_status)),
       parse_interaction_target_(std::move(parse_interaction_target)),
+      resolve_plane_local_interaction_target_(
+          std::move(resolve_plane_local_interaction_target)),
       count_ready_worker_members_(std::move(count_ready_worker_members)),
       probe_controller_target_ok_(std::move(probe_controller_target_ok)),
       describe_unsupported_controller_local_runtime_(
@@ -1689,6 +1692,8 @@ PlaneInteractionResolution InteractionPlaneResolver::Resolve(
   resolution.desired_state = *desired_state;
   resolution.plane_record = store.LoadPlane(plane_name);
   const std::string primary_node = desired_state->inference.primary_infer_node;
+  const auto plane_local_interaction_target =
+      resolve_plane_local_interaction_target_(*desired_state);
   bool observation_matches_plane = false;
   if (!primary_node.empty()) {
     resolution.observation = store.LoadHostObservation(primary_node);
@@ -1730,7 +1735,8 @@ PlaneInteractionResolution InteractionPlaneResolver::Resolve(
         resolution.runtime_status = observed_runtime;
       }
     }
-    if (resolution.runtime_status.has_value()) {
+    if (resolution.runtime_status.has_value() &&
+        !plane_local_interaction_target.has_value()) {
       resolution.target = parse_interaction_target_(
           resolution.runtime_status->gateway_listen,
           desired_state->gateway.listen_port);
@@ -1741,6 +1747,16 @@ PlaneInteractionResolution InteractionPlaneResolver::Resolve(
           plane_name,
           &resolution.target);
     }
+  }
+
+  if (plane_local_interaction_target.has_value()) {
+    resolution.target = plane_local_interaction_target;
+    InteractionTargetRelayPolicy{}.EnableHostdRuntimeRelayForRemoteLoopback(
+        store,
+        db_path,
+        primary_node,
+        plane_name,
+        &resolution.target);
   }
 
   const bool llm_plane = desired_state->plane_mode == naim::PlaneMode::Llm;

--- a/controller/src/interaction/interaction_stream_http_request_preparation_service.cpp
+++ b/controller/src/interaction/interaction_stream_http_request_preparation_service.cpp
@@ -3,7 +3,6 @@
 #include "app/controller_composition_support.h"
 #include "auth/auth_support_service.h"
 #include "interaction/interaction_completion_policy_support.h"
-#include "interaction/interaction_context_compression_service.h"
 #include "interaction/interaction_conversation_service.h"
 #include "interaction/interaction_request_contract_support.h"
 #include "interaction/interaction_stream_http_error_response_builder.h"
@@ -109,7 +108,6 @@ InteractionStreamHttpRequestPreparationService::Prepare(
           std::nullopt,
       };
     }
-    InteractionContextCompressionService().Apply(setup.resolution, &setup.request_context);
   } catch (const nlohmann::json::exception& error) {
     return InteractionStreamHttpRequestPreparationResult{
         error_response_builder.Build(

--- a/controller/src/plane/desired_state_policy_service.cpp
+++ b/controller/src/plane/desired_state_policy_service.cpp
@@ -178,7 +178,8 @@ bool DesiredStatePolicyService::NodeAllowsInstanceRole(
     case naim::HostExecutionMode::InferOnly:
       return role == naim::InstanceRole::Infer ||
              role == naim::InstanceRole::App ||
-             role == naim::InstanceRole::Skills;
+             role == naim::InstanceRole::Skills ||
+             role == naim::InstanceRole::Interaction;
     case naim::HostExecutionMode::WorkerOnly:
       return role == naim::InstanceRole::Worker;
     case naim::HostExecutionMode::Mixed:

--- a/controller/src/plane/plane_placement_payload_builder.cpp
+++ b/controller/src/plane/plane_placement_payload_builder.cpp
@@ -105,6 +105,15 @@ nlohmann::json PlanePlacementPayloadBuilder::Build() const {
     });
   }
 
+  if (const auto interaction_node_name = FindFirstInstanceNodeName(naim::InstanceRole::Interaction);
+      interaction_node_name.has_value()) {
+    service_targets.push_back(nlohmann::json{
+        {"service", "interaction-runtime"},
+        {"target_type", "node"},
+        {"target", *interaction_node_name},
+    });
+  }
+
   payload["service_targets"] = std::move(service_targets);
   return payload;
 }

--- a/hostd/include/app/hostd_desired_state_path_support.h
+++ b/hostd/include/app/hostd_desired_state_path_support.h
@@ -34,6 +34,9 @@ class HostdDesiredStatePathSupport final {
   std::optional<std::string> InferRuntimeConfigPathForNode(
       const naim::DesiredState& state,
       const std::string& node_name) const;
+  std::optional<std::string> DesiredStateSnapshotPathForNode(
+      const naim::DesiredState& state,
+      const std::string& node_name) const;
   std::optional<std::string> InferRuntimeStatusPathForInstance(
       const naim::DesiredState& state,
       const naim::InstanceSpec& infer_instance) const;

--- a/hostd/src/app/hostd_compose_runtime_support.cpp
+++ b/hostd/src/app/hostd_compose_runtime_support.cpp
@@ -121,6 +121,9 @@ bool HostdComposeRuntimeSupport::LocalRuntimeBinaryExists(
   if (image == "naim/webgateway-runtime:dev") {
     return std::filesystem::exists(repo_root / "build" / "linux" / "x64" / "naim-webgatewayd");
   }
+  if (image == "naim/interaction-runtime:dev") {
+    return std::filesystem::exists(repo_root / "build" / "linux" / "x64" / "naim-interactiond");
+  }
   return true;
 }
 
@@ -241,6 +244,14 @@ void HostdComposeRuntimeSupport::BuildNaimRuntimeImage(
     }
     EnsureLocalRuntimeBinary(repo_root, image);
     build_runtime("runtime/browsing/Dockerfile", image);
+    return;
+  }
+  if (image == "naim/interaction-runtime:dev") {
+    if (!DockerImageExists("naim/base-runtime:dev")) {
+      build_base();
+    }
+    EnsureLocalRuntimeBinary(repo_root, image);
+    build_runtime("runtime/interaction/Dockerfile", image);
     return;
   }
   if (image == "naim/web-ui:dev") {

--- a/hostd/src/app/hostd_desired_state_apply_support.cpp
+++ b/hostd/src/app/hostd_desired_state_apply_support.cpp
@@ -4,10 +4,30 @@
 #include <iostream>
 #include <stdexcept>
 
+#include "app/hostd_file_support.h"
 #include "app/hostd_runtime_telemetry_support.h"
+#include "naim/state/state_json.h"
 #include "naim/planning/planner.h"
 
 namespace naim::hostd {
+
+namespace {
+
+void WriteDesiredStateSnapshot(
+    const HostdDesiredStatePathSupport& path_support,
+    const naim::DesiredState& desired_node_state,
+    const std::string& node_name) {
+  const auto snapshot_path =
+      path_support.DesiredStateSnapshotPathForNode(desired_node_state, node_name);
+  if (!snapshot_path.has_value()) {
+    return;
+  }
+  HostdFileSupport().WriteTextFile(
+      *snapshot_path,
+      naim::SerializeDesiredStateJson(desired_node_state));
+}
+
+}  // namespace
 
 HostdDesiredStateApplySupport::HostdDesiredStateApplySupport(
     const HostdDesiredStatePathSupport& path_support,
@@ -88,6 +108,7 @@ void HostdDesiredStateApplySupport::ApplyDesiredNodeState(
             << (compose_mode == ComposeMode::Exec ? "exec" : "skip") << "\n";
 
   ValidateDesiredNodeStateForCurrentHost(desired_node_state, compose_mode);
+  WriteDesiredStateSnapshot(path_support_, desired_node_state, node_name);
 
   auto maybe_publish_progress =
       [&](const std::string& phase,

--- a/hostd/src/app/hostd_desired_state_path_support.cpp
+++ b/hostd/src/app/hostd_desired_state_path_support.cpp
@@ -129,6 +129,12 @@ std::optional<std::string> HostdDesiredStatePathSupport::InferRuntimeConfigPathF
   return ControlFilePathForNode(state, node_name, "infer-runtime.json");
 }
 
+std::optional<std::string> HostdDesiredStatePathSupport::DesiredStateSnapshotPathForNode(
+    const naim::DesiredState& state,
+    const std::string& node_name) const {
+  return ControlFilePathForNode(state, node_name, "desired-state.v2.json");
+}
+
 const naim::InstanceSpec* HostdDesiredStatePathSupport::PrimaryInferInstanceForNode(
     const naim::DesiredState& state,
     const std::string& node_name) const {

--- a/hostd/src/app/hostd_local_runtime_state_support.cpp
+++ b/hostd/src/app/hostd_local_runtime_state_support.cpp
@@ -114,7 +114,8 @@ bool HostdLocalRuntimeStateSupport::InstanceProducesRuntimeStatus(
     const naim::InstanceSpec& instance) {
   return instance.role == naim::InstanceRole::Infer ||
          instance.role == naim::InstanceRole::Worker ||
-         instance.role == naim::InstanceRole::Skills;
+         instance.role == naim::InstanceRole::Skills ||
+         instance.role == naim::InstanceRole::Interaction;
 }
 
 }  // namespace naim::hostd

--- a/hostd/src/app/hostd_runtime_telemetry_support.cpp
+++ b/hostd/src/app/hostd_runtime_telemetry_support.cpp
@@ -193,7 +193,8 @@ std::optional<std::string> HostdRuntimeTelemetrySupport::WorkerRuntimeStatusPath
     const naim::DesiredState& state,
     const naim::InstanceSpec& instance) const {
   if (instance.role != naim::InstanceRole::Worker &&
-      instance.role != naim::InstanceRole::Skills) {
+      instance.role != naim::InstanceRole::Skills &&
+      instance.role != naim::InstanceRole::Interaction) {
     return std::nullopt;
   }
   for (const auto& disk : state.disks) {
@@ -201,12 +202,16 @@ std::optional<std::string> HostdRuntimeTelemetrySupport::WorkerRuntimeStatusPath
         (instance.role == naim::InstanceRole::Worker &&
          disk.kind == naim::DiskKind::WorkerPrivate) ||
         (instance.role == naim::InstanceRole::Skills &&
-         disk.kind == naim::DiskKind::SkillsPrivate);
+         disk.kind == naim::DiskKind::SkillsPrivate) ||
+        (instance.role == naim::InstanceRole::Interaction &&
+         disk.kind == naim::DiskKind::InteractionPrivate);
     if (matching_disk_kind && disk.owner_name == instance.name &&
         disk.node_name == instance.node_name) {
       return (fs::path(disk.host_path) /
               (instance.role == naim::InstanceRole::Skills
                    ? "skills-runtime-status.json"
+                   : instance.role == naim::InstanceRole::Interaction
+                         ? "interaction-runtime-status.json"
                    : "worker-runtime-status.json"))
           .string();
     }

--- a/runtime/interaction/Dockerfile
+++ b/runtime/interaction/Dockerfile
@@ -1,0 +1,20 @@
+ARG BASE_IMAGE=naim/base-runtime:dev
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      bash \
+      curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY build/linux/x64/naim-interactiond /runtime/bin/naim-interactiond
+
+RUN chmod +x /runtime/bin/naim-interactiond
+
+WORKDIR /runtime
+
+EXPOSE 18110
+
+ENTRYPOINT ["/runtime/bin/naim-interactiond"]

--- a/runtime/interaction/include/interaction/interaction_runtime_server.h
+++ b/runtime/interaction/include/interaction/interaction_runtime_server.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <atomic>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "http/controller_http_types.h"
+#include "http/controller_http_transport.h"
+#include "interaction/interaction_types.h"
+#include "naim/core/platform_compat.h"
+
+namespace naim::interaction_runtime {
+
+struct InteractionRuntimeConfig {
+  std::string plane_name;
+  std::string instance_name;
+  std::string instance_role = "interaction";
+  std::string node_name;
+  std::string control_root;
+  std::string controller_url;
+  std::filesystem::path status_path;
+  std::string listen_host = "0.0.0.0";
+  int port = 18110;
+  std::string upstream_base = "http://127.0.0.1:8000/v1";
+};
+
+class InteractionRuntimeServer final {
+ public:
+  explicit InteractionRuntimeServer(InteractionRuntimeConfig config);
+  ~InteractionRuntimeServer();
+
+  int Run();
+  void RequestStop();
+
+ private:
+  struct RuntimeExecution {
+    naim::controller::PlaneInteractionResolution resolution;
+    naim::controller::InteractionRequestContext request_context;
+    naim::controller::ResolvedInteractionPolicy resolved_policy;
+    bool force_stream = false;
+    bool structured_output_json = false;
+  };
+
+  void AcceptLoop();
+  void HandleClient(naim::platform::SocketHandle client_fd);
+  HttpResponse HandleRequest(const HttpRequest& request);
+  HttpResponse HandleGet(const HttpRequest& request);
+  HttpResponse HandlePost(const HttpRequest& request);
+  HttpResponse ExecuteNonStream(const HttpRequest& request);
+  void ExecuteStream(naim::platform::SocketHandle client_fd, const HttpRequest& request);
+  RuntimeExecution BuildRuntimeExecution(const HttpRequest& request) const;
+  std::optional<RuntimeExecution> TryBuildWrappedRuntimeExecution(
+      const std::string& body) const;
+  RuntimeExecution BuildDirectRuntimeExecution(const HttpRequest& request) const;
+  nlohmann::json LoadPlaneStatePayload() const;
+  nlohmann::json LoadPlaneStatePayloadFromSnapshot() const;
+  HttpResponse BuildJsonResponse(int status_code, const nlohmann::json& payload) const;
+  naim::controller::ControllerEndpointTarget UpstreamTarget() const;
+  std::vector<std::string> SplitPath(const std::string& path) const;
+  void WriteRuntimeStatus(const std::string& phase, bool ready) const;
+  void SetReadyFile(bool ready) const;
+
+  InteractionRuntimeConfig config_;
+  std::atomic<bool> stop_requested_{false};
+  naim::platform::SocketHandle listen_fd_ = naim::platform::kInvalidSocket;
+};
+
+}  // namespace naim::interaction_runtime

--- a/runtime/interaction/src/interaction_runtime_server.cpp
+++ b/runtime/interaction/src/interaction_runtime_server.cpp
@@ -1,0 +1,468 @@
+#include "interaction/interaction_runtime_server.h"
+
+#include <array>
+#include <csignal>
+#include <fstream>
+#include <stdexcept>
+#include <thread>
+
+#include "http/controller_http_server_support.h"
+#include "infra/controller_network_manager.h"
+#include "interaction/interaction_completion_policy_support.h"
+#include "interaction/interaction_context_compression_service.h"
+#include "interaction/interaction_payload_builder.h"
+#include "interaction/interaction_runtime_request_codec.h"
+#include "naim/state/state_json.h"
+#include "naim/runtime/runtime_status.h"
+
+namespace naim::interaction_runtime {
+
+namespace {
+
+std::atomic<bool>* g_stop_requested = nullptr;
+
+void SignalHandler(int) {
+  if (g_stop_requested != nullptr) {
+    g_stop_requested->store(true);
+  }
+}
+
+bool RequestWantsStream(const HttpRequest& request) {
+  if (request.path == "/v1/chat/completions/stream") {
+    return true;
+  }
+  try {
+    const auto wrapped_request =
+        naim::controller::InteractionRuntimeRequestCodec{}.Deserialize(request.body);
+    if (wrapped_request.force_stream) {
+      return true;
+    }
+    return wrapped_request.payload.value("stream", false);
+  } catch (const std::exception&) {
+  }
+  try {
+    const auto payload = nlohmann::json::parse(request.body);
+    return payload.is_object() && payload.value("stream", false);
+  } catch (const std::exception&) {
+  }
+  return false;
+}
+
+}  // namespace
+
+InteractionRuntimeServer::InteractionRuntimeServer(InteractionRuntimeConfig config)
+    : config_(std::move(config)) {}
+
+InteractionRuntimeServer::~InteractionRuntimeServer() {
+  RequestStop();
+}
+
+int InteractionRuntimeServer::Run() {
+  std::filesystem::create_directories(config_.status_path.parent_path());
+  WriteRuntimeStatus("starting", false);
+  SetReadyFile(false);
+
+  g_stop_requested = &stop_requested_;
+  std::signal(SIGINT, SignalHandler);
+  std::signal(SIGTERM, SignalHandler);
+
+  listen_fd_ = naim::controller::ControllerNetworkManager::CreateListenSocket(
+      config_.listen_host,
+      config_.port);
+  WriteRuntimeStatus("running", true);
+  SetReadyFile(true);
+
+  try {
+    AcceptLoop();
+  } catch (...) {
+    WriteRuntimeStatus("stopped", false);
+    SetReadyFile(false);
+    naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(listen_fd_);
+    listen_fd_ = naim::platform::kInvalidSocket;
+    throw;
+  }
+
+  WriteRuntimeStatus("stopped", false);
+  SetReadyFile(false);
+  naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(listen_fd_);
+  listen_fd_ = naim::platform::kInvalidSocket;
+  return 0;
+}
+
+void InteractionRuntimeServer::RequestStop() {
+  const bool was_requested = stop_requested_.exchange(true);
+  if (!was_requested && naim::platform::IsSocketValid(listen_fd_)) {
+    WriteRuntimeStatus("stopping", false);
+    SetReadyFile(false);
+    naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(listen_fd_);
+  }
+}
+
+void InteractionRuntimeServer::AcceptLoop() {
+  while (!stop_requested_.load()) {
+    const auto client_fd = accept(listen_fd_, nullptr, nullptr);
+    if (!naim::platform::IsSocketValid(client_fd)) {
+      if (stop_requested_.load() || naim::platform::LastSocketErrorWasInterrupted()) {
+        continue;
+      }
+      throw std::runtime_error(
+          "accept failed: " + naim::controller::ControllerNetworkManager::SocketErrorMessage());
+    }
+    std::thread(&InteractionRuntimeServer::HandleClient, this, client_fd).detach();
+  }
+}
+
+void InteractionRuntimeServer::HandleClient(naim::platform::SocketHandle client_fd) {
+  std::string request_data;
+  std::array<char, 8192> buffer{};
+  std::size_t expected_request_bytes = 0;
+  while (true) {
+    const ssize_t read_count = recv(client_fd, buffer.data(), buffer.size(), 0);
+    if (read_count <= 0) {
+      break;
+    }
+    request_data.append(buffer.data(), static_cast<std::size_t>(read_count));
+    if (expected_request_bytes == 0) {
+      expected_request_bytes =
+          naim::controller::ControllerHttpServerSupport::ExpectedRequestBytes(request_data);
+    }
+    if (expected_request_bytes != 0 && request_data.size() >= expected_request_bytes) {
+      break;
+    }
+  }
+
+  if (request_data.empty()) {
+    naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+    return;
+  }
+
+  try {
+    const HttpRequest request =
+        naim::controller::ControllerHttpServerSupport::ParseHttpRequest(request_data);
+    if (request.method == "POST" &&
+        (request.path == "/v1/chat/completions" ||
+         request.path == "/v1/chat/completions/stream")) {
+      if (RequestWantsStream(request)) {
+        ExecuteStream(client_fd, request);
+        return;
+      }
+    }
+    naim::controller::ControllerNetworkManager::SendHttpResponse(
+        client_fd,
+        HandleRequest(request));
+  } catch (const std::exception& error) {
+    naim::controller::ControllerNetworkManager::SendHttpResponse(
+        client_fd,
+        BuildJsonResponse(
+            500,
+            nlohmann::json{
+                {"error", "internal_error"},
+                {"message", error.what()},
+            }));
+  }
+  naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+}
+
+HttpResponse InteractionRuntimeServer::HandleRequest(const HttpRequest& request) {
+  if (request.method == "GET") {
+    return HandleGet(request);
+  }
+  if (request.method == "POST") {
+    return HandlePost(request);
+  }
+  return BuildJsonResponse(
+      405,
+      nlohmann::json{{"error", "method_not_allowed"}, {"message", "method not allowed"}});
+}
+
+HttpResponse InteractionRuntimeServer::HandleGet(const HttpRequest& request) {
+  const auto parts = SplitPath(request.path);
+  if (parts.size() == 1 && parts[0] == "health") {
+    return BuildJsonResponse(200, nlohmann::json{{"ok", true}, {"ready", true}});
+  }
+  if (parts.size() == 2 && parts[0] == "v1" && parts[1] == "models") {
+    return SendControllerHttpRequest(UpstreamTarget(), "GET", "/models");
+  }
+  return BuildJsonResponse(
+      404,
+      nlohmann::json{{"error", "not_found"}, {"message", "route not found"}});
+}
+
+HttpResponse InteractionRuntimeServer::HandlePost(const HttpRequest& request) {
+  if (request.path == "/v1/chat/completions" ||
+      request.path == "/v1/chat/completions/stream") {
+    return ExecuteNonStream(request);
+  }
+  return BuildJsonResponse(
+      404,
+      nlohmann::json{{"error", "not_found"}, {"message", "route not found"}});
+}
+
+HttpResponse InteractionRuntimeServer::ExecuteNonStream(const HttpRequest& request) {
+  auto execution = BuildRuntimeExecution(request);
+  naim::controller::InteractionContextCompressionService().Apply(
+      execution.resolution,
+      &execution.request_context);
+  const std::string upstream_body = naim::controller::BuildInteractionUpstreamBodyPayload(
+      execution.resolution,
+      execution.request_context.payload,
+      execution.force_stream,
+      execution.resolved_policy,
+      execution.structured_output_json);
+  return SendControllerHttpRequest(
+      UpstreamTarget(),
+      "POST",
+      "/chat/completions",
+      upstream_body,
+      {{"Accept", "application/json"}});
+}
+
+void InteractionRuntimeServer::ExecuteStream(
+    naim::platform::SocketHandle client_fd,
+    const HttpRequest& request) {
+  auto execution = BuildRuntimeExecution(request);
+  execution.force_stream = true;
+  naim::controller::InteractionContextCompressionService().Apply(
+      execution.resolution,
+      &execution.request_context);
+  const std::string upstream_body = naim::controller::BuildInteractionUpstreamBodyPayload(
+      execution.resolution,
+      execution.request_context.payload,
+      true,
+      execution.resolved_policy,
+      execution.structured_output_json);
+  auto upstream = OpenInteractionStreamRequest(
+      UpstreamTarget(),
+      "interaction-runtime",
+      upstream_body);
+  if (!naim::controller::ControllerNetworkManager::SendSseHeaders(client_fd, {})) {
+    upstream.close();
+    naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+    return;
+  }
+  if (!upstream.initial_body.empty() &&
+      !naim::controller::ControllerNetworkManager::SendAll(client_fd, upstream.initial_body)) {
+    upstream.close();
+    naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+    return;
+  }
+  while (true) {
+    const std::string chunk = upstream.read_next_chunk();
+    if (chunk.empty()) {
+      break;
+    }
+    if (!naim::controller::ControllerNetworkManager::SendAll(client_fd, chunk)) {
+      break;
+    }
+  }
+  upstream.close();
+  naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+}
+
+InteractionRuntimeServer::RuntimeExecution
+InteractionRuntimeServer::BuildRuntimeExecution(const HttpRequest& request) const {
+  if (const auto wrapped = TryBuildWrappedRuntimeExecution(request.body);
+      wrapped.has_value()) {
+    return *wrapped;
+  }
+  return BuildDirectRuntimeExecution(request);
+}
+
+std::optional<InteractionRuntimeServer::RuntimeExecution>
+InteractionRuntimeServer::TryBuildWrappedRuntimeExecution(
+    const std::string& body) const {
+  if (body.empty()) {
+    return std::nullopt;
+  }
+  try {
+    const auto request =
+        naim::controller::InteractionRuntimeRequestCodec{}.Deserialize(body);
+    RuntimeExecution execution;
+    execution.resolution.desired_state = request.desired_state;
+    execution.resolution.status_payload = request.status_payload;
+    execution.request_context.original_payload = request.payload;
+    execution.request_context.payload = request.payload;
+    execution.request_context.structured_output_json = request.structured_output_json;
+    execution.resolved_policy = request.resolved_policy;
+    execution.force_stream = request.force_stream;
+    execution.structured_output_json = request.structured_output_json;
+    return std::optional<RuntimeExecution>(std::move(execution));
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
+InteractionRuntimeServer::RuntimeExecution
+InteractionRuntimeServer::BuildDirectRuntimeExecution(const HttpRequest& request) const {
+  const nlohmann::json state_payload = LoadPlaneStatePayload();
+  if (!state_payload.contains("desired_state") ||
+      !state_payload.at("desired_state").is_object()) {
+    throw std::runtime_error(
+        "interaction-runtime plane state payload is missing desired_state");
+  }
+
+  const nlohmann::json payload =
+      request.body.empty() ? nlohmann::json::object() : nlohmann::json::parse(request.body);
+  if (!payload.is_object()) {
+    throw std::runtime_error("interaction-runtime request body must be a JSON object");
+  }
+
+  RuntimeExecution execution;
+  execution.resolution.desired_state =
+      naim::DeserializeDesiredStateJson(state_payload.at("desired_state").dump());
+  execution.resolution.status_payload = state_payload;
+  execution.request_context.original_payload = payload;
+  execution.request_context.payload = payload;
+  execution.request_context.structured_output_json =
+      payload.contains("response_format") && payload.at("response_format").is_object();
+  execution.resolved_policy =
+      naim::controller::InteractionCompletionPolicySupport{}.ResolvePolicy(
+          execution.resolution.desired_state,
+          execution.request_context.payload);
+  execution.force_stream =
+      request.path == "/v1/chat/completions/stream" || payload.value("stream", false);
+  execution.structured_output_json =
+      execution.request_context.structured_output_json;
+  return execution;
+}
+
+nlohmann::json InteractionRuntimeServer::LoadPlaneStatePayload() const {
+  if (const auto snapshot = LoadPlaneStatePayloadFromSnapshot(); snapshot.is_object()) {
+    return snapshot;
+  }
+  if (config_.controller_url.empty()) {
+    throw std::runtime_error("interaction-runtime controller_url is not configured");
+  }
+  const auto target = ParseControllerEndpointTarget(config_.controller_url);
+  const auto response = SendControllerHttpRequest(
+      target,
+      "GET",
+      "/api/v1/planes/" + config_.plane_name);
+  if (response.status_code < 200 || response.status_code >= 300) {
+    throw std::runtime_error(
+        "interaction-runtime failed to load plane state for '" + config_.plane_name +
+        "' from controller");
+  }
+  const auto payload =
+      response.body.empty() ? nlohmann::json::object() : nlohmann::json::parse(response.body);
+  if (!payload.is_object()) {
+    throw std::runtime_error("interaction-runtime plane state response must be a JSON object");
+  }
+  return payload;
+}
+
+nlohmann::json InteractionRuntimeServer::LoadPlaneStatePayloadFromSnapshot() const {
+  if (config_.control_root.empty()) {
+    return nlohmann::json();
+  }
+  const std::filesystem::path snapshot_path =
+      std::filesystem::path(config_.control_root) / "desired-state.v2.json";
+  if (!std::filesystem::exists(snapshot_path)) {
+    return nlohmann::json();
+  }
+  std::ifstream input(snapshot_path);
+  if (!input.is_open()) {
+    throw std::runtime_error(
+        "interaction-runtime failed to open local desired-state snapshot: " +
+        snapshot_path.string());
+  }
+  const std::string state_json{
+      std::istreambuf_iterator<char>(input),
+      std::istreambuf_iterator<char>()};
+  if (state_json.empty()) {
+    throw std::runtime_error(
+        "interaction-runtime local desired-state snapshot is empty: " +
+        snapshot_path.string());
+  }
+  const auto desired_state = naim::DeserializeDesiredStateJson(state_json);
+  return nlohmann::json{
+      {"plane_name", desired_state.plane_name},
+      {"desired_state", nlohmann::json::parse(state_json)},
+      {"ready", true},
+      {"interaction_enabled", true},
+      {"status", "ok"},
+      {"reason", "local_desired_state_snapshot"},
+      {"active_model_id",
+       desired_state.bootstrap_model.has_value()
+           ? nlohmann::json(desired_state.bootstrap_model->model_id)
+           : nlohmann::json(nullptr)},
+      {"served_model_name",
+       desired_state.bootstrap_model.has_value()
+           ? nlohmann::json(
+                 desired_state.bootstrap_model->served_model_name.value_or(
+                     desired_state.bootstrap_model->model_id))
+           : nlohmann::json(nullptr)},
+  };
+}
+
+HttpResponse InteractionRuntimeServer::BuildJsonResponse(
+    int status_code,
+    const nlohmann::json& payload) const {
+  HttpResponse response;
+  response.status_code = status_code;
+  response.content_type = "application/json";
+  response.body = payload.dump();
+  return response;
+}
+
+naim::controller::ControllerEndpointTarget InteractionRuntimeServer::UpstreamTarget() const {
+  return ParseControllerEndpointTarget(config_.upstream_base);
+}
+
+std::vector<std::string> InteractionRuntimeServer::SplitPath(const std::string& path) const {
+  std::vector<std::string> parts;
+  std::size_t start = 0;
+  while (start < path.size()) {
+    while (start < path.size() && path[start] == '/') {
+      ++start;
+    }
+    if (start >= path.size()) {
+      break;
+    }
+    const std::size_t end = path.find('/', start);
+    parts.push_back(path.substr(start, end == std::string::npos ? std::string::npos : end - start));
+    if (end == std::string::npos) {
+      break;
+    }
+    start = end + 1;
+  }
+  return parts;
+}
+
+void InteractionRuntimeServer::WriteRuntimeStatus(
+    const std::string& phase,
+    bool ready) const {
+  naim::RuntimeStatus status;
+  status.plane_name = config_.plane_name;
+  status.control_root = config_.control_root;
+  status.controller_url = config_.controller_url;
+  status.instance_name = config_.instance_name;
+  status.instance_role = config_.instance_role;
+  status.node_name = config_.node_name;
+  status.runtime_backend = "interaction-runtime";
+  status.runtime_phase = phase;
+  status.gateway_listen = config_.listen_host + ":" + std::to_string(config_.port);
+  status.gateway_health_url =
+      "http://127.0.0.1:" + std::to_string(config_.port) + "/health";
+  status.upstream_models_url = config_.upstream_base + "/models";
+  status.ready = ready;
+  status.gateway_ready = ready;
+  status.inference_ready = ready;
+  status.launch_ready = ready;
+  status.active_model_ready = ready;
+  naim::SaveRuntimeStatusJson(status, config_.status_path.string());
+}
+
+void InteractionRuntimeServer::SetReadyFile(bool ready) const {
+  const std::filesystem::path ready_path("/tmp/naim-ready");
+  std::error_code error;
+  if (ready) {
+    std::filesystem::create_directories(ready_path.parent_path(), error);
+    std::ofstream ready_file(ready_path.string());
+    ready_file << '\n';
+  } else {
+    std::filesystem::remove(ready_path, error);
+  }
+}
+
+}  // namespace naim::interaction_runtime

--- a/runtime/interaction/src/main.cpp
+++ b/runtime/interaction/src/main.cpp
@@ -1,0 +1,55 @@
+#include "interaction/interaction_runtime_server.h"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+
+namespace {
+
+std::string GetEnvOr(const char* name, const char* fallback) {
+  const char* value = std::getenv(name);
+  return value != nullptr && *value != '\0' ? std::string(value) : std::string(fallback);
+}
+
+int GetEnvIntOr(const char* name, int fallback) {
+  const char* value = std::getenv(name);
+  if (value == nullptr || *value == '\0') {
+    return fallback;
+  }
+  return std::stoi(value);
+}
+
+}  // namespace
+
+int main() {
+  try {
+    naim::interaction_runtime::InteractionRuntimeConfig config;
+    config.plane_name = GetEnvOr("NAIM_PLANE_NAME", "unknown");
+    config.instance_name = GetEnvOr("NAIM_INSTANCE_NAME", "interaction-unknown");
+    config.instance_role = GetEnvOr("NAIM_INSTANCE_ROLE", "interaction");
+    config.node_name = GetEnvOr("NAIM_NODE_NAME", "unknown");
+    config.control_root = GetEnvOr("NAIM_CONTROL_ROOT", "");
+    config.controller_url = GetEnvOr("NAIM_CONTROLLER_URL", "http://controller.internal:18080");
+    config.status_path = GetEnvOr(
+        "NAIM_INTERACTION_RUNTIME_STATUS_PATH",
+        "/naim/private/interaction-runtime-status.json");
+    config.listen_host = GetEnvOr("NAIM_INTERACTION_LISTEN_HOST", "0.0.0.0");
+    config.port = GetEnvIntOr("NAIM_INTERACTION_PORT", 18110);
+    config.upstream_base = GetEnvOr(
+        "NAIM_INTERACTION_UPSTREAM_BASE",
+        "http://127.0.0.1:8000/v1");
+
+    std::cout << "[naim-interaction] booting plane=" << config.plane_name
+              << " instance=" << config.instance_name << "\n";
+    std::cout << "[naim-interaction] status_path=" << config.status_path.string() << "\n";
+    std::cout << "[naim-interaction] upstream_base=" << config.upstream_base << "\n";
+    std::cout << "[naim-interaction] port=" << config.port << "\n";
+    std::cout.flush();
+
+    naim::interaction_runtime::InteractionRuntimeServer server(std::move(config));
+    return server.Run();
+  } catch (const std::exception& error) {
+    std::cerr << "naim-interactiond: " << error.what() << "\n";
+    return 1;
+  }
+}

--- a/scripts/build-runtime-images.sh
+++ b/scripts/build-runtime-images.sh
@@ -41,9 +41,10 @@ worker_tag="${3:-naim/worker-runtime:dev}"
 web_ui_tag="${4:-naim/web-ui:dev}"
 skills_tag="${5:-naim/skills-runtime:dev}"
 webgateway_tag="${6:-naim/webgateway-runtime:dev}"
-controller_tag="${7:-naim/controller:dev}"
-hostd_tag="${8:-naim/hostd:dev}"
-knowledge_tag="${9:-naim/knowledge-runtime:dev}"
+interaction_tag="${7:-naim/interaction-runtime:dev}"
+controller_tag="${8:-naim/controller:dev}"
+hostd_tag="${9:-naim/hostd:dev}"
+knowledge_tag="${10:-naim/knowledge-runtime:dev}"
 
 build_dir="$("${script_dir}/print-build-dir.sh")"
 turboquant_build_dir="${NAIM_TURBOQUANT_BUILD_DIR:-${repo_root}/build-turboquant/linux/x64}"
@@ -63,7 +64,7 @@ cp "${repo_root}/ui/operator-react/package.json" \
   "${image_context}/ui/operator-react/"
 cp "${repo_root}/ui/operator-react/scripts/webauthn-helper.mjs" \
   "${image_context}/ui/operator-react/scripts/webauthn-helper.mjs"
-for binary in naim-controller naim-hostd naim-node naim-inferctl naim-workerd naim-skillsd naim-knowledged naim-webgatewayd; do
+for binary in naim-controller naim-hostd naim-node naim-inferctl naim-workerd naim-skillsd naim-knowledged naim-webgatewayd naim-interactiond; do
   cp "${build_dir}/${binary}" "${image_context}/build/linux/x64/${binary}"
 done
 cp "${build_dir}/bin/llama-server" "${image_context}/build/linux/x64/bin/llama-server"
@@ -166,6 +167,13 @@ echo "building ${webgateway_tag}"
   -t "${webgateway_tag}" \
   "${image_context}"
 
+echo "building ${interaction_tag}"
+"${docker_cmd[@]}" build \
+  -f "${image_context}/runtime/interaction/Dockerfile" \
+  --build-arg "BASE_IMAGE=${base_tag}" \
+  -t "${interaction_tag}" \
+  "${image_context}"
+
 if [[ "${skip_web_ui}" != "yes" ]]; then
   echo "building ${web_ui_tag}"
   build_web_ui_image
@@ -181,6 +189,7 @@ echo "  worker=${worker_tag}"
 echo "  skills=${skills_tag}"
 echo "  knowledge=${knowledge_tag}"
 echo "  webgateway=${webgateway_tag}"
+echo "  interaction=${interaction_tag}"
 if [[ "${skip_web_ui}" != "yes" ]]; then
   echo "  web_ui=${web_ui_tag}"
 fi

--- a/scripts/release/build-and-push-images.sh
+++ b/scripts/release/build-and-push-images.sh
@@ -132,6 +132,7 @@ web_ui_ref="$(image_ref web-ui)"
 skills_ref="$(image_ref skills-runtime)"
 knowledge_ref="$(image_ref knowledge-runtime)"
 webgateway_ref="$(image_ref webgateway-runtime)"
+interaction_ref="$(image_ref interaction-runtime)"
 controller_ref="$(image_ref controller)"
 hostd_ref="$(image_ref hostd)"
 
@@ -142,6 +143,7 @@ build_args=(
   "${web_ui_ref}"
   "${skills_ref}"
   "${webgateway_ref}"
+  "${interaction_ref}"
   "${controller_ref}"
   "${hostd_ref}"
   "${knowledge_ref}"
@@ -162,6 +164,7 @@ declare -a image_names=(
   skills-runtime
   knowledge-runtime
   webgateway-runtime
+  interaction-runtime
 )
 if [[ "${skip_web_ui}" != "yes" ]]; then
   image_names+=(web-ui)


### PR DESCRIPTION
## Summary
- add a plane-local `interaction-runtime` service and image for `llm` planes
- move request-time Context Compression execution into the plane-local runtime boundary
- let controller `/interaction/*` proxy into the plane-local runtime
- replicate `desired-state.v2.json` into the plane control root so direct plane apps can use the same feature path
- extend hostd/runtime image plumbing and telemetry for the new interaction role

## Validation
- `git diff --check`
- targeted syntax-only compile for updated hostd and interaction-runtime sources
- `cmake --build ... --target naim-interactiond naim-hostd` in the hpc1 sandbox
- hpc1 raw-path smoke with local `desired-state.v2.json` snapshot in control root
  - long OpenAI-style request reached mock upstream with a compressed prompt
  - upstream request had 7 messages instead of the full dialog history and included the context-compression summary in the merged system prompt
