### PR TITLE
Preserve raw user prompt for interaction policy routing

### DIFF
--- a/controller/src/interaction/interaction_payload_builder.cpp
+++ b/controller/src/interaction/interaction_payload_builder.cpp
@@ -176,6 +176,7 @@ std::string BuildInteractionUpstreamBodyPayload(
   payload.erase("response_format");
   payload.erase("session_id");
   payload.erase("skill_ids");
+  payload.erase("__naim_policy_user_message");
   payload.erase(PlaneSkillsService::kSystemInstructionPayloadKey);
   payload.erase(PlaneSkillsService::kAppliedSkillsPayloadKey);
   payload.erase(PlaneSkillsService::kSkillsSessionIdPayloadKey);

--- a/controller/src/interaction/interaction_request_heuristics.cpp
+++ b/controller/src/interaction/interaction_request_heuristics.cpp
@@ -8,6 +8,10 @@ namespace naim::controller {
 
 std::string InteractionRequestHeuristics::LastUserMessageContent(
     const nlohmann::json& payload) const {
+  if (payload.contains("__naim_policy_user_message") &&
+      payload.at("__naim_policy_user_message").is_string()) {
+    return payload.at("__naim_policy_user_message").get<std::string>();
+  }
   if (!payload.contains("messages") || !payload.at("messages").is_array()) {
     return "";
   }

--- a/controller/src/interaction/interaction_request_heuristics_tests.cpp
+++ b/controller/src/interaction/interaction_request_heuristics_tests.cpp
@@ -28,6 +28,25 @@ void TestExtractsLastUserMessage() {
   std::cout << "ok: interaction-heuristics-last-user-message" << '\n';
 }
 
+void TestPrefersRawPolicyUserMessage() {
+  const naim::controller::InteractionRequestHeuristics heuristics;
+  const nlohmann::json payload = {
+      {"__naim_policy_user_message", "Who are you?"},
+      {"messages",
+       nlohmann::json::array(
+           {nlohmann::json{{"role", "system"}, {"content", "sys"}},
+            nlohmann::json{
+                {"role", "user"},
+                {"content",
+                 "Who are you?\n\nResponse language requirement: Reply in English. "
+                 "Ignore the language of the user's message and follow only this interface language setting."}}})},
+  };
+  Expect(
+      heuristics.LastUserMessageContent(payload) == "Who are you?",
+      "heuristics should prefer the raw policy user message over enriched user content");
+  std::cout << "ok: interaction-heuristics-raw-policy-user-message" << '\n';
+}
+
 void TestDetectsLongFormRequest() {
   const naim::controller::InteractionRequestHeuristics heuristics;
   Expect(
@@ -67,6 +86,7 @@ void TestCanonicalizesResponseMode() {
 int main() {
   try {
     TestExtractsLastUserMessage();
+    TestPrefersRawPolicyUserMessage();
     TestDetectsLongFormRequest();
     TestDetectsRepositoryAnalysisRequest();
     TestCanonicalizesResponseMode();


### PR DESCRIPTION
## Summary
- use `__naim_policy_user_message` as the canonical prompt for interaction policy heuristics
- strip that internal field before sending the upstream payload to infer
- add a unit test covering enriched user content with a preserved raw prompt

## Why
`lt-cypher-ai` enriches the final user message with system-side context and language instructions. That was leaking into long-form heuristics and pushing ordinary chat turns into long continuation mode.

## Verification
- `git diff --check`
- `clang++ -fsyntax-only` for updated interaction sources via `compile_commands.json`
