### PR TITLE
Prepare shared vcpkg cache in hpc1 build

### DIFF
--- a/scripts/ci/hpc1-build.sh
+++ b/scripts/ci/hpc1-build.sh
@@ -10,6 +10,7 @@ current_sha="$(naim_ci_require_release_sha)"
 naim_ci_prepare_repo
 
 naim_ci_ensure_writable_dir build
+naim_ci_prepare_shared_vcpkg_cache "$(pwd)"
 
 export NAIM_BUILD_TYPE
 "$(pwd)/scripts/build-target.sh" "${NAIM_BUILD_TYPE}"


### PR DESCRIPTION
## Summary
- call `naim_ci_prepare_shared_vcpkg_cache` in the regular `hpc1-build.sh` path
- normalize ownership and writability of the shared vcpkg cache before the standard Release build
- keep the existing TurboQuant-specific cache preparation unchanged

## Why
The production release workflow for merge commit `3d57d4d` failed in `2. hpc1 build` before compilation with:

`open_for_write("/mnt/shared-storage/naim/vcpkg/buildtrees/detect_compiler/stdout-x64-linux.log"): Permission denied`

The helper to fix shared cache ownership already existed in `hpc1-build-common.sh`, but only the TurboQuant build path called it.

## Validation
- `git diff --check`
- `bash -n scripts/ci/hpc1-build.sh scripts/ci/hpc1-build-common.sh`
- direct hpc1 repro showed the pre-fix failure in `vcpkg-manifest-install.log`
- direct hpc1 re-run with the new helper call got past the vcpkg permission error and continued deep into `cmake --build`
