### PR TITLE
Proxy raw interaction web ingress through controller

### DIFF
--- a/runtime/interaction/src/interaction_runtime_server.cpp
+++ b/runtime/interaction/src/interaction_runtime_server.cpp
@@ -358,7 +358,7 @@ bool InteractionRuntimeServer::ShouldProxyRawRequestThroughController(
   if (TryBuildWrappedRuntimeExecution(request.body).has_value()) {
     return false;
   }
-  return FindRequestHeader(request, "x-naim-session-token").has_value();
+  return !config_.controller_url.empty();
 }
 
 HttpResponse InteractionRuntimeServer::ProxyRawRequestThroughController(


### PR DESCRIPTION
## Summary
- proxy raw interaction-runtime web ingress requests through controller whenever a controller endpoint is configured
- keep wrapped runtime requests executing locally inside interaction-runtime
- ensure unprotected planes persist anonymous interaction sessions and compression telemetry via the canonical controller path

## Verification
- `git diff --check`
- syntax-only compile for `runtime/interaction/src/interaction_runtime_server.cpp` via `build/linux/x64/compile_commands.json`
