### PR TITLE
Normalize interaction usage accounting

### DIFF
--- a/controller/src/interaction/interaction_conversation_service.cpp
+++ b/controller/src/interaction/interaction_conversation_service.cpp
@@ -16,6 +16,17 @@ namespace naim::controller {
 
 using nlohmann::json;
 
+namespace {
+
+int EffectivePromptTokens(const InteractionSessionResult& result) {
+  if (!result.segments.empty()) {
+    return result.segments.back().prompt_tokens;
+  }
+  return result.total_prompt_tokens;
+}
+
+}  // namespace
+
 std::optional<InteractionValidationError> InteractionConversationService::PrepareRequest(
     const std::string& db_path,
     const PlaneInteractionResolution& resolution,
@@ -240,7 +251,7 @@ std::optional<InteractionValidationError> InteractionConversationService::Persis
   updated.archive_codec = session.has_value() ? session->archive_codec : "";
   updated.archive_sha256 = session.has_value() ? session->archive_sha256 : "";
   updated.context_state_json = payload_builder.JsonString(context_state);
-  updated.latest_prompt_tokens = result.total_prompt_tokens;
+  updated.latest_prompt_tokens = EffectivePromptTokens(result);
   updated.estimated_context_tokens =
       payload_builder.EstimateTokensForJson(
           context->payload.value("messages", json::array()));

--- a/controller/src/interaction/interaction_service.cpp
+++ b/controller/src/interaction/interaction_service.cpp
@@ -70,6 +70,18 @@ double ParseDoubleHeader(
   return fallback;
 }
 
+naim::controller::InteractionSegmentSummary EffectiveSegmentUsage(
+    const naim::controller::InteractionSessionResult& result) {
+  if (!result.segments.empty()) {
+    return result.segments.back();
+  }
+  naim::controller::InteractionSegmentSummary summary;
+  summary.prompt_tokens = result.total_prompt_tokens;
+  summary.completion_tokens = result.total_completion_tokens;
+  summary.total_tokens = result.total_tokens;
+  return summary;
+}
+
 }  // namespace
 
 nlohmann::json InteractionRequestValidator::ParsePayload(
@@ -212,6 +224,7 @@ InteractionRequestValidator::ValidateAndNormalizeRequest(
 
 nlohmann::json InteractionSessionPresenter::BuildSessionPayload(
     const InteractionSessionResult& result) const {
+  const InteractionSegmentSummary effective_usage = EffectiveSegmentUsage(result);
   nlohmann::json segments = nlohmann::json::array();
   for (const auto& segment : result.segments) {
     segments.push_back(nlohmann::json{
@@ -236,6 +249,12 @@ nlohmann::json InteractionSessionPresenter::BuildSessionPayload(
       {"continuation_count", result.continuation_count},
       {"finish_reason", result.final_finish_reason},
       {"usage",
+       nlohmann::json{
+           {"prompt_tokens", effective_usage.prompt_tokens},
+           {"completion_tokens", effective_usage.completion_tokens},
+           {"total_tokens", effective_usage.total_tokens},
+       }},
+      {"cumulative_usage",
        nlohmann::json{
            {"prompt_tokens", result.total_prompt_tokens},
            {"completion_tokens", result.total_completion_tokens},


### PR DESCRIPTION
## Summary
- report effective segment usage in interaction responses instead of summing hidden continuation prompt usage into the top-level `usage`
- keep cumulative prompt/completion totals available as `session.cumulative_usage`
- persist `latest_prompt_tokens` using the effective final segment prompt size

## Verification
- `git diff --check`
- syntax-only compile via `build/linux/x64/compile_commands.json` for:
  - `controller/src/interaction/interaction_service.cpp`
  - `controller/src/interaction/interaction_conversation_service.cpp`
