### PR TITLE
Fix interaction dialog anomalies on short replies

### DIFF
--- a/controller/include/interaction/interaction_completion_policy_support.h
+++ b/controller/include/interaction/interaction_completion_policy_support.h
@@ -39,6 +39,10 @@ class InteractionCompletionPolicySupport final {
   bool CanCompleteOnNaturalStop(
       const InteractionCompletionPolicy& policy,
       const InteractionSegmentSummary& summary) const;
+
+  bool ShouldTreatLengthAsNaturalStop(
+      const InteractionCompletionPolicy& policy,
+      const InteractionSegmentSummary& summary) const;
 };
 
 }  // namespace naim::controller

--- a/controller/src/interaction/interaction_completion_policy_support.cpp
+++ b/controller/src/interaction/interaction_completion_policy_support.cpp
@@ -253,4 +253,22 @@ bool InteractionCompletionPolicySupport::CanCompleteOnNaturalStop(
   return summary.finish_reason != "length" && !TrimCopy(summary.text).empty();
 }
 
+bool InteractionCompletionPolicySupport::ShouldTreatLengthAsNaturalStop(
+    const InteractionCompletionPolicy& policy,
+    const InteractionSegmentSummary& summary) const {
+  if (policy.require_completion_marker || policy.response_mode != "normal") {
+    return false;
+  }
+  if (TrimCopy(summary.text).empty()) {
+    return false;
+  }
+  if (summary.finish_reason != "length") {
+    return false;
+  }
+  if (summary.completion_tokens <= 0) {
+    return false;
+  }
+  return summary.completion_tokens < policy.max_tokens;
+}
+
 }  // namespace naim::controller

--- a/controller/src/interaction/interaction_completion_policy_support_tests.cpp
+++ b/controller/src/interaction/interaction_completion_policy_support_tests.cpp
@@ -109,6 +109,22 @@ void TestNaturalStopRules() {
   Expect(
       support.CanCompleteOnNaturalStop(policy, summary),
       "non-marker policies should allow natural stop on non-empty stop segment");
+  naim::controller::InteractionCompletionPolicy fallback_policy;
+  fallback_policy.response_mode = "normal";
+  fallback_policy.max_tokens = 512;
+  naim::controller::InteractionSegmentSummary truncated_like_summary;
+  truncated_like_summary.text = "I am Jex AI.";
+  truncated_like_summary.finish_reason = "length";
+  truncated_like_summary.completion_tokens = 5;
+  Expect(
+      support.ShouldTreatLengthAsNaturalStop(
+          fallback_policy, truncated_like_summary),
+      "normal short responses should be treated as natural stop even when upstream reports length");
+  naim::controller::InteractionCompletionPolicy long_policy;
+  long_policy.response_mode = "very_long";
+  Expect(
+      !support.ShouldTreatLengthAsNaturalStop(long_policy, truncated_like_summary),
+      "long-form policies should keep continuation behavior");
   std::cout << "ok: interaction-completion-policy-natural-stop-rules" << '\n';
 }
 

--- a/controller/src/interaction/interaction_service.cpp
+++ b/controller/src/interaction/interaction_service.cpp
@@ -82,6 +82,44 @@ naim::controller::InteractionSegmentSummary EffectiveSegmentUsage(
   return summary;
 }
 
+std::string NormalizeContinuationText(const std::string& value) {
+  std::string normalized;
+  normalized.reserve(value.size());
+  bool previous_space = false;
+  for (unsigned char ch : value) {
+    if (std::isspace(ch) != 0) {
+      if (!previous_space) {
+        normalized.push_back(' ');
+      }
+      previous_space = true;
+      continue;
+    }
+    normalized.push_back(static_cast<char>(std::tolower(ch)));
+    previous_space = false;
+  }
+  while (!normalized.empty() && normalized.front() == ' ') {
+    normalized.erase(normalized.begin());
+  }
+  while (!normalized.empty() && normalized.back() == ' ') {
+    normalized.pop_back();
+  }
+  return normalized;
+}
+
+bool IsDuplicateContinuationSegment(
+    const std::vector<naim::controller::InteractionSegmentSummary>& segments,
+    const std::string& candidate_text) {
+  if (segments.empty()) {
+    return false;
+  }
+  const std::string candidate = NormalizeContinuationText(candidate_text);
+  if (candidate.empty()) {
+    return false;
+  }
+  const std::string previous =
+      NormalizeContinuationText(segments.back().text);
+  return !previous.empty() && previous == candidate;
+}
 }  // namespace
 
 nlohmann::json InteractionRequestValidator::ParsePayload(
@@ -737,6 +775,11 @@ InteractionSessionResult InteractionSessionExecutor::Execute(
             segment_finished_at - segment_started_at)
             .count());
     summary.marker_seen = marker_seen_in_segment;
