### PR TITLE
Fix hostd proxy KV routes and self-update shell

### DIFF
--- a/hostd/src/app/hostd_app_assignment_support.cpp
+++ b/hostd/src/app/hostd_app_assignment_support.cpp
@@ -660,35 +660,14 @@ void HostdAppAssignmentSupport::ExecuteHostSelfUpdate(
     script += "export DOCKER_CONFIG=" +
               command_support_.ShellQuote(registry_config_dir.string()) + "\n";
   }
-  script += "python3 - " + command_support_.ShellQuote(compose_file.string()) + " " +
-            command_support_.ShellQuote(hostd_image) + " <<'PY'\n"
-            "import pathlib\n"
-            "import sys\n"
-            "\n"
-            "compose_path = pathlib.Path(sys.argv[1])\n"
-            "target_image = sys.argv[2]\n"
-            "text = compose_path.read_text(encoding='utf-8')\n"
-            "lines = text.splitlines()\n"
-            "in_service = False\n"
-            "service_indent = None\n"
-            "updated = False\n"
-            "for index, line in enumerate(lines):\n"
-            "    stripped = line.lstrip()\n"
-            "    indent = len(line) - len(stripped)\n"
-            "    if stripped == 'naim-hostd:':\n"
-            "        in_service = True\n"
-            "        service_indent = indent\n"
-            "        continue\n"
-            "    if in_service and stripped and not stripped.startswith('#') and indent <= service_indent:\n"
-            "        in_service = False\n"
-            "    if in_service and stripped.startswith('image:'):\n"
-            "        lines[index] = ' ' * indent + 'image: ' + target_image\n"
-            "        updated = True\n"
-            "        break\n"
-            "if not updated:\n"
-            "    raise SystemExit('failed to locate naim-hostd image line in compose file')\n"
-            "compose_path.write_text('\\n'.join(lines) + '\\n', encoding='utf-8')\n"
-            "PY\n"
+  const std::string sed_expression =
+      "s#^([[:space:]]*image:[[:space:]]*)chainzano.com/naim/hostd"
+      "(:[^[:space:]]+|@sha256:[a-f0-9]+)?#\\1" +
+      hostd_image + "#";
+  script += "sed -i -E " + command_support_.ShellQuote(sed_expression) + " " +
+            command_support_.ShellQuote(compose_file.string()) + "\n"
+            "grep -F " + command_support_.ShellQuote("image: " + hostd_image) + " " +
+            command_support_.ShellQuote(compose_file.string()) + " >/dev/null\n"
             "sleep 2\n"
             "docker compose -f " + command_support_.ShellQuote(compose_file.string()) +
             " pull naim-hostd\n"

--- a/hostd/src/app/hostd_runtime_http_proxy.cpp
+++ b/hostd/src/app/hostd_runtime_http_proxy.cpp
@@ -182,12 +182,8 @@ bool HostdRuntimeHttpProxy::IsAllowedProxyPath(
     if (method == "GET" && route == "/health") {
       return true;
     }
-    if (method == "GET" && route == "/v1/status") {
-      return true;
-    }
-    if (method == "POST" &&
-        (route == "/v1/context" || route == "/v1/search" ||
-         route == "/v1/graph-neighborhood")) {
+    if ((method == "GET" || method == "POST" || method == "PUT") &&
+        route.rfind("/v1/", 0) == 0) {
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary
- allow Knowledge Vault hostd proxy to forward GET/POST/PUT requests under the KV /v1 namespace
- remove python3 dependency from generated hostd self-update scripts; use sed/grep available on deployed nodes

## Validation
- hpc1: built naim-hostd target