### PR TITLE
Preserve interaction runtime image in plane editor

### DIFF
--- a/ui/operator-react/src/planeV2Form.jsx
+++ b/ui/operator-react/src/planeV2Form.jsx
@@ -498,6 +498,7 @@ export function buildNewPlaneFormState() {
     modelSha256: "",
     systemPrompt:
       "You are a helpful AI assistant. Reply clearly, concisely, and follow the user's instructions.",
+    interactionImage: "",
     thinkingEnabled: false,
     defaultResponseLanguage: "ru",
     followUserLanguage: true,
@@ -650,6 +651,7 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
     modelTargetFilename: value?.model?.target_filename || "",
     modelSha256: value?.model?.sha256 || "",
     systemPrompt: value?.interaction?.system_prompt || defaults.systemPrompt,
+    interactionImage: value?.interaction?.image || "",
     thinkingEnabled:
       value?.interaction?.thinking_enabled ?? defaults.thinkingEnabled,
     defaultResponseLanguage:
@@ -905,6 +907,9 @@ export function buildDesiredStateV2FromForm(form) {
       supported_response_languages: DEFAULT_SUPPORTED_RESPONSE_LANGUAGES,
       follow_user_language: Boolean(form.followUserLanguage),
     };
+    if (String(form.interactionImage || "").trim()) {
+      desiredState.interaction.image = String(form.interactionImage || "").trim();
+    }
     desiredState.infer = {
       replicas: parseNumber(form.inferReplicas, 1),
     };

--- a/ui/operator-react/src/skillsFactory.test.js
+++ b/ui/operator-react/src/skillsFactory.test.js
@@ -242,6 +242,32 @@ describe("planeV2Form SkillsFactory mapping", () => {
     expect(reparsed.contextCompressionMemoryPriority).toBe("balanced");
   });
 
+  it("preserves interaction runtime image through desired state v2 round-trip", () => {
+    const desiredState = {
+      ...buildDesiredStateV2FromForm(buildNewPlaneFormState()),
+      plane_name: "interaction-image-plane",
+      model: {
+        source: { type: "library", ref: "Qwen/Qwen3.6-35B-A3B" },
+        materialization: { mode: "prepare_on_worker" },
+        served_model_name: "interaction-image-plane",
+      },
+      interaction: {
+        image: "chainzano.com/naim/interaction-runtime@sha256:feedface",
+        system_prompt: "Preserve interaction image",
+        thinking_enabled: false,
+        default_response_language: "ru",
+        supported_response_languages: ["en", "de", "uk", "ru"],
+        follow_user_language: true,
+      },
+    };
+
+    const reparsed = buildPlaneFormStateFromDesiredStateV2(desiredState);
+    const rebuilt = buildDesiredStateV2FromForm(reparsed);
+    expect(rebuilt.interaction.image).toBe(
+      "chainzano.com/naim/interaction-runtime@sha256:feedface",
+    );
+  });
+
   it("round-trips multiple feature toggles through desired state v2", () => {
     const form = buildNewPlaneFormState();
     form.planeName = "combined-feature-plane";


### PR DESCRIPTION
## Summary
- preserve `interaction.image` when editing a plane through the operator UI
- round-trip the managed interaction runtime image through desired-state v2 form mapping
- add a regression test so plane saves do not fall back to `naim/interaction-runtime:dev`

## Testing
- `cd ui/operator-react && npx vitest run src/skillsFactory.test.js`
- `git diff --check`
