### PR TITLE
Refresh managed plane runtimes during release rollout

### DIFF
--- a/common/include/naim/state/models.h
+++ b/common/include/naim/state/models.h
@@ -266,6 +266,7 @@ struct InteractionSettings {
     std::optional<std::string> semantic_goal;
   };
 
+  std::optional<std::string> image;
   std::optional<std::string> system_prompt;
   std::optional<std::string> analysis_system_prompt;
   bool thinking_enabled = false;

--- a/common/src/state/desired_state_sqlite_codec.cpp
+++ b/common/src/state/desired_state_sqlite_codec.cpp
@@ -134,6 +134,9 @@ std::optional<InteractionSettings> DesiredStateSqliteCodec::DeserializeInteracti
     return std::nullopt;
   }
   InteractionSettings interaction;
+  if (value.contains("image") && !value.at("image").is_null()) {
+    interaction.image = value.at("image").get<std::string>();
+  }
   if (value.contains("system_prompt") && !value.at("system_prompt").is_null()) {
     interaction.system_prompt = value.at("system_prompt").get<std::string>();
   }

--- a/common/src/state/desired_state_v2_projector.cpp
+++ b/common/src/state/desired_state_v2_projector.cpp
@@ -251,6 +251,9 @@ void DesiredStateV2Projector::ProjectInteraction() {
 
   const auto& interaction = *state_.interaction;
   nlohmann::json interaction_json = nlohmann::json::object();
+  if (interaction.image.has_value() && !interaction.image->empty()) {
+    interaction_json["image"] = *interaction.image;
+  }
   if (interaction.system_prompt.has_value() && !interaction.system_prompt->empty()) {
     interaction_json["system_prompt"] = *interaction.system_prompt;
   }

--- a/common/src/state/desired_state_v2_projector_tests.cpp
+++ b/common/src/state/desired_state_v2_projector_tests.cpp
@@ -213,6 +213,13 @@ void ExpectRoundTrip(const json& source, const std::string& name) {
                source.at("knowledge").at("selected_knowledge_ids"),
            name + ": knowledge.selected_knowledge_ids mismatch");
   }
+  if (source.contains("interaction")) {
+    Expect(projected.contains("interaction"), name + ": interaction block missing after projection");
+    if (source.at("interaction").contains("image")) {
+      Expect(projected.at("interaction").at("image") == source.at("interaction").at("image"),
+             name + ": interaction.image mismatch");
+    }
+  }
   const auto* webgateway_source =
       source.contains("webgateway")
           ? &source.at("webgateway")
@@ -374,6 +381,30 @@ int main() {
             {"app", {{"enabled", false}}},
         },
         "combined-features");