+    if (IsDuplicateContinuationSegment(result.segments, clean_text)) {
+      result.completion_status = "completed";
+      result.stop_reason = "duplicate_continuation_segment";
+      break;
+    }
     result.model = upstream_payload.value("model", result.model);
     result.content += clean_text;
     result.segments.push_back(summary);
@@ -772,6 +815,11 @@ InteractionSessionResult InteractionSessionExecutor::Execute(
         session_reached_target_length_(policy, result.total_completion_tokens)) {
       result.completion_status = "completed";
       result.stop_reason = "natural_stop";
+      break;
+    }
+    if (completion_policy_support.ShouldTreatLengthAsNaturalStop(policy, summary)) {
+      result.completion_status = "completed";
+      result.stop_reason = "length_but_short_natural_stop";
       break;
     }
 
@@ -1120,6 +1168,7 @@ InteractionSessionResult InteractionStreamSessionExecutor::Execute(
     SendDoneFn send_done) const {
   const InteractionCompletionPolicy& policy = resolved_policy.policy;
   const nlohmann::json& original_payload = request_context.payload;
+  const InteractionCompletionPolicySupport completion_policy_support;
   InteractionSessionResult session;
   session.session_id = session_id;
   const auto session_started_at = std::chrono::steady_clock::now();
@@ -1169,6 +1218,12 @@ InteractionSessionResult InteractionStreamSessionExecutor::Execute(
       session.dialog_estimate_after = segment.dialog_estimate_after;
       session.context_compression_ratio = segment.context_compression_ratio;
 
+      if (IsDuplicateContinuationSegment(session.segments, segment.summary.text)) {
+        session.completion_status = "completed";
+        session.stop_reason = "duplicate_continuation_segment";
+        break;
+      }
+
       if (!send_event(
               "segment_complete",
               stream_presenter.BuildSegmentCompleteEvent(
@@ -1186,6 +1241,12 @@ InteractionSessionResult InteractionStreamSessionExecutor::Execute(
           session_reached_target_length_(policy, session.total_completion_tokens)) {
         session.completion_status = "completed";
         session.stop_reason = "natural_stop";
+        break;
+      }
+      if (completion_policy_support.ShouldTreatLengthAsNaturalStop(
+              policy, segment.summary)) {
+        session.completion_status = "completed";
+        session.stop_reason = "length_but_short_natural_stop";
         break;
       }
       if (session.total_completion_tokens >= policy.max_total_completion_tokens) {

--- a/controller/src/interaction/interaction_text_post_processor.cpp
+++ b/controller/src/interaction/interaction_text_post_processor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <vector>
 #include <sstream>
 #include <stdexcept>
 
@@ -125,6 +126,122 @@ std::vector<std::string> InteractionTextPostProcessor::SplitParagraphs(
   return paragraphs;
 }
 
+std::string TrimLocal(const std::string& value) {
+  std::size_t start = 0;
+  while (start < value.size() &&
+         std::isspace(static_cast<unsigned char>(value[start])) != 0) {
+    ++start;
+  }
+  std::size_t end = value.size();
+  while (end > start &&
+         std::isspace(static_cast<unsigned char>(value[end - 1])) != 0) {
+    --end;
+  }
+  return value.substr(start, end - start);
+}
+
+std::vector<std::string> SplitParagraphsLocal(const std::string& value) {
+  std::vector<std::string> paragraphs;
+  std::stringstream stream(value);
+  std::string line;
+  std::string current;
+  while (std::getline(stream, line)) {
+    if (TrimLocal(line).empty()) {
+      if (!TrimLocal(current).empty()) {
+        paragraphs.push_back(TrimLocal(current));
+        current.clear();
+      }
+      continue;
+    }
+    if (!current.empty()) {
+      current += '\n';
+    }
+    current += line;
+  }
+  if (!TrimLocal(current).empty()) {
+    paragraphs.push_back(TrimLocal(current));
+  }
+  return paragraphs;
+}
+
+std::vector<std::string> SplitSentenceLikeUnits(const std::string& value) {
+  std::vector<std::string> units;
+  std::string current;
+  for (char ch : value) {
+    current.push_back(ch);
+    if (ch == '.' || ch == '!' || ch == '?' || ch == '\n') {
+      if (!current.empty()) {
+        units.push_back(current);
+        current.clear();
+      }
+    }
+  }
+  if (!current.empty()) {
+    units.push_back(current);
+  }
+  return units;
+}
+
+std::string NormalizeDedupKey(const std::string& value) {
+  std::string normalized;
+  normalized.reserve(value.size());
+  bool previous_space = false;
+  for (unsigned char ch : value) {
+    if (std::isspace(ch) != 0) {
+      if (!previous_space) {
+        normalized.push_back(' ');
+      }
+      previous_space = true;
+      continue;
+    }
+    normalized.push_back(static_cast<char>(std::tolower(ch)));
+    previous_space = false;
+  }
+  while (!normalized.empty() && normalized.front() == ' ') {
+    normalized.erase(normalized.begin());
+  }
+  while (!normalized.empty() && normalized.back() == ' ') {
+    normalized.pop_back();
+  }
+  return normalized;
+}
+
+std::string CollapseAdjacentDuplicateUnits(
+    const std::vector<std::string>& units,
+    const std::string& separator) {
+  std::string collapsed;
+  std::string previous_key;
+  for (const auto& unit : units) {
+    const std::string trimmed = TrimLocal(unit);
+    if (trimmed.empty()) {
+      continue;
+    }
+    const std::string key = NormalizeDedupKey(trimmed);
+    if (!previous_key.empty() && key == previous_key) {
+      continue;
+    }
+    if (!collapsed.empty()) {
+      collapsed += separator;
+    }
+    collapsed += trimmed;
+    previous_key = key;
+  }
+  return collapsed;
+}
+
+std::string CollapseAdjacentDuplicates(
+    const std::string& value) {
+  const auto paragraphs = SplitParagraphsLocal(value);
+  if (paragraphs.size() > 1) {
+    return CollapseAdjacentDuplicateUnits(paragraphs, "\n\n");
+  }
+  const auto sentences = SplitSentenceLikeUnits(value);
+  if (sentences.size() > 1) {
+    return CollapseAdjacentDuplicateUnits(sentences, " ");
+  }
+  return value;
+}
+
 bool InteractionTextPostProcessor::StartsWithReasoningPreamble(
     const std::string& text) const {
   const std::string lowered = LowercaseCopy(TrimCopy(text));
@@ -162,7 +279,7 @@ std::string InteractionTextPostProcessor::SanitizeInteractionText(
       return candidate;
     }
   }
-  return text;
+  return TrimCopy(CollapseAdjacentDuplicates(text));
 }
 
 std::string InteractionTextPostProcessor::Utf8SafeSuffix(

--- a/controller/src/interaction/interaction_text_post_processor_tests.cpp
+++ b/controller/src/interaction/interaction_text_post_processor_tests.cpp
@@ -81,6 +81,18 @@ void TestUtf8SafeSuffixAvoidsBrokenPrefix() {
   std::cout << "ok: interaction-text-utf8-safe-suffix" << '\n';
 }
 
+void TestCollapsesAdjacentDuplicateSentences() {
+  const naim::controller::InteractionTextPostProcessor processor;
+  const std::string text =
+      "I am Jex AI, the LocalTrade assistant.I am Jex AI, the LocalTrade assistant."
+      "I am Jex AI, the LocalTrade assistant.";
+  Expect(
+      processor.SanitizeInteractionText(text) ==
+          "I am Jex AI, the LocalTrade assistant.",
+      "processor should collapse adjacent duplicate sentences");
+  std::cout << "ok: interaction-text-collapses-duplicate-sentences" << '\n';
+}
+
 }  // namespace
 
 int main() {
@@ -91,6 +103,7 @@ int main() {
     TestSanitizesBareCompletionMarker();
     TestConsumesSplitCompletionMarker();
     TestUtf8SafeSuffixAvoidsBrokenPrefix();
+    TestCollapsesAdjacentDuplicateSentences();
     return 0;
   } catch (const std::exception& error) {
     std::cerr << "interaction_text_post_processor_tests failed: "


### PR DESCRIPTION
## Summary
- stop continuation loops for short normal replies that are already complete
- stop when a continuation segment duplicates the previous segment
- collapse adjacent duplicate assistant sentences in the controller text sanitizer

## Verification
- `git diff --check`
- `clang++ -fsyntax-only` for changed interaction sources via `compile_commands.json`
- reproduced current production issue before deploy: `Who are you?` returned `continuation_count=6`, `segment_count=7`, ~13s latency
