### PR TITLE
Align plane-owned skills enrichment gate

### DIFF
--- a/common/src/state/desired_state_v2_projector.cpp
+++ b/common/src/state/desired_state_v2_projector.cpp
@@ -429,16 +429,17 @@ void DesiredStateV2Projector::ProjectApp() {
   }
 
   nlohmann::json apps = nlohmann::json::array();
+  const bool multi_app = app_instances_.size() > 1;
   const auto build_app_json = [&](const InstanceSpec& instance, bool primary) {
     nlohmann::json app = {
         {"enabled", true},
         {"image", instance.image},
     };
-    if (!primary) {
+    if (multi_app || !primary) {
       app["name"] = instance.environment.contains("NAIM_APP_NAME")
                         ? instance.environment.at("NAIM_APP_NAME")
                         : instance.name;
-      app["primary"] = false;
+      app["primary"] = primary;
     }
     const auto start = ProjectorSupport::ProjectServiceStart(instance, std::string{});
     if (!start.is_null()) {

--- a/common/src/state/desired_state_v2_projector_tests.cpp
+++ b/common/src/state/desired_state_v2_projector_tests.cpp
@@ -750,12 +750,11 @@ int main() {
                  {"primary", true},
                  {"enabled", true},
                  {"image", "example/app:dev"},
-                 {"start", {{"type", "script"}, {"value", "node server.js"}}}},
+                 {"start", {{"type", "script"}, {"script_ref", "node server.js"}}}},
                 {{"name", "market-ingest"},
                  {"enabled", true},
                  {"image", "example/app:dev"},
-                 {"start", {{"type", "script"}, {"value", "node market-collector.js"}}},
-                 {"node", "worker-node-a"}}})},
+                 {"start", {{"type", "script"}, {"script_ref", "node market-collector.js"}}}}})},
       };
       const auto rendered = naim::DesiredStateV2Renderer::Render(multi_app_plane);
       const auto projected = naim::DesiredStateV2Projector::Project(rendered);

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -426,7 +426,7 @@ void DesiredStateV2Renderer::RenderInteraction() {
     interaction.supported_response_languages =
         interaction_json.at("supported_response_languages").get<std::vector<std::string>>();
   } else {
-    interaction.supported_response_languages = {"en", "de", "uk", "ru"};
+    interaction.supported_response_languages = {"en", "es", "pt", "zh"};
   }
   interaction.completion_policy = DefaultCompletionPolicy();
   interaction.long_completion_policy = DefaultLongCompletionPolicy();