+
+    ExpectRoundTrip(
+        json{
+            {"version", 2},
+            {"plane_name", "interaction-image-override"},
+            {"plane_mode", "llm"},
+            {"model",
+             {
+                 {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+                 {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+                 {"served_model_name", "qwen-interaction-image"},
+             }},
+            {"interaction",
+             {
+                 {"image",
+                  "chainzano.com/naim/interaction-runtime@sha256:feedface"},
+                 {"thinking_enabled", false},
+             }},
+            {"runtime",
+             {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+            {"infer", {{"replicas", 1}}},
+            {"app", {{"enabled", false}}},
+        },
+        "interaction-image-override");
 
     ExpectRoundTrip(
         json{

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -981,7 +981,10 @@ void DesiredStateV2Renderer::RenderInteractionInstance() {
   interaction.role = InstanceRole::Interaction;
   interaction.plane_name = state_.plane_name;
   interaction.node_name = ResolveInferNodeName();
-  interaction.image = "naim/interaction-runtime:dev";
+  interaction.image =
+      state_.interaction.has_value() && state_.interaction->image.has_value()
+          ? *state_.interaction->image
+          : std::string("naim/interaction-runtime:dev");
   interaction.command = "/runtime/bin/naim-interactiond";
   interaction.private_disk_name = interaction.name + "-private";
   interaction.private_disk_size_gb = kDefaultInteractionPrivateDiskSizeGb;

--- a/common/src/state/state_json_settings_codecs.cpp
+++ b/common/src/state/state_json_settings_codecs.cpp
@@ -124,6 +124,9 @@ json StateJsonSettingsCodecs::ToJson(const InteractionSettings& interaction) {
       {"supported_response_languages", interaction.supported_response_languages},
       {"follow_user_language", interaction.follow_user_language},
   };
+  if (interaction.image.has_value()) {
+    result["image"] = *interaction.image;
+  }
   if (interaction.system_prompt.has_value()) {
     result["system_prompt"] = *interaction.system_prompt;
   }
@@ -302,6 +305,9 @@ BootstrapModelSpec StateJsonSettingsCodecs::BootstrapModelSpecFromJson(
 InteractionSettings StateJsonSettingsCodecs::InteractionSettingsFromJson(
     const json& value) {
   InteractionSettings interaction;
+  if (value.contains("image") && !value.at("image").is_null()) {
+    interaction.image = value.at("image").get<std::string>();
+  }
   if (value.contains("system_prompt") && !value.at("system_prompt").is_null()) {
     interaction.system_prompt = value.at("system_prompt").get<std::string>();
   }

--- a/scripts/ci/main-bootstrap-controller-update.sh
+++ b/scripts/ci/main-bootstrap-controller-update.sh
@@ -114,6 +114,11 @@ knowledge = images.get("knowledge-runtime", "")
 print("controller_image=" + shlex.quote(controller))
 print("web_ui_image=" + shlex.quote(web_ui))
 print("knowledge_image=" + shlex.quote(knowledge))
+print("infer_image=" + shlex.quote(images.get("infer-runtime", "")))
+print("worker_image=" + shlex.quote(images.get("worker-runtime", "")))
+print("skills_image=" + shlex.quote(images.get("skills-runtime", "")))
+print("webgateway_image=" + shlex.quote(images.get("webgateway-runtime", "")))
+print("interaction_image=" + shlex.quote(images.get("interaction-runtime", "")))
 PY
 )"
 
@@ -321,4 +326,206 @@ raise SystemExit(
     + json.dumps(last, sort_keys=True)
 )
 PY
+
+plane_refresh_root="$(mktemp -d)"
+plane_refresh_plan="${plane_refresh_root}/planes.tsv"
+python3 - "${db_path}" "${manifest_path}" "${plane_refresh_root}" > "${plane_refresh_plan}" <<'PY'
+import json
+import pathlib
+import sqlite3
+import sys
+
+db_path, manifest_path, output_root = sys.argv[1:4]
+output_dir = pathlib.Path(output_root)
+output_dir.mkdir(parents=True, exist_ok=True)
+
+with open(manifest_path, "r", encoding="utf-8") as handle:
+    manifest = json.load(handle)
+
+images = manifest.get("images") or {}
+registry_prefix = f"{manifest.get('registry', '').strip()}/{manifest.get('project', '').strip()}/"
+
+managed_images = {
+    ("infer", "image"): images.get("infer-runtime", ""),
+    ("worker", "image"): images.get("worker-runtime", ""),
+    ("skills", "image"): images.get("skills-runtime", ""),
+    ("webgateway", "image"): images.get("webgateway-runtime", ""),
+    ("browsing", "image"): images.get("webgateway-runtime", ""),
+}
+interaction_image = images.get("interaction-runtime", "")
+
+def is_managed_image(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    normalized = value.strip()
+    if not normalized:
+        return True
+    return normalized.startswith("naim/") or (
+        registry_prefix.strip("/") and normalized.startswith(registry_prefix)
+    )
+
+def ensure_object(parent: dict, key: str) -> dict:
+    current = parent.get(key)
+    if isinstance(current, dict):
+        return current
+    parent[key] = {}
+    return parent[key]
+
+con = sqlite3.connect(db_path)
+con.row_factory = sqlite3.Row
+rows = con.execute(
+    "select name, state, desired_state_json from planes order by name asc"
+).fetchall()
+
+for row in rows:
+    if not row["desired_state_json"]:
+        continue
+    payload = json.loads(row["desired_state_json"])
+    changed = False
+    for (section_name, field_name), image_ref in managed_images.items():
+        if not image_ref:
+            continue
+        section = payload.get(section_name)
+        if not isinstance(section, dict):
+            continue
+        current = section.get(field_name)
+        if current is None or is_managed_image(current):
+            if current != image_ref:
+                section[field_name] = image_ref
+                changed = True
+    if payload.get("plane_mode") == "llm" and interaction_image:
+        interaction = ensure_object(payload, "interaction")
+        current = interaction.get("image")
+        if current is None or is_managed_image(current):
+            if current != interaction_image:
+                interaction["image"] = interaction_image
+                changed = True
+    if not changed:
+        continue
+    state_path = output_dir / f"{row['name']}.desired-state.v2.json"
+    state_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"{row['name']}\t{row['state']}\t{state_path}")
+PY
+
+if [[ -s "${plane_refresh_plan}" ]]; then
+  while IFS=$'\t' read -r plane_name plane_state state_path; do
+    [[ -n "${plane_name}" ]] || continue
+    docker run --rm \
+      -v "${main_root}/state:/naim/state" \
+      -v "${main_root}/artifacts:/naim/artifacts" \
+      -v "${plane_refresh_root}:${plane_refresh_root}:ro" \
+      "${controller_image}" \
+      apply-state-file \
+        --state "${state_path}" \
+        --db /naim/state/controller.sqlite \
+        --artifacts-root /naim/artifacts >/dev/null
+    if [[ "${plane_state}" == "running" ]]; then
+      docker run --rm \
+        -v "${main_root}/state:/naim/state" \
+        "${controller_image}" \
+        stop-plane \
+          --plane "${plane_name}" \
+          --db /naim/state/controller.sqlite >/dev/null
+      docker run --rm \
+        -v "${main_root}/state:/naim/state" \
+        "${controller_image}" \
+        start-plane \
+          --plane "${plane_name}" \
+          --db /naim/state/controller.sqlite >/dev/null
+    fi
+  done < "${plane_refresh_plan}"
+
+  python3 - "${db_path}" "${timeout_sec}" "${plane_refresh_plan}" <<'PY'
+import json
+import sqlite3
+import sys
+import time
+
+db_path, timeout_text, plan_path = sys.argv[1:4]
+targets = []
+with open(plan_path, "r", encoding="utf-8") as handle:
+    for line in handle:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        plane_name, plane_state, _ = line.split("\t", 2)
+        targets.append((plane_name, plane_state))
+
+deadline = time.time() + int(timeout_text)
+last = {}
+while time.time() < deadline:
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    pending = 0
+    failed = 0
+    planes = {}
+    assignments = {}
+    for plane_name, plane_state in targets:
+        plane = con.execute(
+            "select generation, applied_generation, state from planes where name = ?",
+            (plane_name,),
+        ).fetchone()
+        latest_assignment = con.execute(
+            "select id, status, status_message, updated_at from host_assignments "
+            "where plane_name = ? order by id desc limit 1",
+            (plane_name,),
+        ).fetchone()
+        pending += con.execute(
+            "select count(*) as count from host_assignments "
+            "where plane_name = ? and status in ('pending','claimed')",
+            (plane_name,),
+        ).fetchone()["count"]
+        if latest_assignment is not None and latest_assignment["status"] == "failed":
+            failed += 1
+        planes[plane_name] = None if plane is None else {
+            "generation": plane["generation"],
+            "applied_generation": plane["applied_generation"],
+            "state": plane["state"],
+            "target_state": plane_state,
+        }
+        assignments[plane_name] = None if latest_assignment is None else {
+            "id": latest_assignment["id"],
+            "status": latest_assignment["status"],
+            "status_message": latest_assignment["status_message"],
+            "updated_at": latest_assignment["updated_at"],
+        }
+    con.close()
+
+    ready = True
+    for plane_name, plane_state in targets:
+        plane = planes.get(plane_name)
+        if plane is None:
+            ready = False
+            break
+        if plane["generation"] != plane["applied_generation"]:
+            ready = False
+            break
+        if plane_state == "running" and plane["state"] != "running":
+            ready = False
+            break
+    last = {
+        "pending_plane_assignments": pending,
+        "failed_plane_assignments": failed,
+        "planes": planes,
+        "assignments": assignments,
+    }
+    print("plane runtime refresh poll:", json.dumps(last, sort_keys=True), flush=True)
+    if failed > 0:
+      raise SystemExit(
+          "plane runtime refresh observed failed assignments; last="
+          + json.dumps(last, sort_keys=True)
+      )
+    if pending == 0 and ready:
+      raise SystemExit(0)
+    time.sleep(5)
+
+raise SystemExit(
+    "plane runtime refresh did not settle before timeout; last="
+    + json.dumps(last, sort_keys=True)
+)
+PY
+fi
 REMOTE


### PR DESCRIPTION
## Summary
- persist `interaction.image` in desired-state so release automation can pin the plane-local interaction runtime
- extend the main bootstrap release step to refresh managed runtime images for planes after hostd rollout
- restart running planes on the refreshed generation so active plane containers converge to the current release

## Why
The current production release flow updates control-plane services, hostd, and Knowledge Vault, but it does not refresh active plane runtime images.

That leaves running planes on stale `infer`/`worker`/`skills` images, and new plane-local services such as `interaction-runtime` still fall back to `naim/interaction-runtime:dev`.

In production this showed up immediately on `lt-cypher-ai`:
- `hostd` could not materialize the new interaction instance without a local `naim/interaction-runtime:dev`
- the plane stayed on old infer images, so TurboQuant and new runtime behavior did not converge to the release

## What this changes
After the existing hostd + Knowledge Vault rollout settles on `main`, the bootstrap script now:
1. scans controller `planes.desired_state_json`
2. updates managed NAIM runtime image refs from the release manifest
3. writes updated desired-state files
4. applies them through `naim-controller apply-state-file`
5. stop/starts running planes so the new generation is actually materialized
6. waits until plane assignments settle and `generation == applied_generation`

The update preserves custom non-NAIM images such as plane apps.

## Validation
- `bash -n scripts/ci/main-bootstrap-controller-update.sh`
- compiled all embedded Python blocks in `main-bootstrap-controller-update.sh`
- `clang++ -std=c++20 -fsyntax-only` for:
  - `common/src/state/state_json_settings_codecs.cpp`
  - `common/src/state/desired_state_sqlite_codec.cpp`
  - `common/src/state/desired_state_v2_renderer.cpp`
  - `common/src/state/desired_state_v2_projector.cpp`
  - `common/src/state/desired_state_v2_projector_tests.cpp`
- `git diff --check`

## Follow-up after merge
- rerun the full production release workflow on `main`
- verify that `lt-cypher-ai` converges onto the released `interaction-runtime`, `infer`, `worker`, and `skills` images before re-running the E2E chat test
