### PR TITLE
Route remote skills runtime via hostd proxy

### DIFF
--- a/controller/include/skills/plane_skills_service.h
+++ b/controller/include/skills/plane_skills_service.h
@@ -28,6 +28,11 @@ class PlaneSkillsService final {
   std::optional<ControllerEndpointTarget> ResolveTarget(
       const DesiredState& desired_state) const;
 
+  bool ProbeTargetOk(
+      const std::string& db_path,
+      const DesiredState& desired_state,
+      const std::string& path) const;
+
   std::optional<InteractionValidationError> ResolveInteractionSkills(
       const PlaneInteractionResolution& resolution,
       InteractionRequestContext* context) const;

--- a/controller/include/skills/plane_skills_target_resolver.h
+++ b/controller/include/skills/plane_skills_target_resolver.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "http/controller_http_transport.h"
 #include "naim/state/models.h"
 #include "interaction/interaction_types.h"
 
@@ -16,6 +17,14 @@ class PlaneSkillsTargetResolver final {
   static const InstanceSpec* FindSkillsInstance(const DesiredState& desired_state);
   static std::optional<ControllerEndpointTarget> ResolvePlaneLocalTarget(
       const DesiredState& desired_state);
+  static ::HttpResponse SendPlaneLocalRequest(
+      const std::string& db_path,
+      const std::string& plane_name,
+      const ControllerEndpointTarget& target,
+      const std::string& method,
+      const std::string& path,
+      const std::string& body,
+      const std::vector<std::pair<std::string, std::string>>& headers);
   static std::string NormalizeSkillPathSuffix(const std::string& path_suffix);
 };
 

--- a/controller/src/interaction/interaction_service.cpp
+++ b/controller/src/interaction/interaction_service.cpp
@@ -1949,7 +1949,7 @@ PlaneInteractionResolution InteractionPlaneResolver::Resolve(
   const auto skills_target = skills_service.ResolveTarget(*desired_state);
   const bool skills_ready =
       skills_enabled && running_plane && skills_target.has_value() &&
-      probe_controller_target_ok_(skills_target, "/health");
+      skills_service.ProbeTargetOk(db_path, *desired_state, "/health");
   const auto skills_instance = std::find_if(
       desired_state->instances.begin(),
       desired_state->instances.end(),

--- a/controller/src/knowledge/knowledge_vault_service.cpp
+++ b/controller/src/knowledge/knowledge_vault_service.cpp
@@ -132,6 +132,40 @@ HttpResponse ParseHostdProxyResponsePayload(const nlohmann::json& progress) {
   return response;
 }
 
+void RefreshCachedStatusFromMutationResponse(
+    const std::string& db_path,
+    const KnowledgeVaultServiceRecord& record,
+    const std::string& method,
+    const HttpResponse& response) {
+  if (response.status_code < 200 || response.status_code >= 300) {
+    return;
+  }
+  if (method != "POST" && method != "PUT") {
+    return;
+  }
+  if (response.body.empty()) {
+    return;
+  }
+  const auto payload = nlohmann::json::parse(response.body, nullptr, false);
+  if (payload.is_discarded() || !payload.is_object()) {
+    return;
+  }
+  const int event_sequence = payload.value("event_sequence", 0);
+  if (event_sequence <= 0 || event_sequence < record.latest_event_sequence) {
+    return;
+  }
+  KnowledgeVaultServiceRepository{}.UpdateServiceStatus(
+      db_path,
+      record.service_id,
+      nlohmann::json{
+          {"status", "ready"},
+          {"schema_version",
+           record.schema_version.empty() ? std::string("knowledge.v1") : record.schema_version},
+          {"index_epoch", "idx_" + std::to_string(event_sequence)},
+          {"latest_event_sequence", event_sequence},
+      });
+}
+
 }  // namespace
 
 nlohmann::json KnowledgeVaultService::BuildStatus(const std::string& db_path) const {
@@ -294,15 +328,19 @@ HttpResponse KnowledgeVaultService::ProxyServiceRequest(
     path += ControllerHttpServerSupport::UrlEncode(value);
   }
   if (IsLoopbackEndpointHost(record->endpoint_host)) {
-    return SendHostdRuntimeProxy(
+    auto response = SendHostdRuntimeProxy(
         db_path,
         *record,
         request.method,
         path,
         request.body,
         headers);
+    RefreshCachedStatusFromMutationResponse(db_path, *record, request.method, response);
+    return response;
   }
-  return SendDirectRuntime(*record, request.method, path, request.body, headers);
+  auto response = SendDirectRuntime(*record, request.method, path, request.body, headers);
+  RefreshCachedStatusFromMutationResponse(db_path, *record, request.method, response);
+  return response;
 }
 
 HttpResponse KnowledgeVaultService::BuildJsonResponse(

--- a/controller/src/skills/plane_skill_contextual_resolver_service.cpp
+++ b/controller/src/skills/plane_skill_contextual_resolver_service.cpp
@@ -453,6 +453,7 @@ std::vector<std::string> ParseStringArray(const nlohmann::json& value) {
 }
 
 std::vector<ContextualSkillCandidate> LoadPlaneLocalCandidatesFromRuntime(
+    const std::string& db_path,
     const DesiredState& desired_state,
     bool include_internal) {
   if (!desired_state.skills.has_value() || !desired_state.skills->enabled) {
@@ -466,7 +467,9 @@ std::vector<ContextualSkillCandidate> LoadPlaneLocalCandidatesFromRuntime(
 
   HttpResponse response;
   try {
-    response = SendControllerHttpRequest(
+    response = PlaneSkillsTargetResolver::SendPlaneLocalRequest(
+        db_path,
+        desired_state.plane_name,
         *target,
         "GET",
         "/v1/skills",
@@ -512,10 +515,56 @@ std::vector<ContextualSkillCandidate> LoadPlaneLocalCandidatesFromRuntime(
   return candidates;
 }
 
-std::vector<ContextualSkillCandidate> LoadPlaneLocalCandidates(
+std::vector<ContextualSkillCandidate> LoadPlaneLocalCandidatesFromControllerStore(
+    const std::string& db_path,
     const DesiredState& desired_state,
     bool include_internal) {
-  return LoadPlaneLocalCandidatesFromRuntime(desired_state, include_internal);
+  if (db_path.empty() || !desired_state.skills.has_value() ||
+      !desired_state.skills->enabled) {
+    return {};
+  }
+
+  ControllerStore store(db_path);
+  store.Initialize();
+  std::vector<ContextualSkillCandidate> candidates;
+  for (const auto& skill_id : desired_state.skills->factory_skill_ids) {
+    const auto canonical = store.LoadSkillsFactorySkill(skill_id);
+    if (!canonical.has_value()) {
+      continue;
+    }
+    const auto binding =
+        store.LoadPlaneSkillBinding(desired_state.plane_name, skill_id);
+    if (binding.has_value() && !binding->enabled) {
+      continue;
+    }
+    if (canonical->internal && !include_internal) {
+      continue;
+    }
+    candidates.push_back(ContextualSkillCandidate{
+        canonical->id,
+        canonical->name,
+        canonical->description,
+        canonical->content,
+        canonical->match_terms,
+        canonical->internal,
+    });
+  }
+  return candidates;
+}
+
+std::vector<ContextualSkillCandidate> LoadPlaneLocalCandidates(
+    const std::string& db_path,
+    const DesiredState& desired_state,
+    bool include_internal) {
+  auto candidates = LoadPlaneLocalCandidatesFromRuntime(
+      db_path, desired_state, include_internal);
+  if (!candidates.empty()) {
+    return candidates;
+  }
+  return LoadPlaneLocalCandidatesFromControllerStore(
+      db_path,
+      desired_state,
+      include_internal);
 }
 
 int ScoreCandidate(
@@ -681,6 +730,7 @@ ContextualSkillSelection PlaneSkillContextualResolverService::Resolve(
   const auto prompt_text = ExtractPromptText(payload);
   const bool include_internal = ExtractIncludeInternal(payload);
   const auto candidates = LoadPlaneLocalCandidates(
+      db_path,
       resolution.desired_state,
       include_internal);
   selection.candidate_count = static_cast<int>(candidates.size());

--- a/controller/src/skills/plane_skill_runtime_sync_service.cpp
+++ b/controller/src/skills/plane_skill_runtime_sync_service.cpp
@@ -8,6 +8,7 @@
 #include "naim/state/sqlite_store.h"
 #include "http/controller_http_transport.h"
 #include "skills/plane_skills_service.h"
+#include "skills/plane_skills_target_resolver.h"
 
 namespace naim::controller {
 
@@ -65,8 +66,14 @@ bool PlaneSkillRuntimeSyncService::IsReadyForSync(
     return false;
   }
   try {
-    const auto response = SendControllerHttpRequest(
-        *target, "GET", "/health", "", DefaultJsonHeaders());
+    const auto response = PlaneSkillsTargetResolver::SendPlaneLocalRequest(
+        db_path,
+        desired_state.plane_name,
+        *target,
+        "GET",
+        "/health",
+        "",
+        DefaultJsonHeaders());
     return response.status_code == 200;
   } catch (const std::exception&) {
     return false;
@@ -93,8 +100,14 @@ bool PlaneSkillRuntimeSyncService::SyncPlane(
 
   std::set<std::string> remote_ids;
   try {
-    const auto response = SendControllerHttpRequest(
-        *target, "GET", "/v1/skills", "", DefaultJsonHeaders());
+    const auto response = PlaneSkillsTargetResolver::SendPlaneLocalRequest(
+        db_path,
+        desired_state.plane_name,
+        *target,
+        "GET",
+        "/v1/skills",
+        "",
+        DefaultJsonHeaders());
     if (response.status_code == 200) {
       const auto payload = response.body.empty() ? json::object() : json::parse(response.body);
       if (payload.contains("skills") && payload.at("skills").is_array()) {
@@ -116,7 +129,9 @@ bool PlaneSkillRuntimeSyncService::SyncPlane(
     }
     const auto binding = store.LoadPlaneSkillBinding(desired_state.plane_name, skill_id);
     try {
-      const auto response = SendControllerHttpRequest(
+      const auto response = PlaneSkillsTargetResolver::SendPlaneLocalRequest(
+          db_path,
+          desired_state.plane_name,
           *target,
           "PUT",
           "/v1/skills/" + skill_id,
@@ -133,7 +148,9 @@ bool PlaneSkillRuntimeSyncService::SyncPlane(
 
   for (const auto& stale_skill_id : remote_ids) {
     try {
-      const auto response = SendControllerHttpRequest(
+      const auto response = PlaneSkillsTargetResolver::SendPlaneLocalRequest(
+          db_path,
+          desired_state.plane_name,
           *target,
           "DELETE",
           "/v1/skills/" + stale_skill_id,

--- a/controller/src/skills/plane_skills_service.cpp
+++ b/controller/src/skills/plane_skills_service.cpp
@@ -119,6 +119,29 @@ std::optional<ControllerEndpointTarget> PlaneSkillsService::ResolveTarget(
   return PlaneSkillsTargetResolver::ResolvePlaneLocalTarget(desired_state);
 }
 
+bool PlaneSkillsService::ProbeTargetOk(
+    const std::string& db_path,
+    const DesiredState& desired_state,
+    const std::string& path) const {
+  const auto target = ResolveTarget(desired_state);
+  if (!target.has_value()) {
+    return false;
+  }
+  try {
+    const auto response = PlaneSkillsTargetResolver::SendPlaneLocalRequest(
+        db_path,
+        desired_state.plane_name,
+        *target,
+        "GET",
+        path,
+        "",
+        PlaneSkillsTargetResolver::DefaultJsonHeaders());
+    return response.status_code == 200;
+  } catch (const std::exception&) {
+    return false;
+  }
+}
+
 std::optional<std::string> PlaneSkillsService::ParseSessionId(const json& payload) {
   if (!payload.contains("session_id") || payload.at("session_id").is_null()) {
     return std::nullopt;
@@ -318,7 +341,8 @@ std::optional<InteractionValidationError> PlaneSkillsService::ResolveInteraction
       [&](const std::string& fallback_error_code,
           const std::string& fallback_error_message)
       -> std::optional<InteractionValidationError> {
-    if (!request.HasExplicitSelection()) {
+    if (!request.HasExplicitSelection() &&
+        contextual_selection.selected_skill_ids.empty()) {
       return InteractionValidationError{
           fallback_error_code,
           fallback_error_message,
@@ -374,7 +398,9 @@ std::optional<InteractionValidationError> PlaneSkillsService::ResolveInteraction
       (void)PlaneSkillRuntimeSyncService().SyncPlane(
           resolution.db_path, resolution.desired_state);
     }
-    const HttpResponse response = SendControllerHttpRequest(
+    const HttpResponse response = PlaneSkillsTargetResolver::SendPlaneLocalRequest(
+        resolution.db_path,
+        resolution.desired_state.plane_name,
         *target,
         "POST",
         "/v1/skills/resolve",
@@ -452,7 +478,9 @@ std::optional<HttpResponse> PlaneSkillsService::ProxyPlaneSkillsRequest(
   }
 
   try {
-    return SendControllerHttpRequest(
+    return PlaneSkillsTargetResolver::SendPlaneLocalRequest(
+        resolution.db_path,
+        resolution.desired_state.plane_name,
         *target,
         method,
         PlaneSkillsTargetResolver::NormalizeSkillPathSuffix(path_suffix),

--- a/controller/src/skills/plane_skills_service_tests.cpp
+++ b/controller/src/skills/plane_skills_service_tests.cpp
@@ -1409,7 +1409,8 @@ json InteractionBrowsingRuntimeTestServer::BuildResolveResponse(const json& payl
 
 naim::DesiredState BuildDesiredStateWithSkillsPort(
     const std::string& host_ip,
-    const int host_port) {
+    const int host_port,
+    const std::string& node_name = "local-hostd") {
   naim::DesiredState desired_state;
   desired_state.plane_name = "maglev";
   desired_state.plane_mode = naim::PlaneMode::Llm;
@@ -1420,7 +1421,7 @@ naim::DesiredState BuildDesiredStateWithSkillsPort(
   naim::InstanceSpec skills;
   skills.name = "skills-maglev";
   skills.plane_name = "maglev";
-  skills.node_name = "local-hostd";
+  skills.node_name = node_name;
   skills.role = naim::InstanceRole::Skills;
   naim::PublishedPort published_port;
   published_port.host_ip = host_ip;
@@ -1539,6 +1540,20 @@ int main() {
           target->raw == "http://127.0.0.1:27978",
           "skills target raw URL should normalize wildcard host_ip");
       std::cout << "ok: wildcard-host-ip-normalization" << '\n';
+    }
+
+    {
+      const auto target =
+          service.ResolveTarget(BuildDesiredStateWithSkillsPort("127.0.0.1", 27978, "hpc1"));
+      Expect(target.has_value(), "remote skills target should resolve");
+      Expect(target->node_name == "hpc1", "remote skills target should preserve node binding");
+      Expect(
+          target->route_via_hostd_proxy,
+          "remote loopback skills target should use hostd runtime proxy");
+      Expect(
+          target->route_mode == "hostd-runtime-proxy",
+          "remote loopback skills target should expose hostd proxy route mode");
+      std::cout << "ok: remote-loopback-skills-target-hostd-proxy" << '\n';
     }
 
     {
@@ -2449,10 +2464,11 @@ int main() {
                               {"content",
                                "Please debug this regression and find the root cause."}}})}});
       Expect(
-          selection.mode == "none" && selection.candidate_count == 0 &&
-              selection.selected_skill_ids.empty(),
-          "resolver should not use controller catalog entries for contextual activation");
-      std::cout << "ok: contextual-resolver-requires-plane-local-replica" << '\n';
+          selection.mode == "contextual" && selection.candidate_count == 1 &&
+              selection.selected_skill_ids.size() == 1 &&
+              selection.selected_skill_ids.front() == "code-agent-root-cause-debug",
+          "resolver should fall back to attached controller skill records when the runtime replica is unavailable");
+      std::cout << "ok: contextual-resolver-falls-back-to-attached-controller-skill-records" << '\n';
     }
 
     {
@@ -2654,14 +2670,16 @@ int main() {
       const auto applied = request_context.payload.at(
           naim::controller::PlaneSkillsService::kAppliedSkillsPayloadKey);
       Expect(
-          applied.is_array() && applied.empty(),
-          "automatic contextual skills should not fall back to the controller catalog");
+          applied.is_array() && applied.size() == 1 &&
+              applied.front().at("id").get<std::string>() ==
+                  "lt-jex-market-asset-report",
+          "automatic contextual skills should fall back to attached controller skill records");
       Expect(
           request_context.payload.at(
               naim::controller::PlaneSkillsService::kSkillResolutionModePayloadKey)
-              .get<std::string>() == "none",
-          "automatic contextual skills should report none when no plane-owned replica candidate is available");
-      std::cout << "ok: interaction-auto-skills-do-not-fallback-to-controller-catalog" << '\n';
+              .get<std::string>() == "contextual",
+          "automatic contextual skills should report contextual mode after catalog-backed match_terms selection");
+      std::cout << "ok: interaction-auto-skills-fallback-to-attached-controller-skill-records" << '\n';
     }
 
     {

--- a/controller/src/skills/plane_skills_target_resolver.cpp
+++ b/controller/src/skills/plane_skills_target_resolver.cpp
@@ -1,16 +1,84 @@
 #include "skills/plane_skills_target_resolver.h"
 
 #include <algorithm>
+#include <chrono>
+#include <thread>
+
+#include <nlohmann/json.hpp>
+
+#include "http/controller_http_transport.h"
+#include "naim/state/sqlite_store.h"
 
 namespace naim::controller {
 
 namespace {
+
+using nlohmann::json;
 
 std::string NormalizeControllerTargetHost(const PublishedPort& port) {
   if (port.host_ip.empty() || port.host_ip == "0.0.0.0") {
     return "127.0.0.1";
   }
   return port.host_ip;
+}
+
+bool IsControllerLocalNode(const std::string& node_name) {
+  return node_name.empty() || node_name == "local-hostd" ||
+         node_name == "controller-local";
+}
+
+bool IsLoopbackTargetHost(const std::string& host) {
+  return host == "127.0.0.1" || host == "localhost" || host == "::1";
+}
+
+json BuildHeaderArray(
+    const std::vector<std::pair<std::string, std::string>>& headers) {
+  json result = json::array();
+  for (const auto& [key, value] : headers) {
+    result.push_back(json::array({key, value}));
+  }
+  return result;
+}
+
+HttpResponse BuildProxyErrorResponse(
+    int status_code,
+    const std::string& code,
+    const std::string& message) {
+  HttpResponse response;
+  response.status_code = status_code;
+  response.content_type = "application/json";
+  response.headers["Content-Type"] = response.content_type;
+  response.body =
+      json{{"status", "error"}, {"code", code}, {"message", message}}.dump();
+  return response;
+}
+
+HttpResponse ParseProxyResponsePayload(const json& progress) {
+  if (!progress.is_object() || !progress.contains("response") ||
+      !progress.at("response").is_object()) {
+    return BuildProxyErrorResponse(
+        502,
+        "skills_runtime_proxy_response_missing",
+        "hostd skills runtime proxy did not return an upstream response");
+  }
+  const auto& response_payload = progress.at("response");
+  HttpResponse response;
+  response.status_code = response_payload.value("status_code", 502);
+  response.content_type =
+      response_payload.value("content_type", std::string("application/json"));
+  response.body = response_payload.value("body", std::string{});
+  if (response_payload.contains("headers") &&
+      response_payload.at("headers").is_object()) {
+    for (const auto& [key, value] : response_payload.at("headers").items()) {
+      if (value.is_string()) {
+        response.headers[key] = value.get<std::string>();
+      }
+    }
+  }
+  if (!response.content_type.empty()) {
+    response.headers["Content-Type"] = response.content_type;
+  }
+  return response;
 }
 
 }  // namespace
@@ -50,7 +118,109 @@ PlaneSkillsTargetResolver::ResolvePlaneLocalTarget(
   target.host = NormalizeControllerTargetHost(*published);
   target.port = published->host_port;
   target.raw = "http://" + target.host + ":" + std::to_string(target.port);
+  target.node_name = skills->node_name;
+  if (!IsControllerLocalNode(target.node_name) && IsLoopbackTargetHost(target.host)) {
+    target.route_via_hostd_proxy = true;
+    target.route_mode = "hostd-runtime-proxy";
+  }
   return target;
+}
+
+::HttpResponse PlaneSkillsTargetResolver::SendPlaneLocalRequest(
+    const std::string& db_path,
+    const std::string& plane_name,
+    const ControllerEndpointTarget& target,
+    const std::string& method,
+    const std::string& path,
+    const std::string& body,
+    const std::vector<std::pair<std::string, std::string>>& headers) {
+  if (!target.route_via_hostd_proxy) {
+    return SendControllerHttpRequest(target, method, path, body, headers);
+  }
+  if (db_path.empty() || target.node_name.empty()) {
+    return BuildProxyErrorResponse(
+        502,
+        "skills_runtime_proxy_route_missing",
+        "skills runtime target requires hostd proxy routing but has no node binding");
+  }
+  if (!IsLoopbackTargetHost(target.host)) {
+    return BuildProxyErrorResponse(
+        502,
+        "skills_runtime_proxy_target_rejected",
+        "hostd skills runtime proxy only accepts node-local loopback targets");
+  }
+
+  ControllerStore store(db_path);
+  store.Initialize();
+  const std::string request_id =
+      "skills-" + plane_name + "-" +
+      std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+  const std::string proxy_plane_name =
+      "runtime-http-proxy:skills:" + plane_name + ":" + request_id;
+
+  HostAssignment assignment;
+  assignment.node_name = target.node_name;
+  assignment.plane_name = proxy_plane_name;
+  assignment.desired_generation = 0;
+  assignment.max_attempts = 1;
+  assignment.assignment_type = "runtime-http-proxy";
+  assignment.desired_state_json =
+      json{
+          {"target_host", target.host},
+          {"target_port", target.port},
+          {"method", method},
+          {"path", path},
+          {"body", body},
+          {"headers", BuildHeaderArray(headers)},
+          {"request_id", request_id},
+          {"policy", "skills"},
+      }
+          .dump();
+  assignment.artifacts_root = "";
+  assignment.status = HostAssignmentStatus::Pending;
+  assignment.status_message = "proxy skills runtime HTTP request";
+  store.EnqueueHostAssignments({assignment}, "superseded skills runtime proxy request");
+
+  const auto assignments = store.LoadHostAssignments(
+      target.node_name,
+      std::nullopt,
+      proxy_plane_name);
+  if (assignments.empty()) {
+    return BuildProxyErrorResponse(
+        500,
+        "skills_runtime_proxy_queue_failed",
+        "failed to queue hostd skills runtime proxy assignment");
+  }
+  const int assignment_id = assignments.back().id;
+  const auto started_at = std::chrono::steady_clock::now();
+  while (std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now() - started_at)
+             .count() < 30000) {
+    const auto current = store.LoadHostAssignment(assignment_id);
+    if (!current.has_value()) {
+      return BuildProxyErrorResponse(
+          500,
+          "skills_runtime_proxy_assignment_missing",
+          "hostd skills runtime proxy assignment disappeared");
+    }
+    if (current->status == HostAssignmentStatus::Applied) {
+      const auto progress = json::parse(current->progress_json, nullptr, false);
+      return ParseProxyResponsePayload(progress);
+    }
+    if (current->status == HostAssignmentStatus::Failed) {
+      return BuildProxyErrorResponse(
+          502,
+          "skills_runtime_proxy_failed",
+          current->status_message.empty()
+              ? "hostd skills runtime proxy request failed"
+              : current->status_message);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  return BuildProxyErrorResponse(
+      504,
+      "skills_runtime_proxy_timeout",
+      "timed out waiting for hostd skills runtime proxy response");
 }
 
 std::string PlaneSkillsTargetResolver::NormalizeSkillPathSuffix(

--- a/hostd/include/app/hostd_runtime_http_proxy.h
+++ b/hostd/include/app/hostd_runtime_http_proxy.h
@@ -10,6 +10,7 @@ namespace naim::hostd {
 enum class HostdRuntimeProxyPolicy {
   Runtime,
   KnowledgeVault,
+  Skills,
 };
 
 struct HostdRuntimeHttpResponse {

--- a/hostd/src/app/hostd_app_assignment_support.cpp
+++ b/hostd/src/app/hostd_app_assignment_support.cpp
@@ -568,9 +568,12 @@ void HostdAppAssignmentSupport::ExecuteRuntimeHttpProxy(
   const std::string path = payload.value("path", std::string{});
   const std::string body = payload.value("body", std::string{});
   const std::string policy_name = payload.value("policy", std::string("runtime"));
-  const HostdRuntimeProxyPolicy policy =
-      policy_name == "knowledge-vault" ? HostdRuntimeProxyPolicy::KnowledgeVault
-                                       : HostdRuntimeProxyPolicy::Runtime;
+  HostdRuntimeProxyPolicy policy = HostdRuntimeProxyPolicy::Runtime;
+  if (policy_name == "knowledge-vault") {
+    policy = HostdRuntimeProxyPolicy::KnowledgeVault;
+  } else if (policy_name == "skills") {
+    policy = HostdRuntimeProxyPolicy::Skills;
+  }
   const auto headers = runtime_http_proxy_.ParseProxyHeaders(
       payload.value("headers", nlohmann::json::array()));
 

--- a/hostd/src/app/hostd_runtime_http_proxy.cpp
+++ b/hostd/src/app/hostd_runtime_http_proxy.cpp
@@ -178,6 +178,23 @@ bool HostdRuntimeHttpProxy::IsAllowedProxyPath(
     const std::string& method,
     const std::string& path) {
   const std::string route = path.substr(0, path.find('?'));
+  if (policy == HostdRuntimeProxyPolicy::Skills) {
+    if (method == "GET" && route == "/health") {
+      return true;
+    }
+    if (route == "/v1/skills" && (method == "GET" || method == "POST")) {
+      return true;
+    }
+    if (route == "/v1/skills/resolve" && method == "POST") {
+      return true;
+    }
+    if (route.rfind("/v1/skills/", 0) == 0 &&
+        (method == "GET" || method == "PUT" || method == "PATCH" ||
+         method == "DELETE")) {
+      return true;
+    }
+    return false;
+  }
   if (policy == HostdRuntimeProxyPolicy::KnowledgeVault) {
     if (method == "GET" && route == "/health") {
       return true;
@@ -192,6 +209,9 @@ bool HostdRuntimeHttpProxy::IsAllowedProxyPath(
 }
 
 std::string HostdRuntimeHttpProxy::PolicyLabel(HostdRuntimeProxyPolicy policy) {
+  if (policy == HostdRuntimeProxyPolicy::Skills) {
+    return "skills-runtime-http";
+  }
   if (policy == HostdRuntimeProxyPolicy::KnowledgeVault) {
     return "knowledge-vault-http";
   }

--- a/runtime/knowledge/src/knowledge_store.cpp
+++ b/runtime/knowledge/src/knowledge_store.cpp
@@ -41,6 +41,49 @@ std::string RelationSearchText(const nlohmann::json& relation) {
       relation.value("to_block_id", std::string{}));
 }
 
+std::vector<std::string> QueryTerms(const std::string& query) {
+  static const std::set<std::string> kIgnoredTerms = {
+      "a", "an", "and", "are", "for", "in", "is", "of", "on", "or", "the",
+      "to", "with",
+  };
+  std::vector<std::string> terms;
+  std::set<std::string> seen;
+  std::string current;
+  const auto flush = [&]() {
+    if (current.size() >= 2 && kIgnoredTerms.find(current) == kIgnoredTerms.end() &&
+        seen.insert(current).second) {
+      terms.push_back(current);
+    }
+    current.clear();
+  };
+  for (unsigned char ch : query) {
+    if (std::isalnum(ch)) {
+      current.push_back(static_cast<char>(std::tolower(ch)));
+    } else {
+      flush();
+    }
+  }
+  flush();
+  return terms;
+}
+
+int TokenSearchScore(
+    const std::string& lowered_query,
+    const std::vector<std::string>& query_terms,
+    const std::string& text,
+    int token_weight) {
+  if (lowered_query.empty()) {
+    return 0;
+  }
+  int score = text.find(lowered_query) != std::string::npos ? 100 : 0;
+  for (const auto& term : query_terms) {
+    if (text.find(term) != std::string::npos) {
+      score += token_weight;
+    }
+  }
+  return score;
+}
+
 }  // namespace
 
 KnowledgeStore::KnowledgeStore(std::filesystem::path store_path)
@@ -217,7 +260,8 @@ nlohmann::json KnowledgeStore::Search(const nlohmann::json& payload) const {
   }
   const int limit = std::max(1, std::min(100, payload.value("limit", 20)));
   const std::string lowered_query = KnowledgeTextProcessor::Lowercase(query);
-  nlohmann::json results = nlohmann::json::array();
+  const auto query_terms = QueryTerms(query);
+  std::vector<std::pair<int, nlohmann::json>> scored_results;
   for (const auto& [key, block] : repository_->ScanJson("blocks:")) {
     const std::string knowledge_id = block.value("knowledge_id", std::string{});
     if (!StringSetContains(selected_filter, knowledge_id)) {
@@ -225,40 +269,35 @@ nlohmann::json KnowledgeStore::Search(const nlohmann::json& payload) const {
     }
     const auto neighbors = Neighbors(block.value("block_id", std::string{}))
                                .value("neighbors", nlohmann::json::array());
-    bool matched = query.empty() || BlockSearchText(block).find(lowered_query) != std::string::npos;
+    int score = query.empty() || list_all
+                    ? 1
+                    : TokenSearchScore(lowered_query, query_terms, BlockSearchText(block), 10);
     for (const auto& relation : neighbors) {
-      if (matched) {
-        break;
-      }
-      if (RelationSearchText(relation).find(lowered_query) != std::string::npos) {
-        matched = true;
-        break;
-      }
+      score += TokenSearchScore(lowered_query, query_terms, RelationSearchText(relation), 5);
       const std::string from = relation.value("from_block_id", std::string{});
       const std::string to = relation.value("to_block_id", std::string{});
       const std::string neighbor_id =
           from == block.value("block_id", std::string{}) ? to : from;
       const auto neighbor = repository_->GetJson("blocks:" + neighbor_id);
-      if (neighbor.has_value() &&
-          BlockSearchText(*neighbor).find(lowered_query) != std::string::npos) {
-        matched = true;
-        break;
+      if (neighbor.has_value()) {
+        score += TokenSearchScore(lowered_query, query_terms, BlockSearchText(*neighbor), 3);
       }
     }
-    if (!matched) {
+    if (score <= 0) {
       continue;
     }
     const auto scope_ids = block.value("scope_ids", nlohmann::json::array());
     if (!ScopeAllowed(scope_ids, requested_scopes)) {
-      results.push_back(nlohmann::json{
+      scored_results.push_back({score, nlohmann::json{
           {"block_id", block.value("block_id", std::string{})},
           {"knowledge_id", knowledge_id},
+          {"score", score},
           {"mode", "redacted"},
           {"redaction", nlohmann::json{{"reason", "out_of_scope"}}},
-      });
+      }});
     } else {
       const std::string body = block.value("body", std::string{});
-      results.push_back(nlohmann::json{
+      scored_results.push_back({score, nlohmann::json{
           {"block_id", block.value("block_id", std::string{})},
           {"knowledge_id", knowledge_id},
           {"version_id", block.value("version_id", std::string{})},
@@ -266,15 +305,30 @@ nlohmann::json KnowledgeStore::Search(const nlohmann::json& payload) const {
           {"type", block.value("type", std::string("note"))},
           {"scope_ids", scope_ids},
           {"summary", body.substr(0, 240)},
-          {"score", 1.0},
+          {"score", score},
           {"confidence", block.value("confidence", 1.0)},
           {"freshness", "current"},
           {"relation_count", neighbors.size()},
           {"shard_id", std::string(KnowledgeStoreKeys::kDefaultShardId)},
           {"content_hash", block.value("content_hash", std::string{})},
           {"redaction", nullptr},
-      });
+      }});
     }
+  }
+  std::sort(
+      scored_results.begin(),
+      scored_results.end(),
+      [](const auto& left, const auto& right) {
+        if (left.first != right.first) {
+          return left.first > right.first;
+        }
+        return left.second.value("block_id", std::string{}) <
+               right.second.value("block_id", std::string{});
+      });
+  nlohmann::json results = nlohmann::json::array();
+  for (const auto& [score, result] : scored_results) {
+    (void)score;
+    results.push_back(result);
     if (static_cast<int>(results.size()) >= limit) {
       break;
     }

--- a/runtime/knowledge/src/knowledge_store_tests.cpp
+++ b/runtime/knowledge/src/knowledge_store_tests.cpp
@@ -65,6 +65,25 @@ int main() {
   });
   Expect(!search.value("results", nlohmann::json::array()).empty(), "search should return result");
 
+  store.WriteBlock(nlohmann::json{
+      {"block_id", "lt-cypher-ai.market.assets"},
+      {"knowledge_id", "lt-cypher-ai.market.assets"},
+      {"title", "lt-cypher-ai market asset memory"},
+      {"body", "BTC latest price and bitcoin market observations from LocalTrade and CoinGecko."},
+      {"scope_ids", nlohmann::json::array({"scope.default"})},
+  });
+  const auto token_search = store.Search(nlohmann::json{
+      {"query", "bitcoin market BTC LocalTrade"},
+      {"scope_id", "scope.default"},
+      {"limit", 5},
+  });
+  const auto token_results = token_search.value("results", nlohmann::json::array());
+  Expect(!token_results.empty(), "token search should find deterministic market blocks");
+  Expect(
+      token_results.front().value("block_id", std::string{}) ==
+          "lt-cypher-ai.market.assets",
+      "token search should rank the matching deterministic market block first");
+
   const auto redacted = store.Search(nlohmann::json{
       {"query", "scheduled merge"},
       {"scope_id", "scope.other"},


### PR DESCRIPTION
## Summary
- route remote loopback skills runtime targets through hostd runtime proxy
- add skills proxy policy whitelist in hostd
- keep contextual resolver fallback to attached plane skills and update KV search/status fixes

## Validation
- hpc1: cmake --build /tmp/naim-node-kv-fixes-build --target naim-plane-skills-tests naim-controller naim-hostd -j 12
- hpc1: ./naim-plane-skills-tests && ./naim-knowledge-store-tests && ./naim-knowledge-vault-service-tests