### PR TITLE
Reset hpc1 CI checkout to origin branch state

### DIFF
--- a/scripts/ci/hpc1-pull-main.sh
+++ b/scripts/ci/hpc1-pull-main.sh
@@ -4,17 +4,16 @@ set -euo pipefail
 : "${NAIM_RELEASE_SHA:?NAIM_RELEASE_SHA is required}"
 : "${NAIM_RELEASE_BRANCH:=main}"
 
-current_branch="$(git rev-parse --abbrev-ref HEAD)"
-if [[ "${current_branch}" != "${NAIM_RELEASE_BRANCH}" ]]; then
-  if git show-ref --verify --quiet "refs/heads/${NAIM_RELEASE_BRANCH}"; then
-    git checkout "${NAIM_RELEASE_BRANCH}"
-  else
-    git checkout -b "${NAIM_RELEASE_BRANCH}" "origin/${NAIM_RELEASE_BRANCH}"
-  fi
+git fetch --prune origin "${NAIM_RELEASE_BRANCH}"
+
+# This checkout is dedicated to CI builds, so local tracked changes are disposable.
+if git show-ref --verify --quiet "refs/heads/${NAIM_RELEASE_BRANCH}"; then
+  git checkout -f "${NAIM_RELEASE_BRANCH}"
+else
+  git checkout -B "${NAIM_RELEASE_BRANCH}" "origin/${NAIM_RELEASE_BRANCH}"
 fi
 
-git fetch --prune origin "${NAIM_RELEASE_BRANCH}"
-git pull --ff-only origin "${NAIM_RELEASE_BRANCH}"
+git reset --hard "origin/${NAIM_RELEASE_BRANCH}"
 
 current_sha="$(git rev-parse HEAD)"
 if [[ "${current_sha}" != "${NAIM_RELEASE_SHA}" ]]; then


### PR DESCRIPTION
## Summary
- stop using `git pull --ff-only` in the dedicated hpc1 CI checkout
- force the checkout onto `origin/main` and reset tracked changes before validating the target SHA
- keep the hpc1 pull step resilient when previous builds leave tracked edits behind

## Why
The production workflow failed in `1. hpc1 pull main` because the shared checkout on hpc1 had local tracked changes in `CMakeLists.txt`, so `git pull --ff-only` aborted before the build even started.

This checkout is dedicated to CI builds, so the correct behavior is to discard tracked edits and make it match `origin/<branch>` exactly.

## Validation
- `bash -n scripts/ci/hpc1-pull-main.sh`
- `git diff --check`
- executed the updated script against the dirty hpc1 checkout and confirmed it reset the worktree to `e0ff5701cc2b485f087505eb4b14f18f56bdf5cb`
