### PR TITLE
Stop natural chat replies after first natural stop

### DIFF
--- a/controller/src/interaction/interaction_service.cpp
+++ b/controller/src/interaction/interaction_service.cpp
@@ -811,8 +811,7 @@ InteractionSessionResult InteractionSessionExecutor::Execute(
       result.stop_reason = "semantic_completion_marker";
       break;
     }
-    if (can_complete_on_natural_stop_(policy, summary) &&
-        session_reached_target_length_(policy, result.total_completion_tokens)) {
+    if (can_complete_on_natural_stop_(policy, summary)) {
       result.completion_status = "completed";
       result.stop_reason = "natural_stop";
       break;
@@ -1237,8 +1236,7 @@ InteractionSessionResult InteractionStreamSessionExecutor::Execute(
         session.stop_reason = "semantic_completion_marker";
         break;
       }
-      if (can_complete_on_natural_stop_(policy, segment.summary) &&
-          session_reached_target_length_(policy, session.total_completion_tokens)) {
+      if (can_complete_on_natural_stop_(policy, segment.summary)) {
         session.completion_status = "completed";
         session.stop_reason = "natural_stop";
         break;


### PR DESCRIPTION
## Summary
- stop continuation immediately on natural stop for non-marker chat replies
- remove the extra target-length gate that kept short answers in the continuation loop

## Verification
- `git diff --check`
- `clang++ -fsyntax-only` for `controller/src/interaction/interaction_service.cpp`
- production after previous fix still showed `Who are you?` with `continuation_count=6`, `segment_count=7`, `stop_reason=max_continuations_reached`
