### PR TITLE
Improve WSL local deploy builds and add CPU-only mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,9 @@ option(NAIM_CONTROLLER_BUILD_LLAMA_QUANTIZE
        "Build llama-quantize before naim-controller for local model conversion tooling"
        OFF)
 option(NAIM_ENABLE_LLAMA_RUNTIME
-       "Configure llama.cpp, CUDA, and inference runtime targets"
+       "Configure llama.cpp and inference runtime targets"
        ON)
+option(NAIM_ENABLE_CUDA "Build llama.cpp runtime with CUDA backend" ON)
 option(NAIM_ENABLE_CEF_BROWSING "Enable CEF-backed browsing runtime support" OFF)
 set(NAIM_CEF_ROOT "" CACHE PATH "Path to an unpacked CEF binary distribution")
 set(NAIM_CEF_DOWNLOAD_URL "" CACHE STRING "Optional URL to a CEF binary distribution archive")
@@ -107,90 +108,99 @@ if(NAIM_ENABLE_LLAMA_RUNTIME)
   set(LLAMA_BUILD_SERVER ON CACHE BOOL "" FORCE)
   set(LLAMA_OPENSSL OFF CACHE BOOL "" FORCE)
   set(LLAMA_USE_SYSTEM_GGML OFF CACHE BOOL "" FORCE)
-  # llama.cpp needs Blackwell FP4/MXFP4 kernels to be compiled for the
-  # architecture-specific 12Xa targets. CMake's native CUDA detection reports
-  # RTX PRO 6000 Blackwell as plain sm_120, which makes ptxas reject those
-  # kernels. Keep native detection opt-in and let llama.cpp choose its supported
-  # explicit CUDA architecture list by default. For host-specific images, set
-  # NAIM_CUDA_ARCHITECTURES explicitly, for example 120a-real on hpc1.
-  set(NAIM_CUDA_ARCHITECTURES "" CACHE STRING
-      "Explicit CUDA architectures for ggml-cuda builds; empty lets llama.cpp choose defaults")
-  option(NAIM_CUDA_NATIVE "Prefer native CUDA architectures for ggml-cuda builds" OFF)
-  if(NAIM_CUDA_ARCHITECTURES)
-    set(NAIM_CUDA_NATIVE OFF CACHE BOOL "" FORCE)
-    set(CMAKE_CUDA_ARCHITECTURES
-        "${NAIM_CUDA_ARCHITECTURES}"
-        CACHE STRING "Explicit CUDA architectures for naim ggml-cuda builds" FORCE)
-  endif()
-  set(GGML_NATIVE ${NAIM_CUDA_NATIVE} CACHE BOOL "" FORCE)
   set(GGML_RPC ON CACHE BOOL "" FORCE)
 
-  if(NOT DEFINED CUDAToolkit_ROOT OR "${CUDAToolkit_ROOT}" STREQUAL "")
-    set(_naim_cuda_root_candidates
-        "$ENV{CUDA_TOOLKIT_ROOT_DIR}"
-        "$ENV{CUDA_HOME}"
-        "$ENV{CUDA_PATH}"
-        "/usr/local/cuda-13.1"
-        "/usr/local/cuda"
-        "/usr/local/cuda-13.2"
-        "/usr/local/cuda-13.0"
-        "/usr/local/cuda-12.9"
-        "/usr/local/cuda-12.8"
-        "/usr/local/cuda-12.7"
-        "/usr/local/cuda-12.6"
-        "/usr/local/cuda-12.5"
-        "/usr/local/cuda-12.4"
-        "/usr/local/cuda-12.3"
-        "/usr/local/cuda-12.2"
-        "/usr/local/cuda-12.1"
-        "/usr/local/cuda-12.0"
-        "/usr/lib/nvidia-cuda-toolkit")
-
-    find_program(_naim_nvcc_executable NAMES nvcc)
-    if(_naim_nvcc_executable)
-      get_filename_component(_naim_nvcc_bin_dir "${_naim_nvcc_executable}" DIRECTORY)
-      get_filename_component(_naim_nvcc_root_from_path "${_naim_nvcc_bin_dir}" DIRECTORY)
-      list(PREPEND _naim_cuda_root_candidates "${_naim_nvcc_root_from_path}")
+  if(NAIM_ENABLE_CUDA)
+    # llama.cpp needs Blackwell FP4/MXFP4 kernels to be compiled for the
+    # architecture-specific 12Xa targets. CMake's native CUDA detection reports
+    # RTX PRO 6000 Blackwell as plain sm_120, which makes ptxas reject those
+    # kernels. Keep native detection opt-in and let llama.cpp choose its supported
+    # explicit CUDA architecture list by default. For host-specific images, set
+    # NAIM_CUDA_ARCHITECTURES explicitly, for example 120a-real on hpc1.
+    set(NAIM_CUDA_ARCHITECTURES "" CACHE STRING
+        "Explicit CUDA architectures for ggml-cuda builds; empty lets llama.cpp choose defaults")
+    option(NAIM_CUDA_NATIVE "Prefer native CUDA architectures for ggml-cuda builds" OFF)
+    if(NAIM_CUDA_ARCHITECTURES)
+      set(NAIM_CUDA_NATIVE OFF CACHE BOOL "" FORCE)
+      set(CMAKE_CUDA_ARCHITECTURES
+          "${NAIM_CUDA_ARCHITECTURES}"
+          CACHE STRING "Explicit CUDA architectures for naim ggml-cuda builds" FORCE)
     endif()
