### PR TITLE
Add multi-app plane-owned Knowledge Vault ingress

### DIFF
--- a/common/include/naim/state/desired_state_v2_projector.h
+++ b/common/include/naim/state/desired_state_v2_projector.h
@@ -39,6 +39,7 @@ class DesiredStateV2Projector final {
   int InferReplicaCount() const;
 
   const InstanceSpec* FindInstance(InstanceRole role) const;
+  std::vector<const InstanceSpec*> FindInstances(InstanceRole role) const;
   std::vector<const InstanceSpec*> FindWorkerInstances() const;
   const DiskSpec* FindDiskByName(const std::string& name) const;
   const DiskSpec* FindSharedDisk() const;
@@ -52,6 +53,7 @@ class DesiredStateV2Projector final {
   nlohmann::json value_;
   const InstanceSpec* infer_instance_ = nullptr;
   const InstanceSpec* app_instance_ = nullptr;
+  std::vector<const InstanceSpec*> app_instances_;
   const InstanceSpec* skills_instance_ = nullptr;
   const InstanceSpec* browsing_instance_ = nullptr;
   std::vector<const InstanceSpec*> worker_instances_;

--- a/common/include/naim/state/desired_state_v2_renderer.h
+++ b/common/include/naim/state/desired_state_v2_renderer.h
@@ -42,6 +42,7 @@ class DesiredStateV2Renderer final {
   std::string ResolveInferNodeName() const;
   std::string ResolveInferNodeName(int infer_index) const;
   std::string ResolveAppNodeName() const;
+  std::string ResolveAppNodeName(const nlohmann::json& app_json) const;
   std::string ResolveWorkerNodeName(int worker_index) const;
   std::optional<std::string> ResolveWorkerGpuDevice(int worker_index) const;
   std::optional<std::string> ResolveLegacyServiceNodeName(
@@ -57,6 +58,7 @@ class DesiredStateV2Renderer final {
   std::string BuildPlaneSharedDiskName() const;
   std::string BuildInferInstanceName(int infer_index = 0) const;
   std::string BuildAppInstanceName() const;
+  std::string BuildAppInstanceName(const std::string& app_name, bool primary) const;
   std::string BuildSkillsInstanceName() const;
   std::string BuildWebGatewayInstanceName() const;
   std::string BuildInteractionInstanceName() const;
@@ -79,6 +81,7 @@ class DesiredStateV2Renderer final {
       const std::string& binding) const;
   std::string DefaultInferRuntimeBackend() const;
   std::string DefaultWorkerBootMode() const;
+  static std::string NormalizeAppNameToken(const std::string& value);
   void NormalizeInferenceSettings();
 
   int ExtractPrivateDiskSizeGb(
@@ -100,6 +103,7 @@ class DesiredStateV2Renderer final {
   nlohmann::json resources_json_;
   nlohmann::json worker_resources_json_;
   nlohmann::json app_json_;
+  std::vector<nlohmann::json> apps_json_;
   nlohmann::json skills_json_;
   nlohmann::json browsing_json_;
   nlohmann::json knowledge_json_;

--- a/common/include/naim/state/desired_state_v2_validator.h
+++ b/common/include/naim/state/desired_state_v2_validator.h
@@ -25,6 +25,10 @@ class DesiredStateV2Validator final {
   void ValidateWorker() const;
   void ValidateWorkerResources() const;
   void ValidateApp() const;
+  void ValidateSingleAppSpec(
+      const nlohmann::json& app,
+      const char* field_name,
+      bool require_name) const;
   void ValidateSkills() const;
   void ValidateBrowsing() const;
   void ValidateHooks() const;

--- a/common/src/state/desired_state_v2_projector.cpp
+++ b/common/src/state/desired_state_v2_projector.cpp
@@ -61,6 +61,7 @@ nlohmann::json DesiredStateV2Projector::ProjectJson() {
 void DesiredStateV2Projector::CollectInstancesAndDisks() {
   infer_instance_ = FindInstance(InstanceRole::Infer);
   app_instance_ = FindInstance(InstanceRole::App);
+  app_instances_ = FindInstances(InstanceRole::App);
   skills_instance_ = FindInstance(InstanceRole::Skills);
   browsing_instance_ = FindInstance(InstanceRole::Browsing);
   worker_instances_ = FindWorkerInstances();
@@ -422,35 +423,73 @@ void DesiredStateV2Projector::ProjectWorker() {
 }
 
 void DesiredStateV2Projector::ProjectApp() {
-  if (app_instance_ == nullptr) {
+  if (app_instances_.empty()) {
     value_["app"] = {{"enabled", false}};
     return;
   }
 
-  nlohmann::json app = {
-      {"enabled", true},
-      {"image", app_instance_->image},
+  nlohmann::json apps = nlohmann::json::array();
+  const auto build_app_json = [&](const InstanceSpec& instance, bool primary) {
+    nlohmann::json app = {
+        {"enabled", true},
+        {"image", instance.image},
+    };
+    if (!primary) {
+      app["name"] = instance.environment.contains("NAIM_APP_NAME")
+                        ? instance.environment.at("NAIM_APP_NAME")
+                        : instance.name;
+      app["primary"] = false;
+    }
+    const auto start = ProjectorSupport::ProjectServiceStart(instance, std::string{});
+    if (!start.is_null()) {
+      app["start"] = start;
+    }
+    const auto env = ProjectorSupport::ProjectCustomEnv(instance, true);
+    if (!env.empty()) {
+      app["env"] = env;
+    }
+    const auto publish = ProjectorSupport::ProjectPublishedPorts(instance);
+    if (!publish.empty()) {
+      app["publish"] = publish;
+    }
+    if (instance.node_name != DefaultNodeName()) {
+      app["node"] = instance.node_name;
+    }
+    const auto app_disk = FindDiskByName(instance.private_disk_name);
+    const auto volumes = ProjectorSupport::ProjectAppVolumes(app_disk);
+    if (!volumes.empty()) {
+      app["volumes"] = std::move(volumes);
+    }
+    return app;
   };
-  const auto start = ProjectorSupport::ProjectServiceStart(*app_instance_, std::string{});
-  if (!start.is_null()) {
-    app["start"] = start;
+
+  const InstanceSpec* primary_app = nullptr;
+  for (const auto* instance : app_instances_) {
+    if (instance == nullptr) {
+      continue;
+    }
+    const auto it = instance->environment.find("NAIM_APP_PRIMARY");
+    if (it != instance->environment.end() && it->second == "true") {
+      primary_app = instance;
+      break;
+    }
   }
-  if (!app_instance_->environment.empty()) {
-    app["env"] = app_instance_->environment;
+  if (primary_app == nullptr) {
+    primary_app = app_instances_.front();
   }
-  const auto publish = ProjectorSupport::ProjectPublishedPorts(*app_instance_);
-  if (!publish.empty()) {
-    app["publish"] = publish;
+
+  for (const auto* instance : app_instances_) {
+    if (instance == nullptr) {
+      continue;
+    }
+    apps.push_back(build_app_json(*instance, instance == primary_app));
   }
-  if (app_instance_->node_name != DefaultNodeName()) {
-    app["node"] = app_instance_->node_name;
+
+  if (apps.size() == 1) {
+    value_["app"] = apps.front();
+    return;
   }
-  const auto app_disk = FindDiskByName(app_instance_->private_disk_name);
-  const auto volumes = ProjectorSupport::ProjectAppVolumes(app_disk);
-  if (!volumes.empty()) {
-    app["volumes"] = std::move(volumes);
-  }
-  value_["app"] = std::move(app);
+  value_["apps"] = std::move(apps);
 }
 
 void DesiredStateV2Projector::ProjectSkills() {
@@ -631,6 +670,16 @@ const InstanceSpec* DesiredStateV2Projector::FindInstance(InstanceRole role) con
     }
   }
   return nullptr;
+}
+
+std::vector<const InstanceSpec*> DesiredStateV2Projector::FindInstances(InstanceRole role) const {
+  std::vector<const InstanceSpec*> instances;
+  for (const auto& instance : state_.instances) {
+    if (instance.role == role) {
+      instances.push_back(&instance);
+    }
+  }
+  return instances;
 }
 
 std::vector<const InstanceSpec*> DesiredStateV2Projector::FindWorkerInstances() const {

--- a/common/src/state/desired_state_v2_projector_tests.cpp
+++ b/common/src/state/desired_state_v2_projector_tests.cpp
@@ -730,6 +730,52 @@ int main() {
         },
         "execution-node-clean");
 
+    {
+      const json multi_app_plane{
+          {"version", 2},
+          {"plane_name", "multi-app-plane"},
+          {"plane_mode", "llm"},
+          {"model",
+           {
+               {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+               {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+               {"served_model_name", "qwen-multi-app"},
+           }},
+          {"runtime",
+           {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+          {"infer", {{"replicas", 1}}},
+          {"apps",
+           json::array(
+               {{{"name", "chat"},
+                 {"primary", true},
+                 {"enabled", true},
+                 {"image", "example/app:dev"},
+                 {"start", {{"type", "script"}, {"value", "node server.js"}}}},
+                {{"name", "market-ingest"},
+                 {"enabled", true},
+                 {"image", "example/app:dev"},
+                 {"start", {{"type", "script"}, {"value", "node market-collector.js"}}},
+                 {"node", "worker-node-a"}}})},
+      };
+      const auto rendered = naim::DesiredStateV2Renderer::Render(multi_app_plane);
+      const auto projected = naim::DesiredStateV2Projector::Project(rendered);
+      Expect(projected.contains("apps"), "multi-app-plane: apps should project");
+      Expect(projected.at("apps").is_array(), "multi-app-plane: apps should be array");
+      Expect(projected.at("apps").size() == 2, "multi-app-plane: expected two apps");
+      Expect(!projected.contains("app"), "multi-app-plane: legacy app should be suppressed");
+      const auto& primary_app = projected.at("apps").at(0);
+      Expect(primary_app.at("name").get<std::string>() == "chat",
+             "multi-app-plane: primary app name mismatch");
+      Expect(primary_app.value("primary", false),
+             "multi-app-plane: primary app flag mismatch");
+      const auto& collector_app = projected.at("apps").at(1);
+      Expect(collector_app.at("name").get<std::string>() == "market-ingest",
+             "multi-app-plane: collector app name mismatch");
+      Expect(!collector_app.value("primary", false),
+             "multi-app-plane: collector should not be primary");
+      ExpectRoundTrip(multi_app_plane, "multi-app-plane");
+    }
+
     return 0;
   } catch (const std::exception& ex) {
     std::cerr << "desired_state_v2_projector_tests failed: " << ex.what() << '\n';

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -78,9 +78,7 @@ DesiredStateV2Renderer::DesiredStateV2Renderer(const nlohmann::json& value)
           resources_json_.contains("worker") && resources_json_.at("worker").is_object()
               ? resources_json_.at("worker")
               : nlohmann::json::object()),
-      app_json_(
-          value.contains("app") && value.at("app").is_object() ? value.at("app")
-                                                                : nlohmann::json::object()),
+      app_json_(nlohmann::json::object()),
       skills_json_(
           value.contains("skills") && value.at("skills").is_object() ? value.at("skills")
                                                                       : nlohmann::json::object()),
@@ -95,7 +93,29 @@ DesiredStateV2Renderer::DesiredStateV2Renderer(const nlohmann::json& value)
               : nlohmann::json::object()),
       features_json_(
           value.contains("features") && value.at("features").is_object() ? value.at("features")
-                                                                          : nlohmann::json::object()) {}
+                                                                          : nlohmann::json::object()) {
+  if (value.contains("apps") && value.at("apps").is_array()) {
+    for (const auto& item : value.at("apps")) {
+      if (item.is_object()) {
+        apps_json_.push_back(item);
+      }
+    }
+  } else if (value.contains("app") && value.at("app").is_object()) {
+    apps_json_.push_back(value.at("app"));
+  }
+
+  if (!apps_json_.empty()) {
+    const auto primary_it = std::find_if(
+        apps_json_.begin(),
+        apps_json_.end(),
+        [](const nlohmann::json& app_json) {
+          return app_json.value("primary", false);
+        });
+    app_json_ = primary_it != apps_json_.end() ? *primary_it : apps_json_.front();
+  } else {
+    app_json_ = nlohmann::json::object();
+  }
+}
 
 DesiredState DesiredStateV2Renderer::RenderState() {
   RenderIdentity();
@@ -745,71 +765,88 @@ void DesiredStateV2Renderer::RenderWorkerInstances() {
 }
 
 void DesiredStateV2Renderer::RenderAppInstance() {
-  if (!value_.contains("app") || !value_.at("app").is_object() ||
-      !value_.at("app").value("enabled", true)) {
+  if (apps_json_.empty()) {
     return;
   }
 
-  InstanceSpec app;
-  app.name = BuildAppInstanceName();
-  app.role = InstanceRole::App;
-  app.plane_name = state_.plane_name;
-  app.node_name = ResolveAppNodeName();
-  app.image = app_json_.value("image", std::string{});
-  if (app_json_.contains("start") && app_json_.at("start").is_object()) {
-    const auto& start = app_json_.at("start");
-    const auto start_type = start.value("type", std::string("command"));
-    if (start_type == "script") {
-      app.command = BuildAppCommandFromScriptRef(start.value("script_ref", std::string{}));
-    } else {
-      app.command = start.value("command", std::string{});
+  for (std::size_t index = 0; index < apps_json_.size(); ++index) {
+    const auto& app_entry = apps_json_.at(index);
+    if (!app_entry.value("enabled", true)) {
+      continue;
     }
-  }
-  app.private_disk_name = app.name + "-private";
-  app.shared_disk_name = state_.plane_shared_disk_name;
-  if (!infer_names_.empty()) {
-    app.depends_on.push_back(infer_names_.front());
-  }
-  if (app_json_.contains("env") && app_json_.at("env").is_object()) {
-    app.environment = app_json_.at("env").get<std::map<std::string, std::string>>();
-  }
-  app.labels = {
-      {"naim.plane", state_.plane_name},
-      {"naim.role", "app"},
-      {"naim.node", app.node_name},
-  };
-  if (app_json_.contains("publish") && app_json_.at("publish").is_array()) {
-    for (const auto& port_json : app_json_.at("publish")) {
-      app.published_ports.push_back(PublishedPort{
-          port_json.value("host_ip", std::string("127.0.0.1")),
-          port_json.value("host_port", 0),
-          port_json.value("container_port", 0),
-      });
+
+    const bool primary = app_entry.value("primary", false) || index == 0;
+    const std::string app_name =
+        primary ? std::string("primary")
+                : app_entry.value("name", "app-" + std::to_string(index));
+
+    InstanceSpec app;
+    app.name = BuildAppInstanceName(app_name, primary);
+    app.role = InstanceRole::App;
+    app.plane_name = state_.plane_name;
+    app.node_name = ResolveAppNodeName(app_entry);
+    app.image = app_entry.value("image", std::string{});
+    if (app_entry.contains("start") && app_entry.at("start").is_object()) {
+      const auto& start = app_entry.at("start");
+      const auto start_type = start.value("type", std::string("command"));
+      if (start_type == "script") {
+        app.command = BuildAppCommandFromScriptRef(start.value("script_ref", std::string{}));
+      } else {
+        app.command = start.value("command", std::string{});
+      }
     }
-  }
-  ApplyExternalAppHostMetadata(&app, "app");
+    app.private_disk_name = app.name + "-private";
+    app.shared_disk_name = state_.plane_shared_disk_name;
+    if (!infer_names_.empty()) {
+      app.depends_on.push_back(infer_names_.front());
+    }
+    if (app_entry.contains("env") && app_entry.at("env").is_object()) {
+      app.environment = app_entry.at("env").get<std::map<std::string, std::string>>();
+    }
+    app.environment["NAIM_APP_NAME"] = app_name;
+    app.environment["NAIM_APP_PRIMARY"] = primary ? "true" : "false";
+    app.labels = {
+        {"naim.plane", state_.plane_name},
+        {"naim.role", "app"},
+        {"naim.node", app.node_name},
+        {"naim.app_name", app_name},
+        {"naim.app_primary", primary ? "true" : "false"},
+    };
+    if (app_entry.contains("publish") && app_entry.at("publish").is_array()) {
+      for (const auto& port_json : app_entry.at("publish")) {
+        app.published_ports.push_back(PublishedPort{
+            port_json.value("host_ip", std::string("127.0.0.1")),
+            port_json.value("host_port", 0),
+            port_json.value("container_port", 0),
+        });
+      }
+    }
+    if (primary) {
+      ApplyExternalAppHostMetadata(&app, "app");
+    }
 
-  const int app_private_disk_size_gb =
-      ExtractPrivateDiskSizeGb(app_json_, kDefaultAppPrivateDiskSizeGb, "volumes");
-  const std::string app_private_mount_path =
-      ExtractPrivateMountPath(app_json_, "/naim/private", "volumes");
-  if (app_json_.contains("volumes") && app_json_.at("volumes").is_array() &&
-      app_json_.at("volumes").size() > 1) {
-    throw std::runtime_error("desired-state v2 currently supports at most one app volume");
-  }
-  app.private_disk_size_gb = app_private_disk_size_gb;
-  state_.instances.push_back(app);
+    const int app_private_disk_size_gb =
+        ExtractPrivateDiskSizeGb(app_entry, kDefaultAppPrivateDiskSizeGb, "volumes");
+    const std::string app_private_mount_path =
+        ExtractPrivateMountPath(app_entry, "/naim/private", "volumes");
+    if (app_entry.contains("volumes") && app_entry.at("volumes").is_array() &&
+        app_entry.at("volumes").size() > 1) {
+      throw std::runtime_error("desired-state v2 currently supports at most one app volume");
+    }
+    app.private_disk_size_gb = app_private_disk_size_gb;
+    state_.instances.push_back(app);
 
-  DiskSpec app_private_disk;
-  app_private_disk.name = app.private_disk_name;
-  app_private_disk.kind = DiskKind::AppPrivate;
-  app_private_disk.plane_name = state_.plane_name;
-  app_private_disk.owner_name = app.name;
-  app_private_disk.node_name = app.node_name;
-  app_private_disk.host_path = BuildInstancePrivateHostPath(app.name);
-  app_private_disk.container_path = app_private_mount_path;
-  app_private_disk.size_gb = app_private_disk_size_gb;
-  state_.disks.push_back(std::move(app_private_disk));
+    DiskSpec app_private_disk;
+    app_private_disk.name = app.private_disk_name;
+    app_private_disk.kind = DiskKind::AppPrivate;
+    app_private_disk.plane_name = state_.plane_name;
+    app_private_disk.owner_name = app.name;
+    app_private_disk.node_name = app.node_name;
+    app_private_disk.host_path = BuildInstancePrivateHostPath(app.name);
+    app_private_disk.container_path = app_private_mount_path;
+    app_private_disk.size_gb = app_private_disk_size_gb;
+    state_.disks.push_back(std::move(app_private_disk));
+  }
 }
 
 void DesiredStateV2Renderer::RenderSkillsInstance() {
@@ -1109,6 +1146,14 @@ std::string DesiredStateV2Renderer::ResolveAppNodeName() const {
   return ResolveInferNodeName();
 }
 
+std::string DesiredStateV2Renderer::ResolveAppNodeName(const nlohmann::json& app_json) const {
+  if (const auto legacy_node_name = ResolveLegacyServiceNodeName(app_json, "app");
+      legacy_node_name.has_value()) {
+    return *legacy_node_name;
+  }
+  return ResolveAppNodeName();
+}
+
 std::string DesiredStateV2Renderer::ResolveWorkerNodeName(int worker_index) const {
   if (const auto assignment_node_name = ResolveLegacyWorkerAssignmentNodeName(worker_index);
       assignment_node_name.has_value()) {
@@ -1265,6 +1310,15 @@ std::string DesiredStateV2Renderer::BuildAppInstanceName() const {
   return "app-" + state_.plane_name;
 }
 
+std::string DesiredStateV2Renderer::BuildAppInstanceName(
+    const std::string& app_name,
+    bool primary) const {
+  if (primary) {
+    return BuildAppInstanceName();
+  }
+  return "app-" + state_.plane_name + "-" + NormalizeAppNameToken(app_name);
+}
+
 std::string DesiredStateV2Renderer::BuildSkillsInstanceName() const {
   return "skills-" + state_.plane_name;
 }
@@ -1299,6 +1353,31 @@ std::string DesiredStateV2Renderer::BuildAppCommandFromScriptRef(
   const std::string filename =
       slash == std::string::npos ? stripped : stripped.substr(slash + 1);
   return "/app/" + filename;
+}
+
+std::string DesiredStateV2Renderer::NormalizeAppNameToken(const std::string& value) {
+  std::string token;
+  token.reserve(value.size());
+  for (char ch : value) {
+    if ((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')) {
+      token.push_back(ch);
+      continue;
+    }
+    if (ch >= 'A' && ch <= 'Z') {
+      token.push_back(static_cast<char>(ch - 'A' + 'a'));
+      continue;
+    }
+    if (ch == '-' || ch == '_') {
+      token.push_back('-');
+    }
+  }
+  while (!token.empty() && token.front() == '-') {
+    token.erase(token.begin());
+  }
+  while (!token.empty() && token.back() == '-') {
+    token.pop_back();
+  }
+  return token.empty() ? std::string("extra") : token;
 }
 
 std::string DesiredStateV2Renderer::BuildCommandFromStartSpec(

--- a/common/src/state/desired_state_v2_validator.cpp
+++ b/common/src/state/desired_state_v2_validator.cpp
@@ -592,27 +592,70 @@ void DesiredStateV2Validator::ValidateWorkerResources() const {
 }
 
 void DesiredStateV2Validator::ValidateApp() const {
-  if (!value_.contains("app")) {
+  const bool has_legacy_app = value_.contains("app");
+  const bool has_apps = value_.contains("apps");
+  if (has_legacy_app && has_apps) {
+    throw std::runtime_error("desired-state v2 cannot mix app and apps");
+  }
+  if (!has_legacy_app && !has_apps) {
     return;
   }
-  RequireObject("app");
-  const auto& app = value_.at("app");
+
+  if (has_legacy_app) {
+    RequireObject("app");
+    ValidateSingleAppSpec(value_.at("app"), "app", false);
+    return;
+  }
+
+  if (!value_.at("apps").is_array() || value_.at("apps").empty()) {
+    throw std::runtime_error("desired-state v2 apps must be a non-empty array");
+  }
+  int primary_count = 0;
+  std::set<std::string> names;
+  for (const auto& app : value_.at("apps")) {
+    if (!app.is_object()) {
+      throw std::runtime_error("desired-state v2 apps entries must be objects");
+    }
+    ValidateSingleAppSpec(app, "apps[]", true);
+    if (app.value("primary", false)) {
+      ++primary_count;
+    }
+    const auto name = app.value("name", std::string{});
+    if (!name.empty() && !names.insert(name).second) {
+      throw std::runtime_error("desired-state v2 apps names must be unique");
+    }
+  }
+  if (primary_count > 1) {
+    throw std::runtime_error("desired-state v2 apps supports at most one primary app");
+  }
+}
+
+void DesiredStateV2Validator::ValidateSingleAppSpec(
+    const nlohmann::json& app,
+    const char* field_name,
+    bool require_name) const {
   if (!FieldEnabledByDefault(app, true)) {
     return;
   }
+  if (require_name) {
+    const auto name = app.value("name", std::string{});
+    if (name.empty()) {
+      throw std::runtime_error(std::string("desired-state v2 ") + field_name + " requires name");
+    }
+  }
   if (app.contains("node") && !app.at("node").is_string()) {
-    throw std::runtime_error("desired-state v2 app.node must be a string");
+    throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".node must be a string");
   }
   if (app.contains("node") && app.at("node").is_string()) {
     ValidateNodeRoleCompatibility(app.at("node").get<std::string>(), "app", "app");
   }
   if (app.value("image", std::string{}).empty()) {
-    throw std::runtime_error("desired-state v2 enabled app requires image");
+    throw std::runtime_error(std::string("desired-state v2 enabled ") + field_name + " requires image");
   }
   ValidateStartBlock(app, "app");
   if (app.contains("volumes")) {
     if (!app.at("volumes").is_array()) {
-      throw std::runtime_error("desired-state v2 app.volumes must be an array");
+      throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".volumes must be an array");
     }
     if (app.at("volumes").size() > 1) {
       throw std::runtime_error("desired-state v2 currently supports at most one app volume");

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -1839,6 +1839,60 @@ int main() {
         },
         "placement-app-host-rejects-mixed-auth");
 
+    {
+      const json multi_app_plane{
+          {"version", 2},
+          {"plane_name", "multi-app-plane"},
+          {"plane_mode", "llm"},
+          {"model",
+           {
+               {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+               {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+               {"served_model_name", "qwen-multi-app"},
+           }},
+          {"runtime",
+           {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+          {"infer", {{"replicas", 1}}},
+          {"apps",
+           json::array(
+               {{{"name", "chat"},
+                 {"primary", true},
+                 {"enabled", true},
+                 {"image", "example/app:dev"}},
+                {{"name", "market-ingest"},
+                 {"enabled", true},
+                 {"image", "example/app:dev"},
+                 {"start", {{"type", "script"}, {"value", "node market-collector.js"}}}}})},
+      };
+      const auto state = RenderValid(multi_app_plane, "multi-app-plane");
+      const auto primary = FindInstance(state, "app-multi-app-plane");
+      const auto collector = FindInstance(state, "app-market-ingest-multi-app-plane");
+      Expect(primary.role == naim::InstanceRole::App,
+             "multi-app-plane: primary app role mismatch");
+      Expect(primary.environment.at("NAIM_APP_PRIMARY") == "true",
+             "multi-app-plane: primary app should be flagged");
+      Expect(collector.environment.at("NAIM_APP_NAME") == "market-ingest",
+             "multi-app-plane: collector app env mismatch");
+      const auto projected = naim::DesiredStateV2Projector::Project(state);
+      Expect(projected.contains("apps"), "multi-app-plane: projector should emit apps");
+      Expect(projected.at("apps").size() == 2,
+             "multi-app-plane: projector should emit two apps");
+      std::cout << "ok: multi-app-plane" << '\n';
+    }
+
+    ExpectInvalid(
+        json{
+            {"version", 2},
+            {"plane_name", "duplicate-app-names"},
+            {"plane_mode", "compute"},
+            {"runtime", {{"engine", "custom"}, {"workers", 1}}},
+            {"apps",
+             json::array(
+                 {{{"name", "collector"}, {"enabled", true}, {"image", "example/app:dev"}},
+                  {{"name", "collector"}, {"enabled", true}, {"image", "example/app:dev"}}})},
+        },
+        "duplicate-app-names");
+
     return 0;
   } catch (const std::exception& ex) {
     std::cerr << "desired_state_v2_validator_tests failed: " << ex.what() << '\n';

--- a/controller/include/app/controller_plane_support.h
+++ b/controller/include/app/controller_plane_support.h
@@ -25,6 +25,7 @@ PlaneHttpService CreatePlaneHttpService(
     const PlaneRegistryService& plane_registry_service,
     const ControllerStateService& controller_state_service,
     const PlaneSkillCatalogService& plane_skill_catalog_service,
+    const KnowledgeVaultHttpService& knowledge_vault_http_service,
     const DashboardService& dashboard_service,
     int stale_after_seconds);
 

--- a/controller/include/plane/plane_http_support.h
+++ b/controller/include/plane/plane_http_support.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <functional>
 #include <optional>
 #include <string>
 
@@ -17,13 +18,19 @@
 
 class PlaneHttpSupport final {
  public:
+  using PlaneKnowledgeVaultRequestFn = std::function<std::optional<HttpResponse>(
+      const std::string& db_path,
+      const HttpRequest& request,
+      const std::string& plane_name)>;
+
   PlaneHttpSupport(
       const naim::controller::ControllerRequestSupport& request_support,
       const naim::controller::PlaneMutationService& plane_mutation_service,
       const naim::controller::PlaneRegistryService& plane_registry_service,
       const naim::controller::ControllerStateService& controller_state_service,
       const naim::controller::DashboardService& dashboard_service,
-      int stale_after_seconds);
+      int stale_after_seconds,
+      PlaneKnowledgeVaultRequestFn plane_knowledge_vault_request = {});
 
   HttpResponse build_json_response(
       int status_code,
@@ -60,6 +67,10 @@ class PlaneHttpSupport final {
   const naim::controller::PlaneRegistryService* plane_registry_service() const;
   const naim::controller::ControllerStateService* controller_state_service() const;
   const naim::controller::DashboardService* dashboard_service() const;
+  std::optional<HttpResponse> handle_plane_knowledge_vault_request(
+      const std::string& db_path,
+      const HttpRequest& request,
+      const std::string& plane_name) const;
 
  private:
   const naim::controller::ControllerRequestSupport& request_support_;
@@ -68,4 +79,5 @@ class PlaneHttpSupport final {
   const naim::controller::ControllerStateService& controller_state_service_;
   const naim::controller::DashboardService& dashboard_service_;
   int stale_after_seconds_;
+  PlaneKnowledgeVaultRequestFn plane_knowledge_vault_request_;
 };

--- a/controller/include/plane/plane_placement_payload_builder.h
+++ b/controller/include/plane/plane_placement_payload_builder.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <set>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -18,6 +19,7 @@ class PlanePlacementPayloadBuilder final {
  private:
   std::optional<std::string> ResolveExternalAppHostAuthMode() const;
   std::optional<std::string> FindFirstInstanceNodeName(naim::InstanceRole role) const;
+  std::vector<const naim::InstanceSpec*> FindInstances(naim::InstanceRole role) const;
   std::set<std::string> FindInstanceNodeNames(naim::InstanceRole role) const;
 
   const naim::DesiredState& desired_state_;

--- a/controller/src/app/controller_plane_component_factory.cpp
+++ b/controller/src/app/controller_plane_component_factory.cpp
@@ -63,12 +63,14 @@ PlaneService ControllerPlaneComponentFactory::CreatePlaneService(
 }
 
 PlaneHttpService ControllerPlaneComponentFactory::CreatePlaneHttpService() const {
+  static const KnowledgeVaultHttpService knowledge_vault_http_service;
   return plane_support::CreatePlaneHttpService(
       RequestSupport(),
       PlaneMutationServiceInstance(),
       PlaneRegistryServiceInstance(),
       ControllerStateServiceInstance(),
       PlaneSkillCatalogServiceInstance(),
+      knowledge_vault_http_service,
       DashboardServiceInstance(),
       Defaults().DefaultStaleAfterSeconds());
 }

--- a/controller/src/app/controller_plane_support.cpp
+++ b/controller/src/app/controller_plane_support.cpp
@@ -47,6 +47,7 @@ PlaneHttpService CreatePlaneHttpService(
     const PlaneRegistryService& plane_registry_service,
     const ControllerStateService& controller_state_service,
     const PlaneSkillCatalogService& plane_skill_catalog_service,
+    const KnowledgeVaultHttpService& knowledge_vault_http_service,
     const DashboardService& dashboard_service,
     int stale_after_seconds) {
   return PlaneHttpService(PlaneHttpSupport(
@@ -55,7 +56,22 @@ PlaneHttpService CreatePlaneHttpService(
       plane_registry_service,
       controller_state_service,
       dashboard_service,
-      stale_after_seconds),
+      stale_after_seconds,
+      [&knowledge_vault_http_service](
+          const std::string& db_path,
+          const HttpRequest& request,
+          const std::string&) -> std::optional<HttpResponse> {
+        HttpRequest rewritten = request;
+        constexpr const char* kPlanePrefix = "/api/v1/planes/";
+        const std::string remainder = request.path.substr(std::string(kPlanePrefix).size());
+        const auto separator = remainder.find('/');
+        if (separator == std::string::npos) {
+          return std::nullopt;
+        }
+        const std::string suffix = remainder.substr(separator);
+        rewritten.path = "/api/v1" + suffix;
+        return knowledge_vault_http_service.HandleRequest(db_path, rewritten);
+      }),
       plane_skill_catalog_service);
 }
 

--- a/controller/src/app/controller_route_summary_builder.cpp
+++ b/controller/src/app/controller_route_summary_builder.cpp
@@ -70,6 +70,8 @@ std::string ControllerRouteSummaryBuilder::BuildControllerRoutesSummary(
   }
   AppendRoutes(routes, {
       "/api/v1/planes/<plane>/skills",
+      "/api/v1/planes/<plane>/knowledge-vault/blocks",
+      "/api/v1/planes/<plane>/knowledge-vault/source-ingest",
       "/api/v1/skills-factory",
       "/api/v1/skills-factory/<skill>",
   });

--- a/controller/src/interaction/interaction_payload_builder.cpp
+++ b/controller/src/interaction/interaction_payload_builder.cpp
@@ -176,6 +176,7 @@ std::string BuildInteractionUpstreamBodyPayload(
   payload.erase("response_format");
   payload.erase("session_id");
   payload.erase("skill_ids");
+  payload.erase("__naim_policy_user_message");
   payload.erase(PlaneSkillsService::kSystemInstructionPayloadKey);
   payload.erase(PlaneSkillsService::kAppliedSkillsPayloadKey);
   payload.erase(PlaneSkillsService::kSkillsSessionIdPayloadKey);

--- a/controller/src/interaction/interaction_request_heuristics.cpp
+++ b/controller/src/interaction/interaction_request_heuristics.cpp
@@ -8,6 +8,10 @@ namespace naim::controller {
 
 std::string InteractionRequestHeuristics::LastUserMessageContent(
     const nlohmann::json& payload) const {
+  if (payload.contains("__naim_policy_user_message") &&
+      payload.at("__naim_policy_user_message").is_string()) {
+    return payload.at("__naim_policy_user_message").get<std::string>();
+  }
   if (!payload.contains("messages") || !payload.at("messages").is_array()) {
     return "";
   }

--- a/controller/src/interaction/interaction_request_heuristics_tests.cpp
+++ b/controller/src/interaction/interaction_request_heuristics_tests.cpp
@@ -28,6 +28,25 @@ void TestExtractsLastUserMessage() {
   std::cout << "ok: interaction-heuristics-last-user-message" << '\n';
 }
 
+void TestPrefersRawPolicyUserMessage() {
+  const naim::controller::InteractionRequestHeuristics heuristics;
+  const nlohmann::json payload = {
+      {"__naim_policy_user_message", "Who are you?"},
+      {"messages",
+       nlohmann::json::array(
+           {nlohmann::json{{"role", "system"}, {"content", "sys"}},
+            nlohmann::json{
+                {"role", "user"},
+                {"content",
+                 "Who are you?\n\nResponse language requirement: Reply in English. "
+                 "Ignore the language of the user's message and follow only this interface language setting."}}})},
+  };
+  Expect(
+      heuristics.LastUserMessageContent(payload) == "Who are you?",
+      "heuristics should prefer the raw policy user message over enriched user content");
+  std::cout << "ok: interaction-heuristics-raw-policy-user-message" << '\n';
+}
+
 void TestDetectsLongFormRequest() {
   const naim::controller::InteractionRequestHeuristics heuristics;
   Expect(
@@ -67,6 +86,7 @@ void TestCanonicalizesResponseMode() {
 int main() {
   try {
     TestExtractsLastUserMessage();
+    TestPrefersRawPolicyUserMessage();
     TestDetectsLongFormRequest();
     TestDetectsRepositoryAnalysisRequest();
     TestCanonicalizesResponseMode();

--- a/controller/src/plane/plane_http_service.cpp
+++ b/controller/src/plane/plane_http_service.cpp
@@ -373,6 +373,47 @@ HttpResponse PlaneHttpService::HandlePlanePath(
     }
   }
 
+  const auto knowledge_vault_pos = remainder.find("/knowledge-vault");
+  if (knowledge_vault_pos != std::string::npos) {
+    const bool knowledge_vault_suffix_valid =
+        knowledge_vault_pos + std::string("/knowledge-vault").size() == remainder.size() ||
+        remainder.at(knowledge_vault_pos + std::string("/knowledge-vault").size()) == '/';
+    if (knowledge_vault_suffix_valid) {
+      const std::string plane_name = remainder.substr(0, knowledge_vault_pos);
+      try {
+        naim::ControllerStore store(db_path);
+        store.Initialize();
+        const auto desired_state = store.LoadDesiredState(plane_name);
+        if (!desired_state.has_value()) {
+          return support_.build_json_response(
+              404,
+              json{{"status", "not_found"},
+                   {"message", "plane '" + plane_name + "' not found"},
+                   {"path", request.path}},
+              {});
+        }
+        if (const auto proxied = support_.handle_plane_knowledge_vault_request(
+                db_path,
+                request,
+                plane_name);
+            proxied.has_value()) {
+          return *proxied;
+        }
+        return support_.build_json_response(
+            404,
+            json{{"status", "not_found"},
+                 {"message", "plane knowledge vault route not found"},
+                 {"path", request.path}},
+            {});
+      } catch (const std::exception& error) {
+        return support_.build_json_response(
+            500,
+            json{{"status", "internal_error"}, {"message", error.what()}, {"path", request.path}},
+            {});
+      }
+    }
+  }
+
   if (request.method == "DELETE" && remainder.find('/') == std::string::npos) {
     try {
       return support_.build_json_response(

--- a/controller/src/plane/plane_http_support.cpp
+++ b/controller/src/plane/plane_http_support.cpp
@@ -8,13 +8,15 @@ PlaneHttpSupport::PlaneHttpSupport(
     const naim::controller::PlaneRegistryService& plane_registry_service,
     const naim::controller::ControllerStateService& controller_state_service,
     const naim::controller::DashboardService& dashboard_service,
-    int stale_after_seconds)
+    int stale_after_seconds,
+    PlaneKnowledgeVaultRequestFn plane_knowledge_vault_request)
     : request_support_(request_support),
       plane_mutation_service_(plane_mutation_service),
       plane_registry_service_(plane_registry_service),
       controller_state_service_(controller_state_service),
       dashboard_service_(dashboard_service),
-      stale_after_seconds_(stale_after_seconds) {}
+      stale_after_seconds_(stale_after_seconds),
+      plane_knowledge_vault_request_(std::move(plane_knowledge_vault_request)) {}
 
 HttpResponse PlaneHttpSupport::build_json_response(
     int status_code,
@@ -100,4 +102,14 @@ const naim::controller::ControllerStateService* PlaneHttpSupport::controller_sta
 
 const naim::controller::DashboardService* PlaneHttpSupport::dashboard_service() const {
   return &dashboard_service_;
+}
+
+std::optional<HttpResponse> PlaneHttpSupport::handle_plane_knowledge_vault_request(
+    const std::string& db_path,
+    const HttpRequest& request,
+    const std::string& plane_name) const {
+  if (!plane_knowledge_vault_request_) {
+    return std::nullopt;
+  }
+  return plane_knowledge_vault_request_(db_path, request, plane_name);
 }

--- a/controller/src/plane/plane_placement_payload_builder.cpp
+++ b/controller/src/plane/plane_placement_payload_builder.cpp
@@ -58,18 +58,30 @@ nlohmann::json PlanePlacementPayloadBuilder::Build() const {
     });
   }
 
-  if (const auto app_node_name = FindFirstInstanceNodeName(naim::InstanceRole::App);
-      app_node_name.has_value()) {
+  const auto app_instances = FindInstances(naim::InstanceRole::App);
+  if (!app_instances.empty()) {
     const bool external_app_host =
         desired_state_.app_host.has_value() && !desired_state_.app_host->address.empty();
-    service_targets.push_back(nlohmann::json{
-        {"service", "app"},
-        {"target_type", external_app_host ? nlohmann::json("external-app-host")
-                                          : nlohmann::json("node")},
-        {"target",
-         external_app_host ? nlohmann::json(desired_state_.app_host->address)
-                           : nlohmann::json(*app_node_name)},
-    });
+    for (const auto* instance : app_instances) {
+      if (instance == nullptr) {
+        continue;
+      }
+      const auto app_name_it = instance->environment.find("NAIM_APP_NAME");
+      const std::string app_name = app_name_it == instance->environment.end()
+                                       ? instance->name
+                                       : app_name_it->second;
+      const auto primary_it = instance->environment.find("NAIM_APP_PRIMARY");
+      const bool primary = primary_it != instance->environment.end() && primary_it->second == "true";
+      service_targets.push_back(nlohmann::json{
+          {"service", primary ? nlohmann::json("app")
+                              : nlohmann::json("app:" + app_name)},
+          {"target_type", primary && external_app_host ? nlohmann::json("external-app-host")
+                                                       : nlohmann::json("node")},
+          {"target",
+           primary && external_app_host ? nlohmann::json(desired_state_.app_host->address)
+                                        : nlohmann::json(instance->node_name)},
+      });
+    }
   }
 
   if (const auto skills_node_name = FindFirstInstanceNodeName(naim::InstanceRole::Skills);
@@ -147,6 +159,17 @@ std::optional<std::string> PlanePlacementPayloadBuilder::FindFirstInstanceNodeNa
     return std::nullopt;
   }
   return instance_it->node_name;
+}
+
+std::vector<const naim::InstanceSpec*> PlanePlacementPayloadBuilder::FindInstances(
+    naim::InstanceRole role) const {
+  std::vector<const naim::InstanceSpec*> instances;
+  for (const auto& instance : desired_state_.instances) {
+    if (instance.role == role) {
+      instances.push_back(&instance);
+    }
+  }
+  return instances;
 }
 
 std::set<std::string> PlanePlacementPayloadBuilder::FindInstanceNodeNames(

--- a/runtime/browsing/src/browsing_server_tests.cpp
+++ b/runtime/browsing/src/browsing_server_tests.cpp
@@ -21,6 +21,22 @@
 #include "browsing/browsing_server.h"
 #undef private
 
+#include "infra/controller_request_support.h"
+#include "knowledge/knowledge_vault_http_service.h"
+#include "naim/state/desired_state_v2_renderer.h"
+#include "naim/state/desired_state_v2_validator.h"
+#include "naim/state/sqlite_store.h"
+#include "plane/controller_state_service.h"
+#include "plane/dashboard_service.h"
+#include "plane/plane_http_service.h"
+#include "plane/plane_http_support.h"
+#include "plane/plane_lifecycle_support.h"
+#include "plane/plane_mutation_service.h"
+#include "plane/plane_registry_query_support.h"
+#include "plane/plane_registry_service.h"
+#include "skills/plane_skill_catalog_service.h"
+#include "skills/plane_skill_runtime_sync_service.h"
+
 namespace {
 
 void Expect(bool condition, const std::string& message) {
@@ -62,6 +78,103 @@ std::vector<nlohmann::json> ReadAuditLog(const std::filesystem::path& audit_path
     entries.push_back(nlohmann::json::parse(line));
   }
   return entries;
+}
+
+std::string MakeTempDbPath(const std::string& name) {
+  const auto root = std::filesystem::temp_directory_path() /
+                    ("naim-plane-http-tests-" + name + "-" + std::to_string(getpid()));
+  std::error_code error;
+  std::filesystem::remove_all(root, error);
+  std::filesystem::create_directories(root);
+  return (root / "controller.sqlite").string();
+}
+
+naim::DesiredState BuildPlaneDesiredState(const std::string& plane_name) {
+  const nlohmann::json value{
+      {"version", 2},
+      {"plane_name", plane_name},
+      {"plane_mode", "llm"},
+      {"model",
+       {
+           {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+           {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+           {"served_model_name", plane_name + "-model"},
+       }},
+      {"runtime",
+       {
+           {"engine", "llama.cpp"},
+           {"distributed_backend", "llama_rpc"},
+           {"workers", 1},
+       }},
+      {"infer", {{"replicas", 1}}},
+      {"skills", {{"enabled", true}, {"factory_skill_ids", nlohmann::json::array()}}},
+      {"app", {{"enabled", false}}},
+  };
+  naim::DesiredStateV2Validator::ValidateOrThrow(value);
+  return naim::DesiredStateV2Renderer::Render(value);
+}
+
+naim::controller::PlaneMutationService MakePlaneMutationService() {
+  naim::controller::PlaneMutationService::Deps deps;
+  deps.apply_desired_state =
+      [](const std::string& db_path,
+         const naim::DesiredState& desired_state,
+         const std::string&,
+         const std::string&) {
+        naim::ControllerStore store(db_path);
+        store.Initialize();
+        store.ReplaceDesiredState(desired_state);
+        return 0;
+      };
+  deps.make_plane_service = [](const std::string&) -> naim::controller::PlaneService {
+    throw std::runtime_error("plane service should not be used in plane-http smoke tests");
+  };
+  return naim::controller::PlaneMutationService(std::move(deps));
+}
+
+naim::controller::PlaneSkillCatalogService MakePlaneSkillCatalogService() {
+  return naim::controller::PlaneSkillCatalogService(
+      MakePlaneMutationService(),
+      naim::controller::PlaneSkillRuntimeSyncService(),
+      [](const std::string&, const std::string&, const std::string& fallback_artifacts_root) {
+        return fallback_artifacts_root;
+      });
+}
+
+PlaneHttpService MakePlaneHttpServiceForKnowledgeVaultSmoke() {
+  static const naim::controller::ControllerRequestSupport request_support;
+  static const auto plane_mutation_service = MakePlaneMutationService();
+  static const auto plane_registry_service =
+      naim::controller::PlaneRegistryService({}, {});
+  static const auto controller_state_service = naim::controller::ControllerStateService();
+  static const auto dashboard_service =
+      naim::controller::DashboardService(naim::controller::DashboardService::Deps{});
+
+  return PlaneHttpService(
+      PlaneHttpSupport(
+          request_support,
+          plane_mutation_service,
+          plane_registry_service,
+          controller_state_service,
+          dashboard_service,
+          60,
+          [](const std::string& db_path,
+             const HttpRequest& request,
+             const std::string&) -> std::optional<HttpResponse> {
+            static const auto knowledge_vault_http_service =
+                naim::controller::KnowledgeVaultHttpService();
+            HttpRequest rewritten = request;
+            constexpr const char* kPlanePrefix = "/api/v1/planes/";
+            const std::string remainder =
+                request.path.substr(std::string(kPlanePrefix).size());
+            const auto separator = remainder.find('/');
+            if (separator == std::string::npos) {
+              return std::nullopt;
+            }
+            rewritten.path = "/api/v1" + remainder.substr(separator);
+            return knowledge_vault_http_service.HandleRequest(db_path, rewritten);
+          }),
+      MakePlaneSkillCatalogService());
 }
 
 void TestPolicyParsing() {
@@ -448,6 +561,48 @@ void TestWebGatewayReviewBlocksLocalAccessSuggestions() {
       "blocked WebGateway review should return the provided refusal");
 }
 
+void TestPlaneKnowledgeVaultRouteRequiresExistingPlane() {
+  const std::string db_path = MakeTempDbPath("missing-plane");
+  naim::ControllerStore store(db_path);
+  store.Initialize();
+
+  auto plane_http_service = MakePlaneHttpServiceForKnowledgeVaultSmoke();
+  HttpRequest request;
+  request.method = "GET";
+  request.path =
+      "/api/v1/planes/lt-cypher-ai/knowledge-vault/blocks/lt-cypher-ai.market.global";
+
+  const auto response = plane_http_service.HandleRequest(db_path, "/tmp", request);
+  Expect(response.has_value(), "plane knowledge vault request should be handled");
+  Expect(response->status_code == 404, "missing plane should return 404");
+  const auto payload = nlohmann::json::parse(response->body);
+  Expect(
+      payload.value("message", std::string{}).find("plane 'lt-cypher-ai' not found") !=
+          std::string::npos,
+      "missing plane response should name the plane");
+}
+
+void TestPlaneKnowledgeVaultRouteRewritesIntoKnowledgeVaultService() {
+  const std::string db_path = MakeTempDbPath("existing-plane");
+  naim::ControllerStore store(db_path);
+  store.Initialize();
+  store.ReplaceDesiredState(BuildPlaneDesiredState("lt-cypher-ai"), 1);
+
+  auto plane_http_service = MakePlaneHttpServiceForKnowledgeVaultSmoke();
+  HttpRequest request;
+  request.method = "GET";
+  request.path =
+      "/api/v1/planes/lt-cypher-ai/knowledge-vault/blocks/lt-cypher-ai.market.global";
+
+  const auto response = plane_http_service.HandleRequest(db_path, "/tmp", request);
+  Expect(response.has_value(), "plane knowledge vault request should be handled");
+  Expect(response->status_code == 404, "unconfigured knowledge vault should return 404");
+  const auto payload = nlohmann::json::parse(response->body);
+  Expect(
+      payload.value("message", std::string{}) == "knowledge vault service not configured",
+      "existing plane knowledge-vault route should rewrite into knowledge vault service");
+}
+
 }  // namespace
 
 int main() {
@@ -468,6 +623,8 @@ int main() {
     TestWebGatewayDisabledContextDefaults();
     TestWebGatewayResolveBlocksRestrictedTargets();
     TestWebGatewayReviewBlocksLocalAccessSuggestions();
+    TestPlaneKnowledgeVaultRouteRequiresExistingPlane();
+    TestPlaneKnowledgeVaultRouteRewritesIntoKnowledgeVaultService();
     std::cout << "browsing server tests passed\n";
     return 0;
   } catch (const std::exception& error) {

--- a/ui/operator-react/src/planeV2Form.jsx
+++ b/ui/operator-react/src/planeV2Form.jsx
@@ -147,6 +147,7 @@ const FIELD_INFO = {
   inferStorageMountPath: "Mount path for the infer private volume inside the container.",
   inferEnv: "Extra environment variables injected into the infer container.",
   appEnabled: "Enable an application container that uses this plane as a backend.",
+  extraAppName: "Stable logical name for an additional app container in this plane.",
   appImage: "Docker image used for the app container.",
   appStartType: "How the app process is started inside the container.",
   appStartValue: "Script reference or command executed when the app container starts.",
@@ -192,6 +193,99 @@ function renderEnvText(env) {
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([key, value]) => `${key}=${value}`)
     .join("\n");
+}
+
+function buildExtraAppState(overrides = {}) {
+  return {
+    name: "",
+    enabled: true,
+    image: "",
+    startType: "command",
+    startValue: "",
+    envText: "",
+    hostPort: "",
+    containerPort: 8080,
+    node: "",
+    volumeEnabled: false,
+    volumeName: "private-data",
+    volumeType: "persistent",
+    volumeSizeGb: 8,
+    volumeMountPath: "/naim/private",
+    volumeAccess: "rw",
+    ...overrides,
+  };
+}
+
+function appEntryFromDesiredState(app) {
+  const start = app?.start || {};
+  const publish =
+    Array.isArray(app?.publish) && app.publish.length > 0 ? app.publish[0] : {};
+  const volume =
+    Array.isArray(app?.volumes) && app.volumes.length > 0 ? app.volumes[0] : {};
+  return buildExtraAppState({
+    name: app?.name || "",
+    enabled: app?.enabled ?? true,
+    image: app?.image || "",
+    startType: start.type || "command",
+    startValue: start.script_ref || start.command || "",
+    envText: renderEnvText(app?.env),
+    hostPort: publish.host_port ?? "",
+    containerPort: Number(publish.container_port ?? 8080),
+    node: app?.node || "",
+    volumeEnabled: Boolean(volume?.name),
+    volumeName: volume?.name || "private-data",
+    volumeType: volume?.type || "persistent",
+    volumeSizeGb: Number(volume?.size_gb ?? 8),
+    volumeMountPath: volume?.mount_path || "/naim/private",
+    volumeAccess: volume?.access || "rw",
+  });
+}
+
+function buildDesiredStateAppFromEntry(entry, includeName = false) {
+  const rendered = {
+    enabled: entry?.enabled ?? true,
+    image: String(entry?.image || "").trim(),
+  };
+  if (includeName) {
+    rendered.name = String(entry?.name || "").trim();
+    rendered.primary = false;
+  }
+  if (String(entry?.startValue || "").trim()) {
+    rendered.start =
+      entry?.startType === "script"
+        ? { type: "script", script_ref: String(entry.startValue).trim() }
+        : { type: "command", command: String(entry.startValue).trim() };
+  }
+  const env = parseEnvText(String(entry?.envText || ""));
+  if (Object.keys(env).length > 0) {
+    rendered.env = env;
+  }
+  if (String(entry?.node || "").trim()) {
+    rendered.node = String(entry.node).trim();
+  }
+  const hostPort = Number(entry?.hostPort);
+  const containerPort = Number(entry?.containerPort);
+  if (Number.isFinite(hostPort) && hostPort > 0 && Number.isFinite(containerPort) && containerPort > 0) {
+    rendered.publish = [
+      {
+        host_ip: "127.0.0.1",
+        host_port: hostPort,
+        container_port: containerPort,
+      },
+    ];
+  }
+  if (entry?.volumeEnabled) {
+    rendered.volumes = [
+      {
+        name: String(entry?.volumeName || "").trim() || "private-data",
+        type: entry?.volumeType || "persistent",
+        size_gb: parseNumber(entry?.volumeSizeGb, 8),
+        mount_path: String(entry?.volumeMountPath || "").trim() || "/naim/private",
+        access: entry?.volumeAccess || "rw",
+      },
+    ];
+  }
+  return rendered;
 }
 
 function normalizeSearchText(value) {
@@ -253,14 +347,20 @@ function applyLtCypherPresetToForm(form, modelLibraryItems) {
   const sourceQuantization = inferModelQuantization(modelItem) || "Q8_0";
   const appEnv = {
     CYPHER_ACTION_AUDIT_LOG_FILE: "/naim/private/action-audit.log",
-    CYPHER_API_BASE: "http://infer-lt-cypher-ai:18084/v1",
+    CYPHER_API_BASE: "http://interaction-lt-cypher-ai:18110/v1",
     CYPHER_CONTROLLER_SESSION_FILE: "/naim/private/controller-session-token",
-    CYPHER_MARKET_MEMORY_DB_FILE: "/naim/private/market-memory.sqlite",
+    CYPHER_MARKET_BACKGROUND_REFRESH_ENABLED: "false",
     CYPHER_PLANE_API_BASE: "http://controller.internal:18080/api/v1/planes/lt-cypher-ai",
     CYPHER_PUBLIC_BASE_PATH: "/",
     HOST: "0.0.0.0",
     LOCALTRADE_ACTIONS_ENABLED: "true",
     PORT: "8080",
+  };
+  const collectorEnv = {
+    CYPHER_CONTROLLER_SESSION_FILE: "/naim/private/controller-session-token",
+    CYPHER_MARKET_BACKGROUND_REFRESH_ENABLED: "true",
+    CYPHER_MARKET_COLLECTOR_ENABLED: "true",
+    CYPHER_PLANE_API_BASE: "http://controller.internal:18080/api/v1/planes/lt-cypher-ai",
   };
   return {
     ...form,
@@ -329,6 +429,20 @@ function applyLtCypherPresetToForm(form, modelLibraryItems) {
     appVolumeSizeGb: 8,
     appVolumeMountPath: "/naim/private",
     appVolumeAccess: "rw",
+    extraApps: [
+      buildExtraAppState({
+        name: "market-ingest",
+        enabled: true,
+        image: form.appImage?.startsWith(LT_CYPHER_HARBOR_IMAGE_PREFIX)
+          ? form.appImage
+          : LT_CYPHER_DEFAULT_IMAGE,
+        startType: "command",
+        startValue: "node market-collector.js",
+        envText: renderEnvText(collectorEnv),
+        node: "hpc1",
+        volumeEnabled: true,
+      }),
+    ],
     postDeployScript: "",
   };
 }
@@ -439,7 +553,12 @@ function deriveExecutionNodeFromDesiredStateV2(value) {
   if (workerNode) {
     return workerNode;
   }
-  const appNode = String(value?.app?.node || "").trim();
+  const primaryAppNode = String(
+    (Array.isArray(value?.apps)
+      ? (value.apps.find((item) => item?.primary) || value.apps[0])?.node
+      : value?.app?.node) || "",
+  ).trim();
+  const appNode = primaryAppNode;
   if (appNode) {
     return appNode;
   }
@@ -555,6 +674,7 @@ export function buildNewPlaneFormState() {
     appVolumeSizeGb: 8,
     appVolumeMountPath: "/naim/private",
     appVolumeAccess: "rw",
+    extraApps: [],
     placementMode: "auto",
     shareMode: "exclusive",
     gpuFraction: 1.0,
@@ -572,7 +692,17 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
   const network = value?.network || {};
   const infer = value?.infer || {};
   const worker = value?.worker || {};
-  const app = value?.app || {};
+  const rawApps = Array.isArray(value?.apps)
+    ? value.apps.filter((item) => item && typeof item === "object")
+    : (value?.app && typeof value.app === "object" ? [value.app] : []);
+  const primaryApp =
+    rawApps.find((item) => item?.primary) ||
+    rawApps[0] ||
+    {};
+  const extraApps = rawApps
+    .filter((item) => item !== primaryApp)
+    .map((item) => appEntryFromDesiredState(item));
+  const app = primaryApp;
   const workerResources = value?.resources?.worker || {};
   const appStart = app?.start || {};
   const inferStart = infer?.start || {};
@@ -719,6 +849,7 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
     appVolumeSizeGb: Number(appVolume.size_gb ?? defaults.appVolumeSizeGb),
     appVolumeMountPath: appVolume.mount_path || defaults.appVolumeMountPath,
     appVolumeAccess: appVolume.access || defaults.appVolumeAccess,
+    extraApps,
     placementMode: workerResources.placement_mode || defaults.placementMode,
     shareMode: workerResources.share_mode || defaults.shareMode,
     gpuFraction: normalizeShareModeGpuFraction(
@@ -794,9 +925,6 @@ export function buildDesiredStateV2FromForm(form) {
     },
     placement: {
       execution_node: String(form.executionNode || "").trim() || "local-hostd",
-    },
-    app: {
-      enabled: Boolean(form.appEnabled),
     },
     resources: {
       worker: {
@@ -1061,38 +1189,52 @@ export function buildDesiredStateV2FromForm(form) {
     }
   }
 
-  if (form.appEnabled) {
-    desiredState.app.image = form.appImage.trim();
-    if (form.appStartValue.trim()) {
-      desiredState.app.start =
-        form.appStartType === "script"
-          ? { type: "script", script_ref: form.appStartValue.trim() }
-          : { type: "command", command: form.appStartValue.trim() };
+  const extraApps = (Array.isArray(form.extraApps) ? form.extraApps : [])
+    .map((entry) => ({
+      ...entry,
+      name: String(entry?.name || "").trim(),
+      image: String(entry?.image || "").trim(),
+      node: String(entry?.node || "").trim(),
+    }))
+    .filter((entry) => entry.name || entry.image || entry.startValue || entry.envText || entry.node);
+
+  const primaryApp = buildDesiredStateAppFromEntry(
+    {
+      enabled: Boolean(form.appEnabled),
+      image: form.appImage,
+      startType: form.appStartType,
+      startValue: form.appStartValue,
+      envText: form.appEnvText,
+      node: form.topologyEnabled ? form.appNode : "",
+      hostPort: form.appHostPort,
+      containerPort: form.appContainerPort,
+      volumeEnabled: form.appVolumeEnabled,
+      volumeName: form.appVolumeName,
+      volumeType: form.appVolumeType,
+      volumeSizeGb: form.appVolumeSizeGb,
+      volumeMountPath: form.appVolumeMountPath,
+      volumeAccess: form.appVolumeAccess,
+    },
+    false,
+  );
+
+  if (extraApps.length > 0) {
+    desiredState.apps = [];
+    if (Boolean(form.appEnabled)) {
+      desiredState.apps.push({ ...primaryApp, primary: true });
     }
-    const appEnv = parseEnvText(form.appEnvText);
-    if (Object.keys(appEnv).length > 0) {
-      desiredState.app.env = appEnv;
+    for (const entry of extraApps) {
+      desiredState.apps.push(buildDesiredStateAppFromEntry(entry, true));
     }
-    if (form.topologyEnabled && form.appNode.trim()) {
-      desiredState.app.node = form.appNode.trim();
+    if (desiredState.apps.length === 0) {
+      desiredState.apps.push({ enabled: false, name: "primary", primary: true, image: "" });
     }
-    desiredState.app.publish = [
-      {
-        host_ip: "127.0.0.1",
-        host_port: parseNumber(form.appHostPort, 18010),
-        container_port: parseNumber(form.appContainerPort, 8080),
-      },
-    ];
-    if (form.appVolumeEnabled) {
-      desiredState.app.volumes = [
-        {
-          name: form.appVolumeName.trim() || "private-data",
-          type: form.appVolumeType,
-          size_gb: parseNumber(form.appVolumeSizeGb, 8),
-          mount_path: form.appVolumeMountPath.trim() || "/naim/private",
-          access: form.appVolumeAccess,
-        },
-      ];
+  } else {
+    desiredState.app = {
+      enabled: Boolean(form.appEnabled),
+    };
+    if (form.appEnabled) {
+      Object.assign(desiredState.app, primaryApp);
     }
   }
 
@@ -1184,6 +1326,25 @@ export function validatePlaneV2Form(form) {
   if (form?.appEnabled && !String(form?.appImage || "").trim()) {
     errors.push("App image is required when app is enabled.");
   }
+  const extraApps = Array.isArray(form?.extraApps) ? form.extraApps : [];
+  for (const entry of extraApps) {
+    if (!String(entry?.name || "").trim()) {
+      errors.push("Each additional app must have a name.");
+    }
+    if (!String(entry?.image || "").trim()) {
+      errors.push(`Additional app '${String(entry?.name || "").trim() || "unnamed"}' requires an image.`);
+    }
+  }
+  const duplicateExtraAppNames = extraApps
+    .map((entry) => String(entry?.name || "").trim())
+    .filter(Boolean)
+    .filter((name, index, values) => values.indexOf(name) !== index);
+  if (duplicateExtraAppNames.length > 0) {
+    errors.push("Additional app names must be unique.");
+  }
+  if (extraApps.length > 0 && !form?.appEnabled) {
+    warnings.push("Additional app containers are configured while the primary app is disabled.");
+  }
   if (form?.planeMode === "compute") {
     if (!String(form?.workerImage || "").trim()) {
       errors.push("Worker image is required for compute planes.");
@@ -1226,6 +1387,7 @@ export function validatePlaneV2Form(form) {
     String(form?.inferNode || "").trim(),
     String(form?.workerNode || "").trim(),
     String(form?.appNode || "").trim(),
+    ...extraApps.map((entry) => String(entry?.node || "").trim()),
     ...enabledAssignments.map((assignment) => String(assignment.node || "").trim()),
   ].filter(Boolean);
 
@@ -1269,6 +1431,13 @@ export function validatePlaneV2Form(form) {
   }
   if (form?.appEnabled && !String(form?.appStartValue || "").trim()) {
     warnings.push("App start is empty. The app container will rely on its image default command.");
+  }
+  for (const entry of extraApps) {
+    if (!String(entry?.startValue || "").trim()) {
+      warnings.push(
+        `Additional app '${String(entry?.name || "").trim() || "unnamed"}' start is empty. The container will rely on its image default command.`,
+      );
+    }
   }
 
   return { errors, warnings };
@@ -1768,6 +1937,44 @@ export function PlaneV2FormBuilder({
         }
         return next;
       });
+  }
+
+  function updateExtraApp(index, updater) {
+    updatePlaneDialogForm(setDialog, (current) => {
+      const extraApps = Array.isArray(current.extraApps) ? [...current.extraApps] : [];
+      if (index < 0 || index >= extraApps.length) {
+        return current;
+      }
+      extraApps[index] =
+        typeof updater === "function" ? updater(extraApps[index]) : { ...extraApps[index], ...updater };
+      return {
+        ...current,
+        extraApps,
+      };
+    });
+  }
+
+  function addExtraApp() {
+    updatePlaneDialogForm(setDialog, (current) => ({
+      ...current,
+      extraApps: [
+        ...(Array.isArray(current.extraApps) ? current.extraApps : []),
+        buildExtraAppState({
+          name: `app-${(Array.isArray(current.extraApps) ? current.extraApps.length : 0) + 1}`,
+          node:
+            current.topologyEnabled ? current.appNode || current.inferNode || current.workerNode || "" : "",
+        }),
+      ],
+    }));
+  }
+
+  function removeExtraApp(index) {
+    updatePlaneDialogForm(setDialog, (current) => ({
+      ...current,
+      extraApps: (Array.isArray(current.extraApps) ? current.extraApps : []).filter(
+        (_, itemIndex) => itemIndex !== index,
+      ),
+    }));
   }
 
   function bindPlaneMode() {
@@ -3350,7 +3557,7 @@ export function PlaneV2FormBuilder({
         ) : null}
       </AdvancedSection>
 
-      {form.appEnabled ? (
+      {form.appEnabled || (Array.isArray(form.extraApps) && form.extraApps.length > 0) ? (
         <AdvancedSection
           title="App advanced"
           description="Keep app storage and wiring explicit because app containers are treated as opaque user workloads."
@@ -3573,6 +3780,175 @@ export function PlaneV2FormBuilder({
               </div>
             </>
           ) : null}
+
+          <div className="plane-form-section-header" style={{ marginTop: 20 }}>
+            <div className="section-label">Additional apps</div>
+            <p className="plane-form-section-copy">
+              Add extra plane-scoped app containers. External app host remains primary-app only.
+            </p>
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 12 }}>
+            <button className="ghost-button" type="button" onClick={addExtraApp}>
+              Add app
+            </button>
+          </div>
+          {(Array.isArray(form.extraApps) ? form.extraApps : []).map((entry, index) => (
+            <div key={`extra-app-${index}`} className="plane-form-section" style={{ marginTop: 12 }}>
+              <div
+                className="plane-form-grid"
+                style={{ gridTemplateColumns: "minmax(0,1fr) minmax(0,1fr) auto", alignItems: "end" }}
+              >
+                <label className="field-label">
+                  <InfoLabel info={FIELD_INFO.extraAppName}>App name</InfoLabel>
+                  <input
+                    className="text-input"
+                    value={entry.name}
+                    onChange={(event) =>
+                      updateExtraApp(index, { name: event.target.value })
+                    }
+                  />
+                </label>
+                <label className="field-label">
+                  <InfoLabel info={FIELD_INFO.appImage}>App image</InfoLabel>
+                  <input
+                    className="text-input"
+                    value={entry.image}
+                    onChange={(event) =>
+                      updateExtraApp(index, { image: event.target.value })
+                    }
+                  />
+                </label>
+                <button className="ghost-button" type="button" onClick={() => removeExtraApp(index)}>
+                  Remove
+                </button>
+              </div>
+              <div className="plane-form-grid">
+                <label className="field-label">
+                  <InfoLabel info={FIELD_INFO.appStartType}>App start type</InfoLabel>
+                  <select
+                    className="text-input"
+                    value={entry.startType}
+                    onChange={(event) =>
+                      updateExtraApp(index, { startType: event.target.value })
+                    }
+                  >
+                    <option value="script">script</option>
+                    <option value="command">command</option>
+                  </select>
+                </label>
+                <label className="field-label">
+                  <InfoLabel info={FIELD_INFO.appStartValue}>
+                    {entry.startType === "script" ? "App script ref" : "App command"}
+                  </InfoLabel>
+                  <input
+                    className="text-input"
+                    value={entry.startValue}
+                    onChange={(event) =>
+                      updateExtraApp(index, { startValue: event.target.value })
+                    }
+                  />
+                </label>
+              </div>
+              <div className="plane-form-grid">
+                <label className="field-label">
+                  <InfoLabel info={FIELD_INFO.appHostPort}>App host port</InfoLabel>
+                  <input
+                    className="text-input"
+                    type="number"
+                    min="0"
+                    value={entry.hostPort}
+                    onChange={(event) =>
+                      updateExtraApp(index, { hostPort: event.target.value })
+                    }
+                  />
+                </label>
+                <label className="field-label">
+                  <InfoLabel info={FIELD_INFO.appContainerPort}>App container port</InfoLabel>
+                  <input
+                    className="text-input"
+                    type="number"
+                    min="1"
+                    value={entry.containerPort}
+                    onChange={(event) =>
+                      updateExtraApp(index, { containerPort: event.target.value })
+                    }
+                  />
+                </label>
+                {form.topologyEnabled ? (
+                  <label className="field-label">
+                    <InfoLabel info={FIELD_INFO.appNode}>App node</InfoLabel>
+                    <input
+                      className="text-input"
+                      value={entry.node}
+                      onChange={(event) =>
+                        updateExtraApp(index, { node: event.target.value })
+                      }
+                    />
+                  </label>
+                ) : null}
+              </div>
+              <label className="field-label">
+                <InfoLabel info={FIELD_INFO.appEnv}>App env</InfoLabel>
+                <textarea
+                  className="editor-textarea plane-form-textarea"
+                  value={entry.envText}
+                  onChange={(event) =>
+                    updateExtraApp(index, { envText: event.target.value })
+                  }
+                />
+              </label>
+              <div className="plane-form-grid">
+                <label className="field-label plane-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(entry.volumeEnabled)}
+                    onChange={(event) =>
+                      updateExtraApp(index, { volumeEnabled: event.target.checked })
+                    }
+                  />
+                  <InfoLabel info={FIELD_INFO.appVolumeEnabled} className="field-label-inline">
+                    App volume
+                  </InfoLabel>
+                </label>
+              </div>
+              {entry.volumeEnabled ? (
+                <div className="plane-form-grid">
+                  <label className="field-label">
+                    <InfoLabel info={FIELD_INFO.appVolumeName}>App volume name</InfoLabel>
+                    <input
+                      className="text-input"
+                      value={entry.volumeName}
+                      onChange={(event) =>
+                        updateExtraApp(index, { volumeName: event.target.value })
+                      }
+                    />
+                  </label>
+                  <label className="field-label">
+                    <InfoLabel info={FIELD_INFO.appVolumeSizeGb}>App volume size GB</InfoLabel>
+                    <input
+                      className="text-input"
+                      type="number"
+                      min="1"
+                      value={entry.volumeSizeGb}
+                      onChange={(event) =>
+                        updateExtraApp(index, { volumeSizeGb: event.target.value })
+                      }
+                    />
+                  </label>
+                  <label className="field-label">
+                    <InfoLabel info={FIELD_INFO.appVolumeMountPath}>App volume mount path</InfoLabel>
+                    <input
+                      className="text-input"
+                      value={entry.volumeMountPath}
+                      onChange={(event) =>
+                        updateExtraApp(index, { volumeMountPath: event.target.value })
+                      }
+                    />
+                  </label>
+                </div>
+              ) : null}
+            </div>
+          ))}
         </AdvancedSection>
       ) : null}
 

--- a/ui/operator-react/src/skillsFactory.test.js
+++ b/ui/operator-react/src/skillsFactory.test.js
@@ -291,6 +291,56 @@ describe("planeV2Form SkillsFactory mapping", () => {
     });
   });
 
+  it("round-trips multiple app containers through desired state v2", () => {
+    const form = buildNewPlaneFormState();
+    form.planeName = "multi-app-plane";
+    form.modelPath = "/models/qwen";
+    form.appEnabled = true;
+    form.appImage = "example/app:dev";
+    form.appStartType = "script";
+    form.appStartValue = "node server.js";
+    form.extraApps = [
+      {
+        name: "market-ingest",
+        enabled: true,
+        image: "example/app:dev",
+        startType: "script",
+        startValue: "node market-collector.js",
+        hostPort: "",
+        containerPort: "",
+        node: "hpc1",
+        envText: "CYPHER_MARKET_COLLECTOR_ENABLED=true",
+        volumeEnabled: true,
+        volumeName: "market-ingest-data",
+        volumeSizeGb: "5",
+        volumeMountPath: "/naim/private",
+      },
+    ];
+
+    const desiredState = buildDesiredStateV2FromForm(form);
+    expect(desiredState.app).toBeUndefined();
+    expect(desiredState.apps).toHaveLength(2);
+    expect(desiredState.apps[0]).toMatchObject({
+      primary: true,
+      enabled: true,
+      image: "example/app:dev",
+    });
+    expect(desiredState.apps[1]).toMatchObject({
+      name: "market-ingest",
+      primary: false,
+      enabled: true,
+      image: "example/app:dev",
+      node: "hpc1",
+    });
+
+    const reparsed = buildPlaneFormStateFromDesiredStateV2(desiredState);
+    expect(reparsed.appEnabled).toBe(true);
+    expect(reparsed.extraApps).toHaveLength(1);
+    expect(reparsed.extraApps[0].name).toBe("market-ingest");
+    expect(reparsed.extraApps[0].startValue).toBe("node market-collector.js");
+    expect(reparsed.extraApps[0].node).toBe("hpc1");
+  });
+
   it("does not serialize turboquant for compute planes", () => {
     const form = buildNewPlaneFormState();
     form.planeMode = "compute";


### PR DESCRIPTION
## Summary
- add desired-state v2 multi-app support with UI coverage for additional app containers
- expose plane-level Knowledge Vault ingress under `/api/v1/planes/<plane>/knowledge-vault/*`
- add smoke coverage for plane-level KV routing and E2E coverage for `market-ingest -> plane-owned KV -> primary app`

## Validation
- `git diff --check`
- `node --test /mnt/e/dev/repos/ai/lt-cypher-ai/test/market-skills.test.js`
- `/usr/bin/c++ ... -fsyntax-only /mnt/e/dev/Repos/ai/naim-node/runtime/browsing/src/browsing_server_tests.cpp`

## Notes
- live controller on `main` still returns `404` for plane-level KV ingress, so real plane-level live smoke requires deploy of this branch first
- full native `cmake --build` still hits the existing generator/ninja crash path, so validation here is targeted rather than full build