### PR TITLE
Parse interaction runtime image from desired state v2

### DIFF
--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -381,6 +381,9 @@ void DesiredStateV2Renderer::RenderInteraction() {
 
   InteractionSettings interaction;
   const auto& interaction_json = value_.at("interaction");
+  if (interaction_json.contains("image") && interaction_json.at("image").is_string()) {
+    interaction.image = interaction_json.at("image").get<std::string>();
+  }
   if (interaction_json.contains("system_prompt") && interaction_json.at("system_prompt").is_string()) {
     interaction.system_prompt = interaction_json.at("system_prompt").get<std::string>();
   }


### PR DESCRIPTION
## Summary
- parse `interaction.image` in the desired-state v2 renderer
- keep interaction runtime image through `apply-state-file` and persisted plane state
- fix the release refresh path so planes stop falling back to `naim/interaction-runtime:dev`

## Testing
- `git diff --check`
- `cmake --build build/linux/x64 --target naim-state-v2-projector-tests`
- `./build/linux/x64/naim-state-v2-projector-tests`