+    set(GGML_NATIVE ${NAIM_CUDA_NATIVE} CACHE BOOL "" FORCE)
 
-    foreach(_naim_cuda_root IN LISTS _naim_cuda_root_candidates)
-      if(_naim_cuda_root AND EXISTS "${_naim_cuda_root}/include/cuda_runtime.h")
-        set(CUDAToolkit_ROOT "${_naim_cuda_root}" CACHE PATH "Detected CUDA toolkit root")
-        if(NOT DEFINED CMAKE_CUDA_COMPILER AND EXISTS "${_naim_cuda_root}/bin/nvcc")
-          set(CMAKE_CUDA_COMPILER
-              "${_naim_cuda_root}/bin/nvcc"
-              CACHE FILEPATH "Detected CUDA compiler")
-        endif()
-        message(STATUS "Using detected CUDA toolkit: ${CUDAToolkit_ROOT}")
-        break()
+    if(NOT DEFINED CUDAToolkit_ROOT OR "${CUDAToolkit_ROOT}" STREQUAL "")
+      set(_naim_cuda_root_candidates
+          "$ENV{CUDA_TOOLKIT_ROOT_DIR}"
+          "$ENV{CUDA_HOME}"
+          "$ENV{CUDA_PATH}"
+          "/usr/local/cuda-13.1"
+          "/usr/local/cuda"
+          "/usr/local/cuda-13.2"
+          "/usr/local/cuda-13.0"
+          "/usr/local/cuda-12.9"
+          "/usr/local/cuda-12.8"
+          "/usr/local/cuda-12.7"
+          "/usr/local/cuda-12.6"
+          "/usr/local/cuda-12.5"
+          "/usr/local/cuda-12.4"
+          "/usr/local/cuda-12.3"
+          "/usr/local/cuda-12.2"
+          "/usr/local/cuda-12.1"
+          "/usr/local/cuda-12.0"
+          "/usr/lib/nvidia-cuda-toolkit")
+
+      find_program(_naim_nvcc_executable NAMES nvcc)
+      if(_naim_nvcc_executable)
+        get_filename_component(_naim_nvcc_bin_dir "${_naim_nvcc_executable}" DIRECTORY)
+        get_filename_component(_naim_nvcc_root_from_path "${_naim_nvcc_bin_dir}" DIRECTORY)
+        list(PREPEND _naim_cuda_root_candidates "${_naim_nvcc_root_from_path}")
       endif()
-    endforeach()
 
-    unset(_naim_cuda_root_candidates)
-    unset(_naim_nvcc_executable CACHE)
-    unset(_naim_nvcc_bin_dir)
-    unset(_naim_nvcc_root_from_path)
-    unset(_naim_cuda_root)
-  endif()
+      foreach(_naim_cuda_root IN LISTS _naim_cuda_root_candidates)
+        if(_naim_cuda_root AND EXISTS "${_naim_cuda_root}/include/cuda_runtime.h")
+          set(CUDAToolkit_ROOT "${_naim_cuda_root}" CACHE PATH "Detected CUDA toolkit root")
+          if(NOT DEFINED CMAKE_CUDA_COMPILER AND EXISTS "${_naim_cuda_root}/bin/nvcc")
+            set(CMAKE_CUDA_COMPILER
+                "${_naim_cuda_root}/bin/nvcc"
+                CACHE FILEPATH "Detected CUDA compiler")
+          endif()
+          message(STATUS "Using detected CUDA toolkit: ${CUDAToolkit_ROOT}")
+          break()
+        endif()
+      endforeach()
 
-  set(_naim_cuda_available OFF)
-  if(DEFINED CUDAToolkit_ROOT AND EXISTS "${CUDAToolkit_ROOT}/include/cuda_runtime.h")
-    set(_naim_cuda_available ON)
-  elseif(DEFINED CMAKE_CUDA_COMPILER)
-    get_filename_component(_naim_cuda_bin_dir "${CMAKE_CUDA_COMPILER}" DIRECTORY)
-    get_filename_component(_naim_cuda_root_from_compiler "${_naim_cuda_bin_dir}" DIRECTORY)
-    if(EXISTS "${_naim_cuda_root_from_compiler}/include/cuda_runtime.h")
-      set(_naim_cuda_available ON)
+      unset(_naim_cuda_root_candidates)
+      unset(_naim_nvcc_executable CACHE)
+      unset(_naim_nvcc_bin_dir)
+      unset(_naim_nvcc_root_from_path)
+      unset(_naim_cuda_root)
     endif()
