### PR TITLE
Fix interaction runtime shared control mount

### DIFF
--- a/common/include/naim/state/models.h
+++ b/common/include/naim/state/models.h
@@ -43,7 +43,8 @@ inline bool IsNodeLocalDiskKind(DiskKind kind) {
 inline bool InstanceNeedsSharedDiskMount(InstanceRole role) {
   return role == InstanceRole::Infer ||
          role == InstanceRole::Worker ||
-         role == InstanceRole::App;
+         role == InstanceRole::App ||
+         role == InstanceRole::Interaction;
 }
 
 inline bool InstanceNeedsPrivateDisk(InstanceRole role) {

--- a/common/src/state/desired_state_v2_projector_tests.cpp
+++ b/common/src/state/desired_state_v2_projector_tests.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -405,6 +406,36 @@ int main() {
             {"app", {{"enabled", false}}},
         },
         "interaction-image-override");
+
+    {
+      const auto rendered = naim::DesiredStateV2Renderer::Render(
+          json{
+              {"version", 2},
+              {"plane_name", "interaction-shared-disk"},
+              {"plane_mode", "llm"},
+              {"model",
+               {
+                   {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+                   {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+                   {"served_model_name", "qwen-interaction-shared"},
+               }},
+              {"runtime",
+               {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+              {"infer", {{"replicas", 1}}},
+              {"app", {{"enabled", false}}},
+          });
+      const auto interaction_it = std::find_if(
+          rendered.instances.begin(),
+          rendered.instances.end(),
+          [](const naim::InstanceSpec& instance) {
+            return instance.role == naim::InstanceRole::Interaction;
+          });
+      Expect(interaction_it != rendered.instances.end(),
+             "interaction-shared-disk: interaction instance missing");
+      Expect(interaction_it->shared_disk_name == rendered.plane_shared_disk_name,
+             "interaction-shared-disk: interaction instance must mount plane shared disk");
+      std::cout << "ok-roundtrip: interaction-shared-disk\n";
+    }
 
     ExpectRoundTrip(
         json{

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -987,6 +987,8 @@ void DesiredStateV2Renderer::RenderInteractionInstance() {
           : std::string("naim/interaction-runtime:dev");
   interaction.command = "/runtime/bin/naim-interactiond";
   interaction.private_disk_name = interaction.name + "-private";
+  interaction.shared_disk_name =
+      InstanceNeedsSharedDiskMount(interaction.role) ? state_.plane_shared_disk_name : "";
   interaction.private_disk_size_gb = kDefaultInteractionPrivateDiskSizeGb;
   interaction.depends_on.push_back(BuildInferInstanceName());
   interaction.environment = {


### PR DESCRIPTION
## Summary
- mount the plane shared disk for `interaction` instances so `NAIM_CONTROL_ROOT` resolves inside the container
- set `shared_disk_name` for rendered interaction instances in desired-state v2
- add a renderer regression check that interaction instances inherit the plane shared disk

## Validation
- `cmake --build build/linux/x64 --target naim-state-v2-projector-tests`
- `clang++ -std=c++20 -fsyntax-only common/src/state/desired_state_v2_renderer.cpp`
- `git diff --check`

## Notes
- `naim-state-v2-projector-tests` still has a pre-existing failure on `interaction-image-override`; this fix does not introduce that failure, but the target builds successfully.