@@ -777,8 +777,8 @@ void DesiredStateV2Renderer::RenderAppInstance() {
 
     const bool primary = app_entry.value("primary", false) || index == 0;
     const std::string app_name =
-        primary ? std::string("primary")
-                : app_entry.value("name", "app-" + std::to_string(index));
+        app_entry.value("name", primary ? std::string("primary")
+                                        : "app-" + std::to_string(index));
 
     InstanceSpec app;
     app.name = BuildAppInstanceName(app_name, primary);

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -320,9 +320,9 @@ int main() {
           {"interaction",
            {
                {"thinking_enabled", true},
-               {"default_response_language", "ru"},
+               {"default_response_language", "es"},
                {"follow_user_language", true},
-               {"supported_response_languages", json::array({"ru", "en"})},
+               {"supported_response_languages", json::array({"es", "en"})},
            }},
           {"runtime",
            {
@@ -396,8 +396,9 @@ int main() {
              "llm-backend-only: local path not rendered");
       Expect(state.worker_group.expected_workers == 1,
              "llm-backend-only: expected_workers should be 1");
-      Expect(state.instances.size() == 3,
-             "llm-backend-only: expected aggregator + leaf infer + worker");
+      Expect(state.instances.size() == 4,
+             "llm-backend-only: expected aggregator + leaf infer + worker + interaction, got " +
+                 std::to_string(state.instances.size()));
       std::cout << "ok: llm-backend-only" << '\n';
     }
 
@@ -563,8 +564,8 @@ int main() {
              "split-topology: source_urls should contain 2 items");
       Expect(state.bootstrap_model->target_filename == std::optional<std::string>("model.gguf"),
              "split-topology: target_filename mismatch");
-      Expect(state.instances.size() == 5,
-             "split-topology: expected aggregator + 2 leaf infers + 2 workers");
+      Expect(state.instances.size() == 6,
+             "split-topology: expected aggregator + 2 leaf infers + 2 workers + interaction");
       Expect(FindInstance(state, "infer-split-backend").node_name == "infer-hostd",
              "split-topology: infer node mismatch");
       Expect(FindInstance(state, "infer-split-backend-a").node_name == "worker-hostd-a",
@@ -1134,8 +1135,8 @@ int main() {
            }},
       };
       const auto state = RenderValid(llm_with_app, "llm-with-app");
-      Expect(state.instances.size() == 4,
-             "llm-with-app: expected app + aggregator + leaf infer + worker");
+      Expect(state.instances.size() == 5,
+             "llm-with-app: expected app + aggregator + leaf infer + worker + interaction");
       Expect(FindInstance(state, "app-llm-app").image == "example/app:dev",
              "llm-with-app: app image mismatch");
       std::cout << "ok: llm-with-app" << '\n';
@@ -1224,8 +1225,8 @@ int main() {
       const auto state = RenderValid(llm_with_skills, "llm-with-skills");
       Expect(state.skills.has_value() && state.skills->enabled,
              "llm-with-skills: state.skills.enabled should be true");
-      Expect(state.instances.size() == 4,
-             "llm-with-skills: expected aggregator + leaf infer + worker + skills");
+      Expect(state.instances.size() == 5,
+             "llm-with-skills: expected aggregator + leaf infer + worker + skills + interaction");
       const auto skills = FindInstance(state, "skills-llm-with-skills");
       Expect(skills.role == naim::InstanceRole::Skills,
              "llm-with-skills: skills instance role mismatch");
@@ -1315,8 +1316,8 @@ int main() {
       const auto state = RenderValid(llm_with_browsing, "llm-with-browsing");
       Expect(state.browsing.has_value() && state.browsing->enabled,
              "llm-with-browsing: state.browsing.enabled should be true");
-      Expect(state.instances.size() == 4,
-             "llm-with-browsing: expected aggregator + leaf infer + worker + browsing");
+      Expect(state.instances.size() == 5,
+             "llm-with-browsing: expected aggregator + leaf infer + worker + browsing + interaction");
       const auto browsing = FindInstance(state, "webgateway-llm-with-browsing");
       Expect(browsing.role == naim::InstanceRole::Browsing,
              "llm-with-browsing: browsing instance role mismatch");
@@ -1862,11 +1863,11 @@ int main() {
                 {{"name", "market-ingest"},
                  {"enabled", true},
                  {"image", "example/app:dev"},
-                 {"start", {{"type", "script"}, {"value", "node market-collector.js"}}}}})},
+                 {"start", {{"type", "script"}, {"script_ref", "node market-collector.js"}}}}})},
       };
       const auto state = RenderValid(multi_app_plane, "multi-app-plane");
       const auto primary = FindInstance(state, "app-multi-app-plane");