+
+    set(_naim_cuda_available OFF)
+    if(DEFINED CUDAToolkit_ROOT AND EXISTS "${CUDAToolkit_ROOT}/include/cuda_runtime.h")
+      set(_naim_cuda_available ON)
+    elseif(DEFINED CMAKE_CUDA_COMPILER)
+      get_filename_component(_naim_cuda_bin_dir "${CMAKE_CUDA_COMPILER}" DIRECTORY)
+      get_filename_component(_naim_cuda_root_from_compiler "${_naim_cuda_bin_dir}" DIRECTORY)
+      if(EXISTS "${_naim_cuda_root_from_compiler}/include/cuda_runtime.h")
+        set(_naim_cuda_available ON)
+      endif()
+    endif()
+    if(NOT _naim_cuda_available)
+      message(FATAL_ERROR
+        "CUDA toolkit is required for naim-node inference runtime builds. "
+        "Provide CUDAToolkit_ROOT or CMAKE_CUDA_COMPILER so GGML_CUDA can be enabled, "
+        "or configure with -DNAIM_ENABLE_CUDA=OFF.")
+    endif()
+    set(GGML_CUDA ON CACHE BOOL "" FORCE)
+    message(STATUS "Naim CUDA runtime: enabled")
+    message(STATUS "Naim CUDA native architectures: ${NAIM_CUDA_NATIVE}")
+    message(STATUS "Naim CUDA explicit architectures: ${NAIM_CUDA_ARCHITECTURES}")
+  else()
+    set(GGML_CUDA OFF CACHE BOOL "" FORCE)
+    set(GGML_NATIVE OFF CACHE BOOL "" FORCE)
+    message(STATUS "Naim CUDA runtime: disabled")
   endif()
