### PR TITLE
Fix web ingress interaction session persistence

### DIFF
--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -381,6 +381,9 @@ void DesiredStateV2Renderer::RenderInteraction() {
 
   InteractionSettings interaction;
   const auto& interaction_json = value_.at("interaction");
+  if (interaction_json.contains("image") && interaction_json.at("image").is_string()) {
+    interaction.image = interaction_json.at("image").get<std::string>();
+  }
   if (interaction_json.contains("system_prompt") && interaction_json.at("system_prompt").is_string()) {
     interaction.system_prompt = interaction_json.at("system_prompt").get<std::string>();
   }

--- a/controller/include/http/controller_http_transport.h
+++ b/controller/include/http/controller_http_transport.h
@@ -35,4 +35,6 @@ naim::controller::InteractionStreamingUpstreamConnection
 OpenInteractionStreamRequest(
     const naim::controller::ControllerEndpointTarget& target,
     const std::string& request_id,
-    const std::string& body);
+    const std::string& body,
+    const std::string& path_and_query = "/v1/chat/completions",
+    const std::vector<std::pair<std::string, std::string>>& headers = {});

--- a/controller/include/interaction/interaction_types.h
+++ b/controller/include/interaction/interaction_types.h
@@ -90,6 +90,11 @@ struct StreamedInteractionSegmentResult {
   InteractionSegmentSummary summary;
   std::string model;
   std::string cleaned_text;
+  bool context_compression_enabled = false;
+  std::string context_compression_status = "none";
+  int dialog_estimate_before = 0;
+  int dialog_estimate_after = 0;
+  double context_compression_ratio = 1.0;
 };
 
 struct InteractionSessionResult {
@@ -106,6 +111,11 @@ struct InteractionSessionResult {
   std::string stop_reason;
   std::string final_finish_reason = "stop";
   bool marker_seen = false;
+  bool context_compression_enabled = false;
+  std::string context_compression_status = "none";
+  int dialog_estimate_before = 0;
+  int dialog_estimate_after = 0;
+  double context_compression_ratio = 1.0;
 };
 
 struct InteractionRequestContext {
@@ -167,6 +177,7 @@ struct InteractionStreamResolutionResult {
 
 struct InteractionStreamingUpstreamConnection {
   bool chunked_transfer = false;
+  std::map<std::string, std::string> headers;
   std::string initial_body;
   std::function<std::string()> read_next_chunk;
   std::function<void()> close;

--- a/controller/src/http/controller_http_transport.cpp
+++ b/controller/src/http/controller_http_transport.cpp
@@ -250,7 +250,9 @@ naim::controller::InteractionStreamingUpstreamConnection
 OpenInteractionStreamRequest(
     const naim::controller::ControllerEndpointTarget& target,
     const std::string& request_id,
-    const std::string& body) {
+    const std::string& body,
+    const std::string& path_and_query,
+    const std::vector<std::pair<std::string, std::string>>& headers) {
   auto fd = std::make_shared<SocketHandle>(ConnectHttpTarget(target));
   const auto close_transport = [fd]() {
     if (naim::platform::IsSocketValid(*fd)) {
@@ -260,16 +262,23 @@ OpenInteractionStreamRequest(
   };
 
   try {
-    const std::string request_path =
-        target.base_path.empty() ? "/v1/chat/completions"
-                                 : target.base_path + "/chat/completions";
+    const std::string request_path = target.base_path + path_and_query;
     std::ostringstream upstream_request;
     upstream_request << "POST " << request_path << " HTTP/1.1\r\n";
     upstream_request << "Host: " << target.host << ":" << target.port << "\r\n";
     upstream_request << "Connection: close\r\n";
     upstream_request << "Accept: text/event-stream\r\n";
     upstream_request << "X-Naim-Request-Id: " << request_id << "\r\n";
-    upstream_request << "Content-Type: application/json\r\n";
+    bool content_type_written = false;
+    for (const auto& [key, value] : headers) {
+      upstream_request << key << ": " << value << "\r\n";
+      if (LowercaseCopy(key) == "content-type") {
+        content_type_written = true;
+      }
+    }
+    if (!content_type_written) {
+      upstream_request << "Content-Type: application/json\r\n";
+    }
     upstream_request << "Content-Length: " << body.size() << "\r\n\r\n";
     upstream_request << body;
     if (!ControllerNetworkManager::SendAll(*fd, upstream_request.str())) {
@@ -317,6 +326,7 @@ OpenInteractionStreamRequest(
 
     return naim::controller::InteractionStreamingUpstreamConnection{
         chunked_transfer,
+        upstream.headers,
         std::move(upstream.body),
         [fd]() -> std::string {
           std::array<char, 8192> buffer{};

--- a/controller/src/interaction/interaction_conversation_service.cpp
+++ b/controller/src/interaction/interaction_conversation_service.cpp
@@ -200,6 +200,15 @@ std::optional<InteractionValidationError> InteractionConversationService::Persis
                                    .is_object()
                            ? context->payload.at(kInteractionSessionContextStatePayloadKey)
                            : context->session_context_state;
+  context_state["context_compression"] = json{
+      {"enabled", result.context_compression_enabled},
+      {"status", result.context_compression_status},
+      {"dialog_estimate_before", result.dialog_estimate_before},
+      {"dialog_estimate_after", result.dialog_estimate_after},
+      {"compression_ratio", result.context_compression_ratio},
+      {"compressor_id", "context-compression-v1"},
+      {"policy_version", "v1"},
+  };
   json applied_skill_ids = json::array();
   if (context->payload.contains(PlaneSkillsService::kAppliedSkillsPayloadKey) &&
       context->payload.at(PlaneSkillsService::kAppliedSkillsPayloadKey).is_array()) {

--- a/controller/src/interaction/interaction_http_service.cpp
+++ b/controller/src/interaction/interaction_http_service.cpp
@@ -64,6 +64,21 @@ std::string BuildKnowledgeInstruction(const nlohmann::json& context_payload) {
   return instruction;
 }
 
+std::map<std::string, std::string> BuildCompressionHeaders(
+    const naim::controller::InteractionSessionResult& result) {
+  return {
+      {"x-naim-context-compression-enabled",
+       result.context_compression_enabled ? "true" : "false"},
+      {"x-naim-context-compression-status", result.context_compression_status},
+      {"x-naim-dialog-estimate-before",
+       std::to_string(result.dialog_estimate_before)},
+      {"x-naim-dialog-estimate-after",
+       std::to_string(result.dialog_estimate_after)},
+      {"x-naim-context-compression-ratio",
+       std::to_string(result.context_compression_ratio)},
+  };
+}
+
 }  // namespace
 
 InteractionHttpService::InteractionHttpService(InteractionHttpSupport support)
@@ -172,11 +187,16 @@ HttpResponse InteractionHttpService::BuildSessionResponse(
       &reviewed_result);
   const auto response_spec =
       presenter.BuildResponseSpec(resolution, request_context, reviewed_result);
+  auto headers =
+      naim::controller::InteractionRequestContractSupport{}
+          .BuildInteractionResponseHeaders(request_context.request_id);
+  for (const auto& [name, value] : BuildCompressionHeaders(reviewed_result)) {
+    headers[name] = value;
+  }
   return support_.BuildJsonResponse(
       response_spec.status_code,
       response_spec.payload,
-      naim::controller::InteractionRequestContractSupport{}
-          .BuildInteractionResponseHeaders(request_context.request_id));
+      headers);
 }
 
 HttpResponse InteractionHttpService::ProxyJson(

--- a/controller/src/interaction/interaction_service.cpp
+++ b/controller/src/interaction/interaction_service.cpp
@@ -22,6 +22,56 @@
 
 namespace naim::controller {
 
+namespace {
+
+std::optional<std::string> FindHeaderValue(
+    const std::map<std::string, std::string>& headers,
+    const std::string& key) {
+  const auto it = headers.find(key);
+  if (it == headers.end() || it->second.empty()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+bool ParseBoolHeader(
+    const std::map<std::string, std::string>& headers,
+    const std::string& key,
+    bool fallback) {
+  if (const auto value = FindHeaderValue(headers, key); value.has_value()) {
+    return *value == "true" || *value == "1";
+  }
+  return fallback;
+}
+
+int ParseIntHeader(
+    const std::map<std::string, std::string>& headers,
+    const std::string& key,
+    int fallback) {
+  if (const auto value = FindHeaderValue(headers, key); value.has_value()) {
+    try {
+      return std::stoi(*value);
+    } catch (const std::exception&) {
+    }
+  }
+  return fallback;
+}
+
+double ParseDoubleHeader(
+    const std::map<std::string, std::string>& headers,
+    const std::string& key,
+    double fallback) {
+  if (const auto value = FindHeaderValue(headers, key); value.has_value()) {
+    try {
+      return std::stod(*value);
+    } catch (const std::exception&) {
+    }
+  }
+  return fallback;
+}
+
+}  // namespace
+
 nlohmann::json InteractionRequestValidator::ParsePayload(
     const std::string& body) const {
   return body.empty() ? nlohmann::json::object() : nlohmann::json::parse(body);
@@ -680,6 +730,18 @@ InteractionSessionResult InteractionSessionExecutor::Execute(
             .count());
     result.final_finish_reason = summary.finish_reason;
     result.marker_seen = result.marker_seen || marker_seen_in_segment;
+    result.context_compression_enabled = ParseBoolHeader(
+        upstream.headers, "x-naim-context-compression-enabled", false);
+    result.context_compression_status = FindHeaderValue(
+                                            upstream.headers,
+                                            "x-naim-context-compression-status")
+                                            .value_or("none");
+    result.dialog_estimate_before = ParseIntHeader(
+        upstream.headers, "x-naim-dialog-estimate-before", 0);
+    result.dialog_estimate_after = ParseIntHeader(
+        upstream.headers, "x-naim-dialog-estimate-after", 0);
+    result.context_compression_ratio = ParseDoubleHeader(
+        upstream.headers, "x-naim-context-compression-ratio", 1.0);
 
     if (result.marker_seen &&
         session_reached_target_length_(policy, result.total_completion_tokens)) {
@@ -1082,6 +1144,11 @@ InteractionSessionResult InteractionStreamSessionExecutor::Execute(
               .count());
       session.final_finish_reason = segment.summary.finish_reason;
       session.marker_seen = session.marker_seen || segment.summary.marker_seen;
+      session.context_compression_enabled = segment.context_compression_enabled;
+      session.context_compression_status = segment.context_compression_status;
+      session.dialog_estimate_before = segment.dialog_estimate_before;
+      session.dialog_estimate_after = segment.dialog_estimate_after;
+      session.context_compression_ratio = segment.context_compression_ratio;
 
       if (!send_event(
               "segment_complete",
@@ -1344,8 +1411,24 @@ StreamedInteractionSegmentResult InteractionStreamSegmentExecutor::Execute(
     if (fallback.status_code != 200 || fallback.body.empty()) {
       return std::nullopt;
     }
-    return flush_fallback_response(
-        nlohmann::json::parse(fallback.body), assign_only);
+    auto fallback_result =
+        flush_fallback_response(nlohmann::json::parse(fallback.body), assign_only);
+    if (!fallback_result.has_value()) {
+      return std::nullopt;
+    }
+    fallback_result->context_compression_enabled = ParseBoolHeader(
+        fallback.headers, "x-naim-context-compression-enabled", false);
+    fallback_result->context_compression_status = FindHeaderValue(
+                                                      fallback.headers,
+                                                      "x-naim-context-compression-status")
+                                                      .value_or("none");
+    fallback_result->dialog_estimate_before = ParseIntHeader(
+        fallback.headers, "x-naim-dialog-estimate-before", 0);
+    fallback_result->dialog_estimate_after = ParseIntHeader(
+        fallback.headers, "x-naim-dialog-estimate-after", 0);
+    fallback_result->context_compression_ratio = ParseDoubleHeader(
+        fallback.headers, "x-naim-context-compression-ratio", 1.0);
+    return fallback_result;
   };
 
   try {
@@ -1359,6 +1442,18 @@ StreamedInteractionSegmentResult InteractionStreamSegmentExecutor::Execute(
                 true,
                 resolved_policy,
                 request_context.structured_output_json));
+    result.context_compression_enabled = ParseBoolHeader(
+        stream.headers, "x-naim-context-compression-enabled", false);
+    result.context_compression_status = FindHeaderValue(
+                                            stream.headers,
+                                            "x-naim-context-compression-status")
+                                            .value_or("none");
+    result.dialog_estimate_before = ParseIntHeader(
+        stream.headers, "x-naim-dialog-estimate-before", 0);
+    result.dialog_estimate_after = ParseIntHeader(
+        stream.headers, "x-naim-dialog-estimate-after", 0);
+    result.context_compression_ratio = ParseDoubleHeader(
+        stream.headers, "x-naim-context-compression-ratio", 1.0);
     const auto close_stream = [&]() {
       if (stream.close) {
         stream.close();

--- a/controller/src/interaction/interaction_text_post_processor.cpp
+++ b/controller/src/interaction/interaction_text_post_processor.cpp
@@ -142,6 +142,7 @@ bool InteractionTextPostProcessor::StartsWithReasoningPreamble(
 std::string InteractionTextPostProcessor::SanitizeInteractionText(
     std::string text) const {
   text = RemoveThinkBlocks(std::move(text));
+  text = RemoveCompletionMarkers(text, "[[TASK_COMPLETE]]", nullptr);
   text = TrimCopy(text);
   if (StartsWithReasoningPreamble(text)) {
     const auto paragraphs = SplitParagraphs(text);

--- a/controller/src/interaction/interaction_text_post_processor_tests.cpp
+++ b/controller/src/interaction/interaction_text_post_processor_tests.cpp
@@ -46,6 +46,14 @@ void TestRemovesCompletionMarkers() {
   std::cout << "ok: interaction-text-removes-markers" << '\n';
 }
 
+void TestSanitizesBareCompletionMarker() {
+  const naim::controller::InteractionTextPostProcessor processor;
+  Expect(
+      processor.SanitizeInteractionText("[[TASK_COMPLETE]]").empty(),
+      "processor should strip a bare completion marker from visible text");
+  std::cout << "ok: interaction-text-sanitizes-bare-marker" << '\n';
+}
+
 void TestConsumesSplitCompletionMarker() {
   const naim::controller::InteractionTextPostProcessor processor;
   naim::controller::CompletionMarkerFilterState state;
@@ -80,6 +88,7 @@ int main() {
     TestSanitizesReasoningAndThinkBlocks();
     TestSanitizesModelReasoningPreambleLeak();
     TestRemovesCompletionMarkers();
+    TestSanitizesBareCompletionMarker();
     TestConsumesSplitCompletionMarker();
     TestUtf8SafeSuffixAvoidsBrokenPrefix();
     return 0;

--- a/runtime/interaction/include/interaction/interaction_runtime_server.h
+++ b/runtime/interaction/include/interaction/interaction_runtime_server.h
@@ -51,6 +51,14 @@ class InteractionRuntimeServer final {
   HttpResponse HandlePost(const HttpRequest& request);
   HttpResponse ExecuteNonStream(const HttpRequest& request);
   void ExecuteStream(naim::platform::SocketHandle client_fd, const HttpRequest& request);
+  bool ShouldProxyRawRequestThroughController(const HttpRequest& request) const;
+  HttpResponse ProxyRawRequestThroughController(
+      const HttpRequest& request,
+      const std::string& controller_path) const;
+  void ProxyRawStreamThroughController(
+      naim::platform::SocketHandle client_fd,
+      const HttpRequest& request,
+      const std::string& controller_path) const;
   RuntimeExecution BuildRuntimeExecution(const HttpRequest& request) const;
   std::optional<RuntimeExecution> TryBuildWrappedRuntimeExecution(
       const std::string& body) const;

--- a/runtime/interaction/src/interaction_runtime_server.cpp
+++ b/runtime/interaction/src/interaction_runtime_server.cpp
@@ -1,6 +1,7 @@
 #include "interaction/interaction_runtime_server.h"
 
 #include <array>
+#include <cctype>
 #include <csignal>
 #include <fstream>
 #include <map>
@@ -29,6 +30,13 @@ void SignalHandler(int) {
   }
 }
 
+std::string LowercaseCopy(std::string value) {
+  for (char& ch : value) {
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  }
+  return value;
+}
+
 bool RequestWantsStream(const HttpRequest& request) {
   if (request.path == "/v1/chat/completions/stream") {
     return true;
@@ -48,6 +56,16 @@ bool RequestWantsStream(const HttpRequest& request) {
   } catch (const std::exception&) {
   }
   return false;
+}
+
+std::optional<std::string> FindRequestHeader(
+    const HttpRequest& request,
+    const std::string& key) {
+  const auto it = request.headers.find(LowercaseCopy(key));
+  if (it == request.headers.end() || it->second.empty()) {
+    return std::nullopt;
+  }
+  return it->second;
 }
 
 std::map<std::string, std::string> BuildCompressionHeaders(
@@ -257,6 +275,11 @@ HttpResponse InteractionRuntimeServer::HandlePost(const HttpRequest& request) {
 }
 
 HttpResponse InteractionRuntimeServer::ExecuteNonStream(const HttpRequest& request) {
+  if (ShouldProxyRawRequestThroughController(request)) {
+    return ProxyRawRequestThroughController(
+        request,
+        "/api/v1/planes/" + config_.plane_name + "/interaction/chat/completions");
+  }
   auto execution = BuildRuntimeExecution(request);
   naim::controller::InteractionContextCompressionService().Apply(
       execution.resolution,
@@ -282,6 +305,13 @@ HttpResponse InteractionRuntimeServer::ExecuteNonStream(const HttpRequest& reque
 void InteractionRuntimeServer::ExecuteStream(
     naim::platform::SocketHandle client_fd,
     const HttpRequest& request) {
+  if (ShouldProxyRawRequestThroughController(request)) {
+    ProxyRawStreamThroughController(
+        client_fd,
+        request,
+        "/api/v1/planes/" + config_.plane_name + "/interaction/chat/completions/stream");
+    return;
+  }
   auto execution = BuildRuntimeExecution(request);
   execution.force_stream = true;
   naim::controller::InteractionContextCompressionService().Apply(
@@ -300,6 +330,81 @@ void InteractionRuntimeServer::ExecuteStream(
   if (!naim::controller::ControllerNetworkManager::SendSseHeaders(
           client_fd,
           BuildCompressionHeaders(execution.request_context))) {
+    upstream.close();
+    naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+    return;
+  }
+  if (!upstream.initial_body.empty() &&
+      !naim::controller::ControllerNetworkManager::SendAll(client_fd, upstream.initial_body)) {
+    upstream.close();
+    naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+    return;
+  }
+  while (true) {
+    const std::string chunk = upstream.read_next_chunk();
+    if (chunk.empty()) {
+      break;
+    }
+    if (!naim::controller::ControllerNetworkManager::SendAll(client_fd, chunk)) {
+      break;
+    }
+  }
+  upstream.close();
+  naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+}
+
+bool InteractionRuntimeServer::ShouldProxyRawRequestThroughController(
+    const HttpRequest& request) const {
+  if (TryBuildWrappedRuntimeExecution(request.body).has_value()) {
+    return false;
+  }
+  return FindRequestHeader(request, "x-naim-session-token").has_value();
+}
+
+HttpResponse InteractionRuntimeServer::ProxyRawRequestThroughController(
+    const HttpRequest& request,
+    const std::string& controller_path) const {
+  std::vector<std::pair<std::string, std::string>> headers{
+      {"Accept", "application/json"},
+      {"Content-Type", "application/json"},
+  };
+  if (const auto token = FindRequestHeader(request, "x-naim-session-token");
+      token.has_value()) {
+    headers.emplace_back("X-Naim-Session-Token", *token);
+  }
+  if (const auto request_id = FindRequestHeader(request, "x-naim-request-id");
+      request_id.has_value()) {
+    headers.emplace_back("X-Naim-Request-Id", *request_id);
+  }
+  return SendControllerHttpRequest(
+      ParseControllerEndpointTarget(config_.controller_url),
+      "POST",
+      controller_path,
+      request.body,
+      headers);
+}
+
+void InteractionRuntimeServer::ProxyRawStreamThroughController(
+    naim::platform::SocketHandle client_fd,
+    const HttpRequest& request,
+    const std::string& controller_path) const {
+  std::vector<std::pair<std::string, std::string>> headers{
+      {"Accept", "text/event-stream"},
+      {"Content-Type", "application/json"},
+  };
+  const std::string request_id =
+      FindRequestHeader(request, "x-naim-request-id").value_or("interaction-runtime");
+  if (const auto token = FindRequestHeader(request, "x-naim-session-token");
+      token.has_value()) {
+    headers.emplace_back("X-Naim-Session-Token", *token);
+  }
+  auto upstream = OpenInteractionStreamRequest(
+      ParseControllerEndpointTarget(config_.controller_url),
+      request_id,
+      request.body,
+      controller_path,
+      headers);
+  if (!naim::controller::ControllerNetworkManager::SendSseHeaders(client_fd, {})) {
     upstream.close();
     naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
     return;


### PR DESCRIPTION
## Summary
- strip bare `[[TASK_COMPLETE]]` markers from interaction text before it reaches users
- preserve context-compression metadata through controller-managed session persistence, including streamed requests
- proxy raw web-ingress chat traffic through the controller interaction session flow when an internal NAIM session token is available

## Verification
- `git diff --check`
- `node --check lib/server/http.js`
- `node --test test/market-skills.test.js test/actions.test.js`
- `cmake --build build/linux/x64 --target naim-interaction-text-post-processor-tests`
- `./build/linux/x64/naim-interaction-text-post-processor-tests`
- `./build/linux/x64/naim-interaction-http-support-tests`
- `python3` compile-commands `-fsyntax-only` check for `runtime/interaction/src/interaction_runtime_server.cpp`
