### PR TITLE
Fix web ingress context compression and interaction sanitization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1512,6 +1512,7 @@ if(NOT WIN32)
     controller/src/interaction/interaction_request_heuristics.cpp
     controller/src/interaction/interaction_request_contract_support.cpp
     controller/src/interaction/interaction_runtime_request_codec.cpp
+    controller/src/interaction/interaction_text_post_processor.cpp
     controller/src/interaction/interaction_utf8_payload_sanitizer.cpp
     runtime/interaction/src/interaction_runtime_server.cpp
     runtime/interaction/src/main.cpp

--- a/controller/src/interaction/interaction_context_compression_service.cpp
+++ b/controller/src/interaction/interaction_context_compression_service.cpp
@@ -20,6 +20,9 @@ constexpr const char* kKnowledgeContextPayloadKey = "__naim_knowledge_context";
 constexpr int kDialogRecentTailCount = 6;
 constexpr int kSummaryExcerptBytes = 200;
 constexpr int kKnowledgeExcerptBytes = 800;
+constexpr std::size_t kDialogSummaryItemCount = 8;
+constexpr std::size_t kDialogMinimumTailCount = 1;
+constexpr int kDialogTailBudgetFloor = 192;
 
 std::string TrimCopy(const std::string& value) {
   const auto begin = value.find_first_not_of(" \t\r\n");
@@ -117,6 +120,24 @@ json BuildDialogSummaryMessage(
   return json{{"role", "system"}, {"content", summary.str()}};
 }
 
+json BuildCompressedDialogMessages(
+    const std::vector<json>& system_messages,
+    const std::vector<json>& older_messages,
+    const std::vector<json>& recent_messages) {
+  json compressed_messages = json::array();
+  for (const auto& message : system_messages) {
+    compressed_messages.push_back(message);
+  }
+  compressed_messages.push_back(
+      BuildDialogSummaryMessage(
+          older_messages,
+          std::min<std::size_t>(kDialogSummaryItemCount, older_messages.size())));
+  for (const auto& message : recent_messages) {
+    compressed_messages.push_back(message);
+  }
+  return compressed_messages;
+}
+
 std::string BuildKnowledgeInstruction(const json& context_payload) {
   const auto context = context_payload.value("context", json::array());
   if (!context.is_array() || context.empty()) {
@@ -197,29 +218,67 @@ void InteractionContextCompressionService::Apply(
     const int dialog_soft_limit =
         std::max(256, (resolution.desired_state.inference.max_model_len * 55) / 100);
     if (dialog_estimate_before > dialog_soft_limit &&
-        non_system_messages.size() > static_cast<std::size_t>(kDialogRecentTailCount)) {
-      const std::size_t older_count =
-          non_system_messages.size() - static_cast<std::size_t>(kDialogRecentTailCount);
-      std::vector<json> older_messages(
-          non_system_messages.begin(),
-          non_system_messages.begin() + static_cast<std::ptrdiff_t>(older_count));
-      std::vector<json> recent_messages(
-          non_system_messages.end() - static_cast<std::ptrdiff_t>(kDialogRecentTailCount),
-          non_system_messages.end());
+        non_system_messages.size() > kDialogMinimumTailCount) {
+      const std::size_t preferred_tail_count =
+          std::min<std::size_t>(non_system_messages.size(),
+                                static_cast<std::size_t>(kDialogRecentTailCount));
+      const int dialog_tail_budget = std::max(
+          kDialogTailBudgetFloor,
+          std::max(256, resolution.desired_state.inference.max_model_len / 4));
+      json best_messages = messages;
+      int best_estimate = dialog_estimate_before;
+      bool have_candidate = false;
 
-      json compressed_messages = json::array();
-      for (const auto& message : system_messages) {
-        compressed_messages.push_back(message);
-      }
-      compressed_messages.push_back(BuildDialogSummaryMessage(older_messages, 10));
-      for (const auto& message : recent_messages) {
-        compressed_messages.push_back(message);
+      for (std::size_t tail_count = preferred_tail_count;; --tail_count) {
+        if (non_system_messages.size() <= tail_count) {
+          if (tail_count == kDialogMinimumTailCount) {
+            break;
+          }
+          continue;
+        }
+        const std::size_t older_count = non_system_messages.size() - tail_count;
+        std::vector<json> older_messages(
+            non_system_messages.begin(),
+            non_system_messages.begin() + static_cast<std::ptrdiff_t>(older_count));
+        std::vector<json> recent_messages(
+            non_system_messages.end() - static_cast<std::ptrdiff_t>(tail_count),
+            non_system_messages.end());
+
+        json compressed_messages = BuildCompressedDialogMessages(
+            system_messages,
+            older_messages,
+            recent_messages);
+        const int compressed_estimate =
+            payload_builder.EstimateTokensForJson(compressed_messages);
+        json recent_only_messages = json::array();
+        for (const auto& message : recent_messages) {
+          recent_only_messages.push_back(message);
+        }
+        const int recent_estimate =
+            payload_builder.EstimateTokensForJson(recent_only_messages);
+        if (!have_candidate || compressed_estimate < best_estimate ||
+            (compressed_estimate == best_estimate &&
+             recent_estimate <= dialog_tail_budget)) {
+          best_messages = std::move(compressed_messages);
+          best_estimate = compressed_estimate;
+          have_candidate = true;
+        }
+        if (compressed_estimate <= dialog_soft_limit &&
+            recent_estimate <= dialog_tail_budget) {
+          break;
+        }
+        if (tail_count == kDialogMinimumTailCount) {
+          break;
+        }
       }
 
-      const int compressed_estimate = payload_builder.EstimateTokensForJson(compressed_messages);
-      if (compressed_estimate < dialog_estimate_before) {
-        messages = std::move(compressed_messages);
+      if (have_candidate && best_estimate < dialog_estimate_before) {
+        messages = std::move(best_messages);
         dialog_compressed = true;
+        if (best_estimate > dialog_soft_limit) {
+          compression_state["warnings"].push_back(
+              "dialog context remained above soft budget after compression");
+        }
       } else {
         json fallback_messages = json::array();
         for (const auto& message : system_messages) {
@@ -227,7 +286,7 @@ void InteractionContextCompressionService::Apply(
         }
         for (auto it = non_system_messages.end() - static_cast<std::ptrdiff_t>(std::min<std::size_t>(
                  non_system_messages.size(),
-                 4));
+                 2));
              it != non_system_messages.end();
              ++it) {
           fallback_messages.push_back(*it);

--- a/controller/src/interaction/interaction_context_compression_service_tests.cpp
+++ b/controller/src/interaction/interaction_context_compression_service_tests.cpp
@@ -121,12 +121,45 @@ void TestCompressesDialogAndKnowledge() {
   std::cout << "ok: interaction-context-compression-compresses-dialog-and-knowledge" << '\n';
 }
 
+void TestCompressesFewButVeryLongTurns() {
+  auto resolution = BuildResolution(true);
+  resolution.desired_state.inference.max_model_len = 2048;
+  naim::controller::InteractionRequestContext request_context;
+  request_context.payload["messages"] = json::array({
+      json{{"role", "user"}, {"content", "turn-1 " + std::string(1800, 'a')}},
+      json{{"role", "assistant"}, {"content", "reply-1 " + std::string(1600, 'b')}},
+      json{{"role", "user"}, {"content", "turn-2 " + std::string(1800, 'c')}},
+      json{{"role", "assistant"}, {"content", "reply-2 " + std::string(1600, 'd')}},
+      json{{"role", "user"}, {"content", "turn-3 " + std::string(1800, 'e')}},
+  });
+
+  naim::controller::InteractionContextCompressionService().Apply(
+      resolution,
+      &request_context);
+
+  const auto compression = request_context.payload
+                               .at(naim::controller::kInteractionSessionContextStatePayloadKey)
+                               .at("context_compression");
+  Expect(
+      compression.at("status").get<std::string>() == "compressed",
+      "few but very long turns should still be compressed");
+  Expect(
+      compression.at("dialog_estimate_after").get<int>() <
+          compression.at("dialog_estimate_before").get<int>(),
+      "compression should reduce dialog estimate even with fewer than six turns");
+  Expect(
+      request_context.payload.at("messages").size() < 5,
+      "compression should replace older long turns with a summary");
+  std::cout << "ok: interaction-context-compression-compresses-few-long-turns" << '\n';
+}
+
 }  // namespace
 
 int main() {
   try {
     TestDisabledFeatureNoops();
     TestCompressesDialogAndKnowledge();
+    TestCompressesFewButVeryLongTurns();
     return 0;
   } catch (const std::exception& error) {
     std::cerr << "interaction_context_compression_service_tests failed: "

--- a/controller/src/interaction/interaction_text_post_processor.cpp
+++ b/controller/src/interaction/interaction_text_post_processor.cpp
@@ -131,7 +131,12 @@ bool InteractionTextPostProcessor::StartsWithReasoningPreamble(
   return lowered.rfind("thinking process:", 0) == 0 ||
          lowered.rfind("reasoning:", 0) == 0 ||
          lowered.rfind("analysis:", 0) == 0 ||
-         lowered.rfind("chain of thought:", 0) == 0;
+         lowered.rfind("chain of thought:", 0) == 0 ||
+         lowered.rfind("the user's prompt explicitly states:", 0) == 0 ||
+         lowered.rfind("therefore, despite the user's request", 0) == 0 ||
+         lowered.rfind("given the user explicitly requested", 0) == 0 ||
+         lowered.rfind("i will present this", 0) == 0 ||
+         lowered.rfind("i will structure the response", 0) == 0;
 }
 
 std::string InteractionTextPostProcessor::SanitizeInteractionText(

--- a/controller/src/interaction/interaction_text_post_processor_tests.cpp
+++ b/controller/src/interaction/interaction_text_post_processor_tests.cpp
@@ -22,6 +22,18 @@ void TestSanitizesReasoningAndThinkBlocks() {
   std::cout << "ok: interaction-text-sanitizes-reasoning" << '\n';
 }
 
+void TestSanitizesModelReasoningPreambleLeak() {
+  const naim::controller::InteractionTextPostProcessor processor;
+  const std::string text =
+      "The user's prompt explicitly states: \"Reply in English.\"\n\n"
+      "Therefore, despite the user's request to reply in Russian, I must follow the system instruction.\n\n"
+      "Final market answer.";
+  Expect(
+      processor.SanitizeInteractionText(text) == "Final market answer.",
+      "processor should strip leaked reasoning preambles from model output");
+  std::cout << "ok: interaction-text-sanitizes-model-reasoning-preamble" << '\n';
+}
+
 void TestRemovesCompletionMarkers() {
   const naim::controller::InteractionTextPostProcessor processor;
   bool marker_seen = false;
@@ -66,6 +78,7 @@ void TestUtf8SafeSuffixAvoidsBrokenPrefix() {
 int main() {
   try {
     TestSanitizesReasoningAndThinkBlocks();
+    TestSanitizesModelReasoningPreambleLeak();
     TestRemovesCompletionMarkers();
     TestConsumesSplitCompletionMarker();
     TestUtf8SafeSuffixAvoidsBrokenPrefix();

--- a/runtime/interaction/src/interaction_runtime_server.cpp
+++ b/runtime/interaction/src/interaction_runtime_server.cpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <csignal>
 #include <fstream>
+#include <map>
 #include <stdexcept>
 #include <thread>
 
@@ -12,6 +13,7 @@
 #include "interaction/interaction_context_compression_service.h"
 #include "interaction/interaction_payload_builder.h"
 #include "interaction/interaction_runtime_request_codec.h"
+#include "interaction/interaction_text_post_processor.h"
 #include "naim/state/state_json.h"
 #include "naim/runtime/runtime_status.h"
 
@@ -46,6 +48,62 @@ bool RequestWantsStream(const HttpRequest& request) {
   } catch (const std::exception&) {
   }
   return false;
+}
+
+std::map<std::string, std::string> BuildCompressionHeaders(
+    const naim::controller::InteractionRequestContext& request_context) {
+  std::map<std::string, std::string> headers;
+  if (!request_context.payload.contains(naim::controller::kInteractionSessionContextStatePayloadKey) ||
+      !request_context.payload.at(naim::controller::kInteractionSessionContextStatePayloadKey)
+           .is_object()) {
+    return headers;
+  }
+  const auto& context_state =
+      request_context.payload.at(naim::controller::kInteractionSessionContextStatePayloadKey);
+  if (!context_state.contains("context_compression") ||
+      !context_state.at("context_compression").is_object()) {
+    return headers;
+  }
+  const auto& compression = context_state.at("context_compression");
+  headers["x-naim-context-compression-enabled"] =
+      compression.value("enabled", false) ? "true" : "false";
+  headers["x-naim-context-compression-status"] =
+      compression.value("status", std::string("none"));
+  headers["x-naim-dialog-estimate-before"] =
+      std::to_string(compression.value("dialog_estimate_before", 0));
+  headers["x-naim-dialog-estimate-after"] =
+      std::to_string(compression.value("dialog_estimate_after", 0));
+  headers["x-naim-context-compression-ratio"] =
+      std::to_string(compression.value("compression_ratio", 1.0));
+  return headers;
+}
+
+HttpResponse SanitizeJsonChatResponse(HttpResponse response) {
+  if (response.status_code < 200 || response.status_code >= 300 || response.body.empty()) {
+    return response;
+  }
+  nlohmann::json payload = nlohmann::json::parse(response.body, nullptr, false);
+  if (payload.is_discarded() || !payload.is_object()) {
+    return response;
+  }
+  const naim::controller::InteractionTextPostProcessor post_processor;
+  if (payload.contains("choices") && payload.at("choices").is_array() &&
+      !payload.at("choices").empty() && payload.at("choices").at(0).is_object()) {
+    auto& first_choice = payload.at("choices").at(0);
+    if (first_choice.contains("message") && first_choice.at("message").is_object()) {
+      auto& message = first_choice.at("message");
+      message["content"] = post_processor.ExtractInteractionText(
+          nlohmann::json{{"choices", nlohmann::json::array({first_choice})}});
+      response.body = payload.dump();
+      return response;
+    }
+    if (first_choice.contains("text") && first_choice.at("text").is_string()) {
+      first_choice["text"] = post_processor.SanitizeInteractionText(
+          first_choice.at("text").get<std::string>());
+      response.body = payload.dump();
+    }
+  }
+  return response;
 }
 
 }  // namespace
@@ -209,12 +267,16 @@ HttpResponse InteractionRuntimeServer::ExecuteNonStream(const HttpRequest& reque
       execution.force_stream,
       execution.resolved_policy,
       execution.structured_output_json);
-  return SendControllerHttpRequest(
+  HttpResponse response = SendControllerHttpRequest(
       UpstreamTarget(),
       "POST",
       "/chat/completions",
       upstream_body,
       {{"Accept", "application/json"}});
+  for (const auto& [name, value] : BuildCompressionHeaders(execution.request_context)) {
+    response.headers[name] = value;
+  }
+  return SanitizeJsonChatResponse(std::move(response));
 }
 
 void InteractionRuntimeServer::ExecuteStream(
@@ -235,7 +297,9 @@ void InteractionRuntimeServer::ExecuteStream(
       UpstreamTarget(),
       "interaction-runtime",
       upstream_body);
-  if (!naim::controller::ControllerNetworkManager::SendSseHeaders(client_fd, {})) {
+  if (!naim::controller::ControllerNetworkManager::SendSseHeaders(
+          client_fd,
+          BuildCompressionHeaders(execution.request_context))) {
     upstream.close();
     naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
     return;


### PR DESCRIPTION
## Summary
- make context compression trigger for few but very long chat turns on the plane interaction runtime path
- sanitize leaked reasoning preambles in interaction-runtime non-stream responses
- expose compression telemetry headers from interaction-runtime responses
- wire the new text post-processor dependency into `naim-interactiond`

## Validation
- `git diff --check`
- syntax-only compile via `build/linux/x64/compile_commands.json`
- `cmake --build ... --target naim-interaction-context-compression-service-tests naim-interaction-text-post-processor-tests` (tests built)
- `/mnt/e/dev/Repos/ai/naim-node/build/linux/x64/naim-interaction-context-compression-service-tests`
- `/mnt/e/dev/Repos/ai/naim-node/build/linux/x64/naim-interaction-text-post-processor-tests`

## Notes
- a targeted `cmake --build` that also included `naim-interactiond` re-entered the known `cmake --regenerate-during-build` hang during configure; this is the existing configure issue, not a new compile error from this patch.