-  if(NOT _naim_cuda_available)
-    message(FATAL_ERROR
-      "CUDA toolkit is required for naim-node inference runtime builds. "
-      "Provide CUDAToolkit_ROOT or CMAKE_CUDA_COMPILER so GGML_CUDA can be enabled.")
-  endif()
-  set(GGML_CUDA ON CACHE BOOL "" FORCE)
-  message(STATUS "Naim CUDA native architectures: ${NAIM_CUDA_NATIVE}")
-  message(STATUS "Naim CUDA explicit architectures: ${NAIM_CUDA_ARCHITECTURES}")
 
   if(NAIM_LLAMA_CPP_SOURCE_DIR AND EXISTS "${NAIM_LLAMA_CPP_SOURCE_DIR}/CMakeLists.txt")
     FetchContent_Declare(
@@ -208,7 +218,7 @@ if(NAIM_ENABLE_LLAMA_RUNTIME)
   endif()
   FetchContent_MakeAvailable(llama_cpp)
 
-  if(TARGET ggml-cuda AND CMAKE_GENERATOR STREQUAL "Ninja")
+  if(NAIM_ENABLE_CUDA AND TARGET ggml-cuda AND CMAKE_GENERATOR STREQUAL "Ninja")
     if(NAIM_CUDA_NVCC_JOBS MATCHES "^[1-9][0-9]*$")
       set_property(GLOBAL APPEND PROPERTY JOB_POOLS "naim_cuda_pool=${NAIM_CUDA_NVCC_JOBS}")
       set_property(TARGET ggml-cuda PROPERTY JOB_POOL_COMPILE naim_cuda_pool)

--- a/scripts/build-context.sh
+++ b/scripts/build-context.sh
@@ -26,6 +26,87 @@ naim_detect_host_target() {
   "${script_dir}/detect-host-target.sh"
 }
 
+naim_is_wsl() {
+  grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null
+}
+
+naim_is_windows_mount_path() {
+  [[ "${1:-}" == /mnt/* ]]
+}
+
+naim_default_cache_root() {
+  if [[ -n "${NAIM_CACHE_ROOT:-}" ]]; then
+    printf '%s\n' "${NAIM_CACHE_ROOT}"
+    return
+  fi
+  if [[ -n "${XDG_CACHE_HOME:-}" ]]; then
+    printf '%s\n' "${XDG_CACHE_HOME}/naim"
+    return
+  fi
+  printf '%s\n' "${HOME:-/tmp}/.cache/naim"
+}
+
+naim_repo_path_hash() {
+  printf '%s' "${1}" | sha256sum | awk '{print substr($1, 1, 16)}'
+}
+
+naim_sync_source_mirror() {
+  if [[ "${NAIM_SOURCE_MIRROR_ACTIVE:-0}" != "1" ]]; then
+    return
+  fi
+  if ! command -v rsync >/dev/null 2>&1; then
+    echo "error: rsync is required for WSL source mirror builds" >&2
+    echo "install rsync or set NAIM_WSL_SOURCE_MIRROR=off to build directly from the checkout" >&2
+    exit 1
+  fi
+
+  mkdir -p "${NAIM_SOURCE_MIRROR_DIR}"
+  echo "[build] syncing WSL source mirror" >&2
+  echo "[build]   source=${NAIM_ORIGINAL_REPO_DIR}" >&2
+  echo "[build]   mirror=${NAIM_SOURCE_MIRROR_DIR}" >&2
+
+  rsync -a --delete --delete-excluded \
+    --exclude '/.git/' \
+    --exclude '/.local/' \
+    --exclude '/build/' \
+    --exclude '/build-*/' \
+    --exclude '/dist/' \
+    --exclude '/var/' \
+    --exclude '/ui/operator-react/dist/' \
+    --exclude '/ui/operator-react/node_modules/' \
+    "${NAIM_ORIGINAL_REPO_DIR}/" \
+    "${NAIM_SOURCE_MIRROR_DIR}/"
+}
+
+naim_drop_windows_mount_path_entries() {
+  local value="${1:-}"
+  local result=""
+  local entry
+
+  IFS=':' read -r -a entries <<< "${value}"
+  for entry in "${entries[@]}"; do
+    if [[ -z "${entry}" || "${entry}" == /mnt/* ]]; then
+      continue
+    fi
+    if [[ -z "${result}" ]]; then
+      result="${entry}"
+    else
+      result="${result}:${entry}"
+    fi
+  done
+
+  printf '%s\n' "${result}"
+}
+
+naim_prepare_source_mirror_environment() {
+  if [[ "${NAIM_SOURCE_MIRROR_ACTIVE:-0}" != "1" ]]; then
+    return
+  fi
+
+  PATH="$(naim_drop_windows_mount_path_entries "${PATH:-}")"
+  export PATH
+}
+
 naim_resolve_target_context() {
   local script_dir="${1}"
   shift
@@ -55,6 +136,31 @@ naim_resolve_target_context() {
   local repo_dir
   repo_dir="$(cd -- "${script_dir}/.." && pwd)"
   local build_root="${NAIM_BUILD_ROOT:-${repo_dir}/build}"
+
+  NAIM_ORIGINAL_REPO_DIR="${repo_dir}"
+  NAIM_SOURCE_MIRROR_ACTIVE=0
+  NAIM_SOURCE_MIRROR_DIR=""
+  NAIM_SOURCE_MIRROR_WORKSPACE=""
+
+  local mirror_mode="${NAIM_WSL_SOURCE_MIRROR:-auto}"
+  if [[ "${target_os}" == "linux" ]] \
+    && [[ "${mirror_mode}" != "off" ]] \
+    && naim_is_windows_mount_path "${repo_dir}" \
+    && naim_is_wsl; then
+    local cache_root
+    local repo_hash
+    local repo_name
+
+    cache_root="${NAIM_WSL_BUILD_MIRROR_ROOT:-$(naim_default_cache_root)/wsl-build-mirror}"
+    repo_hash="$(naim_repo_path_hash "${repo_dir}")"
+    repo_name="$(basename -- "${repo_dir}")"
+
+    NAIM_SOURCE_MIRROR_ACTIVE=1
+    NAIM_SOURCE_MIRROR_WORKSPACE="${cache_root}/${repo_name}-${repo_hash}"
+    NAIM_SOURCE_MIRROR_DIR="${NAIM_SOURCE_MIRROR_WORKSPACE}/src"
+    build_root="${NAIM_BUILD_ROOT:-${NAIM_SOURCE_MIRROR_WORKSPACE}/build}"
+    repo_dir="${NAIM_SOURCE_MIRROR_DIR}"
+  fi
 
   TARGET_OS="${target_os}"
   TARGET_ARCH="${target_arch}"

--- a/scripts/build-context.sh
+++ b/scripts/build-context.sh
@@ -21,6 +21,21 @@ naim_validate_build_type() {
   exit 1
 }
 
+naim_normalize_on_off() {
+  case "${1:-}" in
+    1|ON|On|on|TRUE|True|true|YES|Yes|yes)
+      printf 'ON\n'
+      ;;
+    0|OFF|Off|off|FALSE|False|false|NO|No|no)
+      printf 'OFF\n'
+      ;;
+    *)
+      echo "error: expected ON/OFF boolean value, got '${1:-}'" >&2
+      exit 1
+      ;;
+  esac
+}
+
 naim_detect_host_target() {
   local script_dir="${1}"
   "${script_dir}/detect-host-target.sh"
@@ -173,7 +188,45 @@ naim_resolve_build_context() {
   shift
 
   local build_type="${NAIM_BUILD_TYPE:-Debug}"
+  local enable_cuda
   local -a target_args=()
+  local -a positional_args=()
+
+  enable_cuda="$(naim_normalize_on_off "${NAIM_ENABLE_CUDA:-ON}")"
+
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      --no-cuda|--cpu)
+        enable_cuda="OFF"
+        shift
+        ;;
+      --with-cuda|--cuda)
+        enable_cuda="ON"
+        shift
+        ;;
+      --)
+        shift
+        positional_args+=("$@")
+        break
+        ;;
+      -h|--help)
+        echo "usage: $0 [--no-cuda|--with-cuda] [<build-type>] | [--no-cuda|--with-cuda] [<os> <arch> [<build-type>]]" >&2
+        exit 0
+        ;;
+      -*)
+        echo "error: unknown argument '${1}'" >&2
+        echo "usage: $0 [--no-cuda|--with-cuda] [<build-type>] | [--no-cuda|--with-cuda] [<os> <arch> [<build-type>]]" >&2
+        exit 1
+        ;;
+      *)
+        positional_args+=("${1}")
+        shift
+        ;;
+    esac
+  done
+
+  set -- "${positional_args[@]}"
+  export NAIM_ENABLE_CUDA="${enable_cuda}"
 
   case $# in
     0)
@@ -182,7 +235,7 @@ naim_resolve_build_context() {
       if naim_is_build_type "${1}"; then
         build_type="${1}"
       else
-        echo "usage: $0 [<build-type>] | [<os> <arch> [<build-type>]]" >&2
+        echo "usage: $0 [--no-cuda|--with-cuda] [<build-type>] | [--no-cuda|--with-cuda] [<os> <arch> [<build-type>]]" >&2
         exit 1
       fi
       ;;
@@ -194,7 +247,7 @@ naim_resolve_build_context() {
       build_type="${3}"
       ;;
     *)
-      echo "usage: $0 [<build-type>] | [<os> <arch> [<build-type>]]" >&2
+      echo "usage: $0 [--no-cuda|--with-cuda] [<build-type>] | [--no-cuda|--with-cuda] [<os> <arch> [<build-type>]]" >&2
       exit 1
       ;;
   esac

--- a/scripts/build-runtime-images.sh
+++ b/scripts/build-runtime-images.sh
@@ -104,8 +104,9 @@ knowledge_tag="${10:-naim/knowledge-runtime:dev}"
 
 build_dir="$("${script_dir}/print-build-dir.sh")"
 turboquant_build_dir="${NAIM_TURBOQUANT_BUILD_DIR:-${repo_root}/build-turboquant/linux/x64}"
-mkdir -p "${repo_root}/var"
-image_context="$(mktemp -d "${repo_root}/var/runtime-image-context.XXXXXX")"
+image_work_root="${NAIM_RUNTIME_IMAGE_CONTEXT_ROOT:-${build_dir}/image-contexts}"
+mkdir -p "${image_work_root}"
+image_context="$(mktemp -d "${image_work_root}/runtime-image-context.XXXXXX")"
 cleanup_image_context() {
   rm -rf "${image_context}" 2>/dev/null || sudo -n rm -rf "${image_context}" 2>/dev/null || true
 }
@@ -119,15 +120,38 @@ for binary in naim-controller naim-hostd naim-node naim-inferctl naim-workerd na
 done
 cp "${build_dir}/bin/llama-server" "${image_context}/build/linux/x64/bin/llama-server"
 cp "${build_dir}/bin/rpc-server" "${image_context}/build/linux/x64/bin/rpc-server"
-cp "${turboquant_build_dir}/bin/llama-server" \
-  "${image_context}/build-turboquant/linux/x64/bin/llama-server"
-cp "${turboquant_build_dir}/bin/rpc-server" \
-  "${image_context}/build-turboquant/linux/x64/bin/rpc-server"
+copy_turboquant_binary() {
+  local binary="$1"
+  local source_path="${turboquant_build_dir}/bin/${binary}"
+  local target_path="${image_context}/build-turboquant/linux/x64/bin/${binary}"
+
+  if [[ -x "${source_path}" ]]; then
+    cp "${source_path}" "${target_path}"
+    return
+  fi
+
+  if [[ "${NAIM_REQUIRE_TURBOQUANT:-0}" == "1" ]]; then
+    echo "error: required TurboQuant binary was not found: ${source_path}" >&2
+    echo "run scripts/build-turboquant-runtime.sh first, or unset NAIM_REQUIRE_TURBOQUANT for local images" >&2
+    exit 1
+  fi
+
+  echo "warning: TurboQuant binary not found; adding unsupported-runtime placeholder for ${binary}" >&2
+  cat > "${target_path}" <<EOF
+#!/usr/bin/env sh
+echo "TurboQuant runtime is not included in this local image. Run scripts/build-turboquant-runtime.sh and rebuild images, or use the default runtime flavor." >&2
+exit 127
+EOF
+  chmod +x "${target_path}"
+}
+
+copy_turboquant_binary llama-server
+copy_turboquant_binary rpc-server
 
 build_web_ui_image() {
   local temp_root
-  mkdir -p "${repo_root}/var"
-  temp_root="$(mktemp -d "${repo_root}/var/web-ui-image.XXXXXX")"
+  mkdir -p "${image_work_root}"
+  temp_root="$(mktemp -d "${image_work_root}/web-ui-image.XXXXXX")"
   cleanup_web_ui_image() {
     rm -rf "${temp_root}" 2>/dev/null || sudo -n rm -rf "${temp_root}" 2>/dev/null || true
   }

--- a/scripts/configure-build.sh
+++ b/scripts/configure-build.sh
@@ -6,6 +6,9 @@ source "${script_dir}/build-context.sh"
 
 naim_resolve_build_context "${script_dir}" "$@"
 
+naim_sync_source_mirror
+naim_prepare_source_mirror_environment
+
 if [[ "${TARGET_OS}" == "linux" && "${REPO_DIR}" == /mnt/* ]] \
   && grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null \
   && [[ "${NAIM_ALLOW_WSL_MOUNT_BUILD:-}" != "1" ]]; then
@@ -270,6 +273,9 @@ if [[ -n "${NAIM_CMAKE_ARGS:-}" ]]; then
   cmake_args+=("${extra_cmake_args[@]}")
 fi
 
-"${cmake_exe}" "${cmake_args[@]}"
+(
+  cd "${REPO_DIR}"
+  "${cmake_exe}" "${cmake_args[@]}"
+)
 
 echo "${BUILD_DIR}"

--- a/scripts/configure-build.sh
+++ b/scripts/configure-build.sh
@@ -37,6 +37,7 @@ cuda_nvcc=""
 openmp_root=""
 openmp_include_dir=""
 openmp_library=""
+: "${NAIM_ENABLE_CUDA:=ON}"
 : "${NAIM_CUDA_NATIVE:=OFF}"
 : "${NAIM_CUDA_ARCHITECTURES:=}"
 : "${NAIM_CUDA_NVCC_JOBS:=1}"
@@ -121,16 +122,19 @@ detect_macos_openmp() {
   return 1
 }
 
-if detect_cuda_root; then
+if [[ "${NAIM_ENABLE_CUDA}" == "ON" ]] && detect_cuda_root; then
   export CUDA_TOOLKIT_ROOT_DIR="${cuda_root}"
   export CUDA_HOME="${cuda_root}"
   export CUDA_PATH="${cuda_root}"
   export CUDA_BIN_PATH="${cuda_root}/bin"
   export CUDACXX="${cuda_nvcc}"
-else
+elif [[ "${NAIM_ENABLE_CUDA}" == "ON" ]]; then
   echo "[cmake] CUDA toolkit is required for naim-node builds; none was found" >&2
   echo "[cmake] checked CUDA_TOOLKIT_ROOT_DIR, CUDA_HOME, CUDA_PATH, /usr/local/cuda*, and nvcc on PATH" >&2
+  echo "[cmake] pass --no-cuda or set NAIM_ENABLE_CUDA=OFF to build CPU-only runtime binaries" >&2
   exit 1
+else
+  echo "[cmake] CUDA build disabled by NAIM_ENABLE_CUDA=OFF" >&2
 fi
 
 if detect_macos_openmp; then
@@ -236,6 +240,11 @@ if [[ -f "${cache_path}" ]]; then
     && ! grep -Fq "CMAKE_MAKE_PROGRAM:STRING=${ninja_exe}" "${cache_path}"; then
     needs_clean_reconfigure=1
   fi
+  if ! grep -Fq "NAIM_ENABLE_CUDA:BOOL=${NAIM_ENABLE_CUDA}" "${cache_path}" \
+    && ! grep -Fq "NAIM_ENABLE_CUDA:UNINITIALIZED=${NAIM_ENABLE_CUDA}" "${cache_path}" \
+    && ! grep -Fq "NAIM_ENABLE_CUDA:STRING=${NAIM_ENABLE_CUDA}" "${cache_path}"; then
+    needs_clean_reconfigure=1
+  fi
 fi
 
 if [[ "${needs_clean_reconfigure}" == "1" ]]; then
@@ -254,11 +263,16 @@ cmake_args=(
   -DVCPKG_TARGET_TRIPLET="${VCPKG_TRIPLET}"
 )
 
-cmake_args+=("-DCUDAToolkit_ROOT=${cuda_root}")
-cmake_args+=("-DCMAKE_CUDA_COMPILER=${cuda_nvcc}")
-cmake_args+=("-DNAIM_CUDA_NATIVE=${NAIM_CUDA_NATIVE}")
-cmake_args+=("-DNAIM_CUDA_ARCHITECTURES=${NAIM_CUDA_ARCHITECTURES}")
-cmake_args+=("-DNAIM_CUDA_NVCC_JOBS=${NAIM_CUDA_NVCC_JOBS}")
+cmake_args+=("-DNAIM_ENABLE_CUDA=${NAIM_ENABLE_CUDA}")
+if [[ "${NAIM_ENABLE_CUDA}" == "ON" ]]; then
+  cmake_args+=("-DCUDAToolkit_ROOT=${cuda_root}")
+  cmake_args+=("-DCMAKE_CUDA_COMPILER=${cuda_nvcc}")
+  cmake_args+=("-DNAIM_CUDA_NATIVE=${NAIM_CUDA_NATIVE}")
+  cmake_args+=("-DNAIM_CUDA_ARCHITECTURES=${NAIM_CUDA_ARCHITECTURES}")
+  cmake_args+=("-DNAIM_CUDA_NVCC_JOBS=${NAIM_CUDA_NVCC_JOBS}")
+else
+  cmake_args+=("-DGGML_CUDA=OFF")
+fi
 if [[ -n "${openmp_root}" ]]; then
   cmake_args+=(
     "-DOpenMP_ROOT=${openmp_root}"

--- a/scripts/find-vcpkg.sh
+++ b/scripts/find-vcpkg.sh
@@ -5,9 +5,86 @@ mode="${1:---exe}"
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_dir="$(cd -- "${script_dir}/.." && pwd)"
 
+is_wsl() {
+  grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null
+}
+
+is_windows_mount_path() {
+  [[ "${1:-}" == /mnt/* ]]
+}
+
+default_cache_root() {
+  if [[ -n "${NAIM_CACHE_ROOT:-}" ]]; then
+    printf '%s\n' "${NAIM_CACHE_ROOT}"
+    return
+  fi
+  if [[ -n "${XDG_CACHE_HOME:-}" ]]; then
+    printf '%s\n' "${XDG_CACHE_HOME}/naim"
+    return
+  fi
+  printf '%s\n' "${HOME:-/tmp}/.cache/naim"
+}
+
+emit_vcpkg_path() {
+  local root="$1"
+  if [[ "${mode}" == "--root" ]]; then
+    echo "${root}"
+  else
+    echo "${root}/vcpkg"
+  fi
+}
+
+ensure_wsl_vcpkg_mirror() {
+  local source_root="$1"
+  local mirror_root="${NAIM_WSL_VCPKG_ROOT:-$(default_cache_root)/wsl-vcpkg}"
+  local source_head=""
+  local mirror_head=""
+
+  if [[ "${NAIM_WSL_VCPKG_MIRROR:-auto}" == "off" ]]; then
+    emit_vcpkg_path "${source_root}"
+    return
+  fi
+
+  if ! command -v git >/dev/null 2>&1; then
+    emit_vcpkg_path "${source_root}"
+    return
+  fi
+
+  source_head="$(git -C "${source_root}" rev-parse HEAD 2>/dev/null || true)"
+  if [[ -z "${source_head}" ]]; then
+    emit_vcpkg_path "${source_root}"
+    return
+  fi
+
+  if [[ -d "${mirror_root}/.git" ]]; then
+    mirror_head="$(git -C "${mirror_root}" rev-parse HEAD 2>/dev/null || true)"
+  fi
+
+  if [[ ! -x "${mirror_root}/vcpkg" || "${mirror_head}" != "${source_head}" ]]; then
+    local tmp_root="${mirror_root}.tmp"
+    echo "[vcpkg] preparing WSL vcpkg mirror" >&2
+    echo "[vcpkg]   source=${source_root}" >&2
+    echo "[vcpkg]   mirror=${mirror_root}" >&2
+    rm -rf "${tmp_root}"
+    mkdir -p "$(dirname -- "${mirror_root}")"
+    git clone --quiet "${source_root}" "${tmp_root}"
+    git -C "${tmp_root}" checkout --quiet "${source_head}"
+    "${tmp_root}/bootstrap-vcpkg.sh" -disableMetrics >/dev/null
+    rm -rf "${mirror_root}"
+    mv "${tmp_root}" "${mirror_root}"
+  fi
+
+  emit_vcpkg_path "${mirror_root}"
+}
+
 declare -a candidates=()
 if [[ -n "${VCPKG_ROOT:-}" ]]; then
   candidates+=("${VCPKG_ROOT}")
+fi
+if is_wsl; then
+  candidates+=(
+    "${NAIM_WSL_VCPKG_ROOT:-$(default_cache_root)/wsl-vcpkg}"
+  )
 fi
 candidates+=(
   "${repo_dir}/.tools/vcpkg"
@@ -20,10 +97,10 @@ candidates+=(
 
 for root in "${candidates[@]}"; do
   if [[ -x "${root}/vcpkg" ]]; then
-    if [[ "${mode}" == "--root" ]]; then
-      echo "${root}"
+    if is_wsl && is_windows_mount_path "${root}"; then
+      ensure_wsl_vcpkg_mirror "${root}"
     else
-      echo "${root}/vcpkg"
+      emit_vcpkg_path "${root}"
     fi
     exit 0
   fi
@@ -32,10 +109,10 @@ done
 if command -v vcpkg >/dev/null 2>&1; then
   exe_path="$(command -v vcpkg)"
   root_path="$(cd -- "$(dirname -- "${exe_path}")/.." && pwd)"
-  if [[ "${mode}" == "--root" ]]; then
-    echo "${root_path}"
+  if is_wsl && is_windows_mount_path "${root_path}"; then
+    ensure_wsl_vcpkg_mirror "${root_path}"
   else
-    echo "${exe_path}"
+    emit_vcpkg_path "${root_path}"
   fi
   exit 0
 fi

--- a/scripts/install-single-node.sh
+++ b/scripts/install-single-node.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  install-single-node.sh [--build-type Debug|Release] [--listen-port <port>] [--node <name>] [--with-web-ui] [--skip-prereqs] [--skip-image-build]
+  install-single-node.sh [--build-type Debug|Release] [--listen-port <port>] [--node <name>] [--with-web-ui] [--no-cuda] [--skip-prereqs] [--skip-image-build]
 
 Builds naim-node on the current Linux host, installs controller+local-hostd as systemd services,
 and starts them.
@@ -12,6 +12,7 @@ and starts them.
 By default the installer builds CUDA runtime artifacts for the local GPU architecture only.
 Set NAIM_CUDA_NATIVE=OFF and NAIM_CUDA_ARCHITECTURES=<list> before running the installer if you
 need portable runtime images for multiple GPU generations.
+Pass --no-cuda to build CPU-only runtime binaries and skip CUDA toolkit checks.
 EOF
 }
 
@@ -24,6 +25,24 @@ node_name="local-hostd"
 with_web_ui="no"
 skip_prereqs="no"
 skip_image_build="no"
+enable_cuda="${NAIM_ENABLE_CUDA:-ON}"
+
+normalize_on_off() {
+  case "${1:-}" in
+    1|ON|On|on|TRUE|True|true|YES|Yes|yes)
+      printf 'ON\n'
+      ;;
+    0|OFF|Off|off|FALSE|False|false|NO|No|no)
+      printf 'OFF\n'
+      ;;
+    *)
+      echo "error: expected ON/OFF boolean value, got '${1:-}'" >&2
+      exit 1
+      ;;
+  esac
+}
+
+enable_cuda="$(normalize_on_off "${enable_cuda}")"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -41,6 +60,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --with-web-ui)
       with_web_ui="yes"
+      shift
+      ;;
+    --no-cuda|--cpu)
+      enable_cuda="OFF"
+      shift
+      ;;
+    --with-cuda|--cuda)
+      enable_cuda="ON"
       shift
       ;;
     --skip-prereqs)
@@ -91,6 +118,10 @@ run_as_invoking_user() {
       DOCKER_HOST="${DOCKER_HOST:-}" \
       VCPKG_ROOT="${VCPKG_ROOT:-}" \
       XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-}" \
+      NAIM_ENABLE_CUDA="${NAIM_ENABLE_CUDA:-}" \
+      NAIM_CUDA_NATIVE="${NAIM_CUDA_NATIVE:-}" \
+      NAIM_CUDA_ARCHITECTURES="${NAIM_CUDA_ARCHITECTURES:-}" \
+      NAIM_CUDA_NVCC_JOBS="${NAIM_CUDA_NVCC_JOBS:-}" \
       "$@"
     return
   fi
@@ -267,9 +298,15 @@ storage_root="$(printf '%s\n' "${config_summary}" | sed -n '1p')"
 model_cache_root="$(printf '%s\n' "${config_summary}" | sed -n '2p')"
 
 install_prereqs_if_needed
-install_cuda_toolkit_if_needed
+export NAIM_ENABLE_CUDA="${enable_cuda}"
 
-if [[ -z "${NAIM_CUDA_NATIVE:-}" && -z "${NAIM_CUDA_ARCHITECTURES:-}" ]]; then
+if [[ "${NAIM_ENABLE_CUDA}" == "ON" ]]; then
+  install_cuda_toolkit_if_needed
+else
+  echo "[install-single-node] skipping CUDA toolkit install because --no-cuda was requested"
+fi
+
+if [[ "${NAIM_ENABLE_CUDA}" == "ON" && -z "${NAIM_CUDA_NATIVE:-}" && -z "${NAIM_CUDA_ARCHITECTURES:-}" ]]; then
   export NAIM_CUDA_NATIVE=ON
 fi
 

--- a/scripts/install-single-node.sh
+++ b/scripts/install-single-node.sh
@@ -8,6 +8,10 @@ Usage:
 
 Builds naim-node on the current Linux host, installs controller+local-hostd as systemd services,
 and starts them.
+
+By default the installer builds CUDA runtime artifacts for the local GPU architecture only.
+Set NAIM_CUDA_NATIVE=OFF and NAIM_CUDA_ARCHITECTURES=<list> before running the installer if you
+need portable runtime images for multiple GPU generations.
 EOF
 }
 
@@ -175,6 +179,7 @@ install_prereqs_if_needed() {
     libssl-dev
     ninja-build
     pkg-config
+    rsync
     sqlite3
   )
 
@@ -263,6 +268,10 @@ model_cache_root="$(printf '%s\n' "${config_summary}" | sed -n '2p')"
 
 install_prereqs_if_needed
 install_cuda_toolkit_if_needed
+
+if [[ -z "${NAIM_CUDA_NATIVE:-}" && -z "${NAIM_CUDA_ARCHITECTURES:-}" ]]; then
+  export NAIM_CUDA_NATIVE=ON
+fi
 
 echo "[install-single-node] building host binaries (${build_type})"
 run_as_invoking_user "${script_dir}/build-host.sh" "${build_type}"


### PR DESCRIPTION
## Summary
- mirror WSL /mnt checkouts and vcpkg into Linux cache for local builds
- make runtime image builds more tolerant of missing optional TurboQuant binaries
- add --no-cuda / NAIM_ENABLE_CUDA=OFF CPU-only build and installer mode

## Validation
- local: NAIM_BUILD_ROOT=/tmp/naim-node-no-cuda-build ./scripts/build-target.sh --no-cuda Debug
- hpc1: VCPKG_ROOT=/tmp/naim-hpc-vcpkg-20260424-1777049252 NAIM_BUILD_ROOT=/tmp/naim-hpc-no-cuda-build-20260424 ./scripts/build-target.sh --no-cuda linux x64 Debug