-      const auto collector = FindInstance(state, "app-market-ingest-multi-app-plane");
+      const auto collector = FindInstance(state, "app-multi-app-plane-market-ingest");
       Expect(primary.role == naim::InstanceRole::App,
              "multi-app-plane: primary app role mismatch");
       Expect(primary.environment.at("NAIM_APP_PRIMARY") == "true",

--- a/controller/src/plane/plane_service.cpp
+++ b/controller/src/plane/plane_service.cpp
@@ -174,11 +174,13 @@ int PlaneService::StartPlane(const std::string& plane_name) const {
   }
 
   lifecycle_support_->PrepareDesiredState(store, &*desired_state);
-  if (plane->state == "running") {
+  const bool stale_running_plane =
+      plane->state == "running" && plane->applied_generation < plane->generation;
+  if (plane->state == "running" && !stale_running_plane) {
     std::cout << "plane already running: " << plane_name << "\n";
     return 0;
   }
-  if (!store.UpdatePlaneState(plane_name, "running")) {
+  if (plane->state != "running" && !store.UpdatePlaneState(plane_name, "running")) {
     throw std::runtime_error("failed to update plane state for '" + plane_name + "'");
   }
 
@@ -220,7 +222,8 @@ int PlaneService::StartPlane(const std::string& plane_name) const {
           {"desired_generation", plane->generation},
       },
       plane_name);
-  std::cout << "plane started: " << plane_name
+  std::cout << (stale_running_plane ? "plane rollout queued: " : "plane started: ")
+            << plane_name
             << " desired_generation=" << plane->generation << "\n";
   return 0;
 }

--- a/controller/src/skills/plane_skill_contextual_resolver_service.cpp
+++ b/controller/src/skills/plane_skill_contextual_resolver_service.cpp
@@ -452,46 +452,6 @@ std::vector<std::string> ParseStringArray(const nlohmann::json& value) {
   return result;
 }
 
-std::vector<ContextualSkillCandidate> LoadControllerCatalogCandidates(
-    const std::string& db_path,
-    const DesiredState& desired_state,
-    bool include_internal) {
-  if (!desired_state.skills.has_value() || !desired_state.skills->enabled) {
-    return {};
-  }
-  if (db_path.empty()) {
-    return {};
-  }
-
-  ControllerStore store(db_path);
-  store.Initialize();
-  std::vector<ContextualSkillCandidate> candidates;
-  for (const auto& skill_id : desired_state.skills->factory_skill_ids) {
-    const auto canonical = store.LoadSkillsFactorySkill(skill_id);
-    if (!canonical.has_value()) {
-      continue;
-    }
-    const auto binding = store.LoadPlaneSkillBinding(
-        desired_state.plane_name,
-        skill_id);
-    if (binding.has_value() && !binding->enabled) {
-      continue;
-    }
-    if (canonical->internal && !include_internal) {
-      continue;
-    }
-    candidates.push_back(ContextualSkillCandidate{
-        canonical->id,
-        canonical->name,
-        canonical->description,
-        canonical->content,
-        canonical->match_terms,
-        canonical->internal,
-    });
-  }
-  return candidates;
-}
-
 std::vector<ContextualSkillCandidate> LoadPlaneLocalCandidatesFromRuntime(
     const DesiredState& desired_state,
     bool include_internal) {
@@ -553,14 +513,8 @@ std::vector<ContextualSkillCandidate> LoadPlaneLocalCandidatesFromRuntime(
 }
 
 std::vector<ContextualSkillCandidate> LoadPlaneLocalCandidates(
-    const std::string& db_path,
     const DesiredState& desired_state,
     bool include_internal) {
-  auto candidates =
-      LoadControllerCatalogCandidates(db_path, desired_state, include_internal);
-  if (!candidates.empty()) {
-    return candidates;
-  }
   return LoadPlaneLocalCandidatesFromRuntime(desired_state, include_internal);
 }
 
@@ -634,9 +588,7 @@ int ScoreCandidate(
     score += 4;
   }
 
-  if (matched_match_terms.empty() && matched_match_phrases.empty() &&
-      matched_id_terms.empty() && matched_name_terms.empty() &&
-      matched_description_terms.empty()) {
+  if (matched_match_terms.empty() && matched_match_phrases.empty()) {
     score = 0;
   }
 
@@ -729,7 +681,6 @@ ContextualSkillSelection PlaneSkillContextualResolverService::Resolve(
   const auto prompt_text = ExtractPromptText(payload);
   const bool include_internal = ExtractIncludeInternal(payload);
   const auto candidates = LoadPlaneLocalCandidates(
-      db_path,
       resolution.desired_state,
       include_internal);
   selection.candidate_count = static_cast<int>(candidates.size());

--- a/controller/src/skills/plane_skills_service.cpp
+++ b/controller/src/skills/plane_skills_service.cpp
@@ -318,6 +318,15 @@ std::optional<InteractionValidationError> PlaneSkillsService::ResolveInteraction
       [&](const std::string& fallback_error_code,
           const std::string& fallback_error_message)
       -> std::optional<InteractionValidationError> {
+    if (!request.HasExplicitSelection()) {
+      return InteractionValidationError{
+          fallback_error_code,
+          fallback_error_message,
+          fallback_error_code == "skills_not_ready",
+          json::object(),
+      };
+    }
+
     std::string catalog_error_code;
     std::string catalog_error_message;
     const auto response_payload = ResolveSkillsFromControllerCatalog(

--- a/controller/src/skills/plane_skills_service_tests.cpp
+++ b/controller/src/skills/plane_skills_service_tests.cpp
@@ -1615,6 +1615,7 @@ int main() {
                  "Debug bugs by reproducing them, isolating the invariant, and validating the root cause."},
                 {"content",
                  "When handling a bug or regression, reproduce the issue, validate the root cause, and confirm the path."},
+                {"match_terms", json::array({"debug", "regression", "root cause"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances = BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
@@ -1651,6 +1652,7 @@ int main() {
                 {"name", "safe-change"},
                 {"description", "Limit changes to the smallest safe patch."},
                 {"content", "Keep the patch minimal and avoid unrelated edits."},
+                {"match_terms", json::array({"safe patch", "minimal change"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances = BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
@@ -1682,6 +1684,7 @@ int main() {
                  "Build a fast repository map before non-trivial changes."},
                 {"content",
                  "Map the repository structure, entry points, and major dependencies before editing."},
+                {"match_terms", json::array({"repository map", "карта репозитория"})},
                 {"enabled", true}},
            json{{"id", "code-agent-test-first-fix"},
                 {"name", "test-first-fix"},
@@ -1689,6 +1692,7 @@ int main() {
                  "Explain a test-first bug-fix approach without starting execution unless the user explicitly asks for it."},
                 {"content",
                  "First define the failing regression test, then make the smallest safe patch."},
+                {"match_terms", json::array({"test first", "failing regression test"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances =
@@ -1723,6 +1727,7 @@ int main() {
                  "Explain the real deployment path and required live verification steps before executing them."},
                 {"content",
                  "Describe rollout order, rebuild requirements, restarts, pull steps, and live verification."},
+                {"match_terms", json::array({"deployment path", "live verification steps"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances =
@@ -1755,6 +1760,8 @@ int main() {
                  "Protect desired-state, projectors, validators, renderers, and store changes as one contract."},
                 {"content",
                  "Review desired-state schema changes together with the projector, validator, renderer, and store."},
+                {"match_terms",
+                 json::array({"desired-state schema", "projector validator renderer store"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances =
@@ -1808,6 +1815,7 @@ int main() {
                  "Debug bugs by reproducing them, isolating the invariant, and validating the root cause."},
                 {"content",
                  "When handling a bug or regression, reproduce the issue, validate the root cause, and confirm the path."},
+                {"match_terms", json::array({"debug", "regression", "root cause"})},
                 {"enabled", false}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances = BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
@@ -1838,6 +1846,7 @@ int main() {
                  "Debug bugs by reproducing them, isolating the invariant, and validating the root cause."},
                 {"content",
                  "When handling a bug or regression, reproduce the issue, validate the root cause, and confirm the path."},
+                {"match_terms", json::array({"debug", "regression", "root cause"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances = BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
@@ -1872,6 +1881,7 @@ int main() {
                  "Use for LocalTrade sign-in state, Access cookie reuse, GET /auth/me, and session validation."},
                 {"content",
                  "Check whether the active LocalTrade session is valid and whether the Access cookie is required."},
+                {"match_terms", json::array({"авторизация", "сессия", "access cookie"})},
                 {"enabled", true}},
            json{{"id", "lt-cypher-localtrade-user-streams"},
                 {"name", "localtrade-user-streams"},
@@ -1879,6 +1889,7 @@ int main() {
                  "Use for LocalTrade Socket.IO rooms such as balances and user_orders."},
                 {"content",
                  "Explain protected rooms, public rooms, and Socket.IO room names."},
+                {"match_terms", json::array({"socket.io rooms", "user_orders", "balances"})},
                 {"enabled", true}},
            json{{"id", "lt-cypher-localtrade-account-balances"},
                 {"name", "localtrade-account-balances"},
@@ -1886,6 +1897,7 @@ int main() {
                  "Use for LocalTrade balances, available balances, and totals."},
                 {"content",
                  "Explain balance endpoints and when login is required."},
+                {"match_terms", json::array({"balances", "балансы", "available balances"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances =
@@ -2017,6 +2029,8 @@ int main() {
                  "Use when the user wants to place, inspect, or cancel a LocalTrade spot order."},
                 {"content",
                  "Clarify limit order parameters, pairId, side, amount, rate, and require confirmation."},
+                {"match_terms",
+                 json::array({"лимитный ордер", "покупку btc", "подтверждение"})},
                 {"enabled", true}},
            json{{"id", "lt-cypher-localtrade-market-data"},
                 {"name", "localtrade-market-data"},
@@ -2024,6 +2038,7 @@ int main() {
                  "Use for public pairs, charts, trades, and order book."},
                 {"content",
                  "Explain pairs, chart endpoints, and public market-data rooms."},
+                {"match_terms", json::array({"pairs", "charts", "order book"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances =
@@ -2055,6 +2070,7 @@ int main() {
                  "Use for public LocalTrade pairs, charts, trades, order book, and pairs state without account data."},
                 {"content",
                  "Prefer this skill for public pairs, public order book, public trades, and public market streams."},
+                {"match_terms", json::array({"публичные пары", "order book", "public trades"})},
                 {"enabled", true}},
            json{{"id", "lt-cypher-localtrade-user-streams"},
                 {"name", "localtrade-user-streams"},
@@ -2062,6 +2078,7 @@ int main() {
                  "Use for authenticated LocalTrade Socket.IO user rooms such as balances, user_orders, and user_trades."},
                 {"content",
                  "Protected rooms require the Access cookie and are for account-specific streams."},
+                {"match_terms", json::array({"authenticated rooms", "user_orders", "balances"})},
                 {"enabled", true}},
            json{{"id", "lt-cypher-localtrade-spot-order-clarification"},
                 {"name", "localtrade-spot-order-clarification"},
@@ -2069,6 +2086,7 @@ int main() {
                  "Use when the user wants to create, inspect, or cancel a LocalTrade spot order."},
                 {"content",
                  "Collect limit-order parameters and require explicit confirmation."},
+                {"match_terms", json::array({"spot order", "limit order", "confirmation"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances =
@@ -2100,6 +2118,7 @@ int main() {
                  "Use for LocalTrade balances, available balances, and totals."},
                 {"content",
                  "Explain balances endpoints and whether login is required."},
+                {"match_terms", json::array({"доступные балансы", "balances", "available balances"})},
                 {"enabled", true}},
            json{{"id", "lt-cypher-localtrade-auth-session"},
                 {"name", "localtrade-auth-session"},
@@ -2107,6 +2126,7 @@ int main() {
                  "Use for LocalTrade sign-in state, Access cookie reuse, GET /auth/me, and session validation."},
                 {"content",
                  "Check whether the active LocalTrade session is valid and whether the Access cookie is required."},
+                {"match_terms", json::array({"login", "session", "access cookie"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances =
@@ -2138,6 +2158,7 @@ int main() {
                  "Use to discover, compare, and filter LocalTrade copy-trading traders by ROI, drawdown, sharpe ratio, subscribers, and PnL."},
                 {"content",
                  "Discovery is read-only and should not be confused with follow or subscribe actions."},
+                {"match_terms", json::array({"найди", "сравни", "копитрейдинг", "roi", "drawdown"})},
                 {"enabled", true}},
            json{{"id", "lt-cypher-localtrade-copy-trading-actions"},
                 {"name", "localtrade-copy-trading-actions"},
@@ -2145,6 +2166,7 @@ int main() {
                  "Use to follow, unfollow, or subscribe to a LocalTrade trader and require confirmation before any write action."},
                 {"content",
                  "These are write actions and need explicit confirmation."},
+                {"match_terms", json::array({"follow", "subscribe", "подпиши"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances =
@@ -2176,6 +2198,7 @@ int main() {
                  "Use to follow, unfollow, or subscribe to a LocalTrade trader and require confirmation before any write action."},
                 {"content",
                  "These are write actions and need explicit confirmation."},
+                {"match_terms", json::array({"подпиши", "subscribe", "follow"})},
                 {"enabled", true}},
            json{{"id", "lt-cypher-localtrade-copy-trading-discovery"},
                 {"name", "localtrade-copy-trading-discovery"},
@@ -2183,6 +2206,7 @@ int main() {
                  "Use to discover, compare, and filter LocalTrade copy-trading traders by ROI, drawdown, sharpe ratio, subscribers, and PnL."},
                 {"content",
                  "Discovery is read-only and should not be confused with follow or subscribe actions."},
+                {"match_terms", json::array({"discover", "compare", "roi", "drawdown"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances =
@@ -2214,6 +2238,7 @@ int main() {
                  "Use for LocalTrade sign-in state, Access cookie reuse, GET /auth/me, and logout confirmation."},
                 {"content",
                  "Check the current session, explain logout, and require confirmation before state-changing session actions."},
+                {"match_terms", json::array({"выйди", "сессии", "logout"})},
                 {"enabled", true}},
            json{{"id", "lt-cypher-localtrade-copy-trading-actions"},
                 {"name", "localtrade-copy-trading-actions"},
@@ -2221,6 +2246,7 @@ int main() {
                  "Use to follow, unfollow, or subscribe to a LocalTrade trader and require confirmation before any write action."},
                 {"content",
                  "These are write actions and need explicit confirmation."},
+                {"match_terms", json::array({"follow", "subscribe", "подпиши"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances =
@@ -2252,6 +2278,8 @@ int main() {
                  "Use for protected LocalTrade Socket.IO user rooms such as balances, user_orders, user_trades, and authenticated private channels."},
                 {"content",
                  "Explain protected user rooms and the Access cookie requirement."},
+                {"match_terms",
+                 json::array({"пользовательские websocket-каналы", "приватных обновлений", "балансов", "ордеров"})},
                 {"enabled", true}},
            json{{"id", "lt-cypher-localtrade-account-balances"},
                 {"name", "localtrade-account-balances"},
@@ -2259,6 +2287,7 @@ int main() {
                  "Use for LocalTrade balances, available balances, and totals."},
                 {"content",
                  "Explain balances endpoints and whether login is required."},
+                {"match_terms", json::array({"balances", "балансы", "available balances"})},
                 {"enabled", true}},
            json{{"id", "lt-cypher-localtrade-market-data"},
                 {"name", "localtrade-market-data"},
@@ -2266,6 +2295,7 @@ int main() {
                  "Use for public LocalTrade pairs, charts, trades, order book, and pairs state without account data."},
                 {"content",
                  "Prefer this skill for public market feeds."},
+                {"match_terms", json::array({"public pairs", "order book", "market feeds"})},
                 {"enabled", true}}}));
       auto desired_state = BuildDesiredState("catalog-plane", {});
       desired_state.instances =
@@ -2402,6 +2432,7 @@ int main() {
           "Debug bugs by reproducing them, isolating the invariant, and validating the root cause.";
       record.content =
           "When handling a bug or regression, reproduce the issue, validate the root cause, and confirm the path.";
+      record.match_terms = {"debug", "regression", "root cause"};
       store.UpsertSkillsFactorySkill(record);
 
       naim::controller::PlaneInteractionResolution resolution;
@@ -2418,12 +2449,10 @@ int main() {
                               {"content",
                                "Please debug this regression and find the root cause."}}})}});
       Expect(
-          selection.mode == "contextual" &&
-              selection.candidate_count == 1 &&
-              selection.selected_skill_ids.size() == 1 &&
-              selection.selected_skill_ids.front() == "code-agent-root-cause-debug",
-          "resolver should use controller catalog entries when runtime skillsd is remote or unreachable");
-      std::cout << "ok: contextual-resolver-uses-controller-catalog" << '\n';
+          selection.mode == "none" && selection.candidate_count == 0 &&
+              selection.selected_skill_ids.empty(),
+          "resolver should not use controller catalog entries for contextual activation");
+      std::cout << "ok: contextual-resolver-requires-plane-local-replica" << '\n';
     }
 
     {
@@ -2436,7 +2465,21 @@ int main() {
       knowledge.enabled = true;
       desired_state.knowledge = knowledge;
       naim::controller::EnsureKnowledgeVaultCommonSkills(store, &desired_state);
-      store.ReplaceDesiredState(desired_state, 1);
+      json common_skills = json::array();
+      for (const auto& definition :
+           naim::controller::KnowledgeVaultCommonSkillDefinitions()) {
+        common_skills.push_back(json{
+            {"id", definition.id},
+            {"name", definition.name},
+            {"description", definition.description},
+            {"content", definition.content},
+            {"match_terms", definition.match_terms},
+            {"enabled", true},
+        });
+      }
+      SkillRuntimeTestServer runtime(common_skills);
+      desired_state.instances =
+          BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
 
       naim::controller::PlaneInteractionResolution resolution;
       resolution.db_path = db_path;
@@ -2607,22 +2650,70 @@ int main() {
           skills_service.ResolveInteractionSkills(resolution, &request_context);
       Expect(
           !error.has_value(),
-          "interaction skills should resolve from controller catalog when runtime endpoint is unreachable");
+          "automatic contextual skills should not fail when the plane-local replica is unreachable");
+      const auto applied = request_context.payload.at(
+          naim::controller::PlaneSkillsService::kAppliedSkillsPayloadKey);
+      Expect(
+          applied.is_array() && applied.empty(),
+          "automatic contextual skills should not fall back to the controller catalog");
+      Expect(
+          request_context.payload.at(
+              naim::controller::PlaneSkillsService::kSkillResolutionModePayloadKey)
+              .get<std::string>() == "none",
+          "automatic contextual skills should report none when no plane-owned replica candidate is available");
+      std::cout << "ok: interaction-auto-skills-do-not-fallback-to-controller-catalog" << '\n';
+    }
+
+    {
+      const std::string db_path = MakeTempDbPath();
+      fs::remove(db_path);
+      naim::ControllerStore store(db_path);
+      store.Initialize();
+      auto desired_state = BuildDesiredState(
+          "interaction-plane", {"lt-jex-market-asset-report"});
+      desired_state.instances =
+          BuildDesiredStateWithSkillsPort("127.0.0.1", 9).instances;
+      naim::SkillsFactorySkillRecord record;
+      record.id = "lt-jex-market-asset-report";
+      record.name = "asset-market-report";
+      record.description = "Use for current state reports of one tracked asset.";
+      record.content = "Use factual market data and separate venue-specific data.";
+      record.match_terms = {"ситуация по bnb", "текущий срез", "current asset report"};
+      store.UpsertSkillsFactorySkill(record);
+
+      naim::controller::PlaneSkillsService skills_service;
+      naim::controller::InteractionRequestContext request_context;
+      request_context.payload = json{
+          {"skill_ids", json::array({"lt-jex-market-asset-report"})},
+          {"messages",
+           json::array(
+               {json{{"role", "user"},
+                     {"content", "Какая сейчас ситуация по BNB? Текущий срез."}}})},
+      };
+      naim::controller::PlaneInteractionResolution resolution;
+      resolution.db_path = db_path;
+      resolution.desired_state = desired_state;
+
+      const auto error =
+          skills_service.ResolveInteractionSkills(resolution, &request_context);
+      Expect(
+          !error.has_value(),
+          "explicit skills should still resolve from controller catalog when runtime endpoint is unreachable");
       const auto applied = request_context.payload.at(
           naim::controller::PlaneSkillsService::kAppliedSkillsPayloadKey);
       Expect(
           applied.is_array() && applied.size() == 1 &&
               applied.front().at("id").get<std::string>() ==
                   "lt-jex-market-asset-report",
-          "controller catalog fallback should apply selected market skill metadata");
+          "explicit controller catalog fallback should apply requested skill metadata");
       Expect(
           ContainsLiteral(
               request_context.payload.at(
                   naim::controller::PlaneSkillsService::kSystemInstructionPayloadKey)
                   .get<std::string>(),
               "Use factual market data"),
-          "controller catalog fallback should inject skill instructions");
-      std::cout << "ok: interaction-skills-fallback-to-controller-catalog" << '\n';
+          "explicit controller catalog fallback should inject skill instructions");
+      std::cout << "ok: interaction-explicit-skills-fallback-to-controller-catalog" << '\n';
     }
 
     {

--- a/scripts/build-runtime-images.sh
+++ b/scripts/build-runtime-images.sh
@@ -11,25 +11,81 @@ if [[ "${1:-}" == "--skip-web-ui" ]]; then
 fi
 
 declare -a docker_cmd
+docker_probe_output=""
+
+probe_docker() {
+  local -a candidate=("$@")
+  docker_probe_output="$("${candidate[@]}" version 2>&1)" && return 0
+  return 1
+}
+
+print_docker_probe_error() {
+  local label="$1"
+  local output="$2"
+
+  if [[ -z "${output}" ]]; then
+    return
+  fi
+
+  echo "  ${label}:" >&2
+  printf '%s\n' "${output}" | sed 's/^/    /' >&2
+}
+
+print_docker_socket_diagnostics() {
+  if [[ ! -S /var/run/docker.sock ]]; then
+    return
+  fi
+
+  echo "  docker socket:" >&2
+  ls -ln /var/run/docker.sock 2>/dev/null | sed 's/^/    /' >&2 || true
+  id 2>/dev/null | sed 's/^/    current user: /' >&2 || true
+}
 
 resolve_docker() {
-  if command -v docker >/dev/null 2>&1 && docker version >/dev/null 2>&1; then
-    docker_cmd=(docker)
-    return 0
-  fi
-
-  if command -v sudo >/dev/null 2>&1 && sudo -n docker version >/dev/null 2>&1; then
-    docker_cmd=(sudo -n docker)
-    return 0
-  fi
-
+  local docker_error="docker was not found on PATH"
+  local sudo_error="sudo is unavailable or passwordless sudo is not configured"
+  local windows_error=""
   local windows_docker="/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe"
-  if [[ -x "${windows_docker}" ]] && "${windows_docker}" version >/dev/null 2>&1; then
-    docker_cmd=("${windows_docker}")
-    return 0
+
+  if command -v docker >/dev/null 2>&1; then
+    if probe_docker docker; then
+      docker_cmd=(docker)
+      return 0
+    fi
+    docker_error="${docker_probe_output}"
   fi
 
-  echo "error: no working Docker CLI found; checked 'docker', 'sudo -n docker', and '${windows_docker}'" >&2
+  if command -v sudo >/dev/null 2>&1; then
+    if probe_docker sudo -n docker; then
+      docker_cmd=(sudo -n docker)
+      return 0
+    fi
+    sudo_error="${docker_probe_output}"
+  fi
+
+  if [[ -x "${windows_docker}" ]]; then
+    if probe_docker "${windows_docker}"; then
+      docker_cmd=("${windows_docker}")
+      return 0
+    fi
+    windows_error="${docker_probe_output}"
+  else
+    windows_error="${windows_docker} was not found or is not executable"
+  fi
+
+  echo "error: no usable Docker API connection is available" >&2
+  echo "checked: docker, sudo -n docker, and ${windows_docker}" >&2
+  print_docker_probe_error "docker" "${docker_error}"
+  print_docker_probe_error "sudo -n docker" "${sudo_error}"
+  print_docker_probe_error "${windows_docker}" "${windows_error}"
+  print_docker_socket_diagnostics
+  cat >&2 <<'EOF'
+
+For WSL + Docker Desktop, make sure Docker Desktop is running and WSL integration
+is enabled for this distribution. Then verify that this exact command works:
+
+  docker version
+EOF
   return 1
 }
 

--- a/scripts/configure-build.sh
+++ b/scripts/configure-build.sh
@@ -9,14 +9,24 @@ naim_resolve_build_context "${script_dir}" "$@"
 if [[ "${TARGET_OS}" == "linux" && "${REPO_DIR}" == /mnt/* ]] \
   && grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null \
   && [[ "${NAIM_ALLOW_WSL_MOUNT_BUILD:-}" != "1" ]]; then
-  cat >&2 <<EOF
+  if [[ "${NAIM_STRICT_WSL_MOUNT_BUILD_GUARD:-}" == "1" ]]; then
+    cat >&2 <<EOF
 error: refusing to configure from a Windows-mounted WSL path: ${REPO_DIR}
 
 The llama.cpp/CUDA configure step can hang in uninterruptible p9_client_rpc I/O
 when the source tree is under /mnt/*. Clone or mirror the repository into the
 WSL Linux filesystem, or set NAIM_ALLOW_WSL_MOUNT_BUILD=1 to bypass this guard.
 EOF
-  exit 2
+    exit 2
+  fi
+  cat >&2 <<EOF
+warning: configuring from a Windows-mounted WSL path: ${REPO_DIR}
+
+The llama.cpp/CUDA configure step can be slow or hang in p9_client_rpc I/O when
+the source tree is under /mnt/*. For release builds or repeated local deploys,
+prefer a checkout inside the WSL Linux filesystem. Set
+NAIM_STRICT_WSL_MOUNT_BUILD_GUARD=1 to make this warning fatal.
+EOF
 fi
 
 cuda_root=""

--- a/scripts/install-single-node.sh
+++ b/scripts/install-single-node.sh
@@ -83,11 +83,23 @@ run_as_invoking_user() {
     sudo -u "${SUDO_USER}" env \
       PATH="${PATH}" \
       HOME="${user_home}" \
+      DOCKER_CONTEXT="${DOCKER_CONTEXT:-}" \
+      DOCKER_HOST="${DOCKER_HOST:-}" \
       VCPKG_ROOT="${VCPKG_ROOT:-}" \
+      XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-}" \
       "$@"
     return
   fi
   "$@"
+}
+
+docker_cli_available() {
+  if command -v docker >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local windows_docker="/mnt/c/Program Files/Docker/Docker/resources/bin/docker.exe"
+  [[ -x "${windows_docker}" ]]
 }
 
 wait_for_http() {
@@ -165,15 +177,19 @@ install_prereqs_if_needed() {
     pkg-config
     sqlite3
   )
-  local docker_packages=(
-    docker.io
-    docker-compose-plugin
-  )
 
   echo "[install-single-node] installing apt prerequisites"
   run_as_root apt-get update
   run_as_root apt-get install -y "${packages[@]}"
-  run_as_root apt-get install -y "${docker_packages[@]}" || run_as_root apt-get install -y docker.io || true
+  if docker_cli_available; then
+    echo "[install-single-node] Docker CLI already exists; skipping apt Docker package installation"
+  else
+    local docker_packages=(
+      docker.io
+      docker-compose-plugin
+    )
+    run_as_root apt-get install -y "${docker_packages[@]}" || run_as_root apt-get install -y docker.io || true
+  fi
   run_as_root apt-get clean || true
 }
 
@@ -257,7 +273,7 @@ if [[ "${skip_image_build}" != "yes" ]]; then
   if [[ "${with_web_ui}" != "yes" ]]; then
     image_build_args+=(--skip-web-ui)
   fi
-  run_as_root env PATH="${PATH}" HOME="${HOME}" "${script_dir}/build-runtime-images.sh" "${image_build_args[@]}"
+  run_as_invoking_user "${script_dir}/build-runtime-images.sh" "${image_build_args[@]}"
 fi
 
 build_dir="$("${script_dir}/print-build-dir.sh")"


### PR DESCRIPTION
## Summary
- Make automatic contextual skill enrichment use only the plane-owned Skills runtime replica and require matching `match_terms`.
- Keep controller catalog fallback only for explicit `skill_ids`, not auto enrichment.
- Carry forward the current multi-app/state follow-up and operational build/install script fixes needed by the rollout path.

## Tests
- `git diff --check`
- hpc1 isolated `/tmp` build: `naim-plane-skills-tests`
- hpc1 isolated `/tmp` build: `naim-skills-factory-tests`
- hpc1 isolated `/tmp` build: `naim-controller-apply-state-tests`
- hpc1 isolated `/tmp` build: `naim-state-v2-tests`
- hpc1 isolated `/tmp` build: `naim-state-v2-projector-tests`

No production rollout or deployment was performed.