### PR TITLE
Fix interaction HTTP support test linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -845,6 +845,7 @@ add_executable(
   controller/src/interaction/interaction_request_identity_support.cpp
   controller/src/interaction/interaction_request_heuristics.cpp
   controller/src/interaction/interaction_replica_group_summary_builder.cpp
+  controller/src/interaction/interaction_runtime_request_codec.cpp
   controller/src/interaction/interaction_text_post_processor.cpp
   controller/src/interaction/interaction_utf8_payload_sanitizer.cpp
   controller/src/interaction/interaction_http_support_tests.cpp


### PR DESCRIPTION
## Summary
- add `controller/src/interaction/interaction_runtime_request_codec.cpp` to `naim-interaction-http-support-tests`
- fix the test linkage regression introduced by the interaction-runtime changes

## Why
Production release run `24844230686` failed in `2. hpc1 build` while linking `naim-interaction-http-support-tests`:

`undefined reference to InteractionRuntimeRequestCodec::Serialize(...)`

`interaction_http_support.cpp` now depends on `InteractionRuntimeRequestCodec`, but that translation unit was not linked into the test target.

## Validation
- `git diff --check`
- direct hpc1 targeted rebuild of `naim-interaction-http-support-tests`
  - reconfigured successfully
  - compiled `interaction_runtime_request_codec.cpp`
  - linked `naim-interaction-http-support-tests` successfully
