### PR TITLE
Run hostd self-update from helper container

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1001,6 +1001,17 @@ target_link_libraries(naim-hostd-command-support-tests PRIVATE naim-common)
 naim_enable_strict_warnings(naim-hostd-command-support-tests)
 
 add_executable(
+  naim-hostd-self-update-support-tests
+  hostd/src/app/hostd_command_support.cpp
+  hostd/src/app/hostd_self_update_support.cpp
+  hostd/src/app/hostd_self_update_support_tests.cpp
+)
+target_include_directories(
+  naim-hostd-self-update-support-tests PRIVATE common/include hostd/include)
+target_link_libraries(naim-hostd-self-update-support-tests PRIVATE naim-common)
+naim_enable_strict_warnings(naim-hostd-self-update-support-tests)
+
+add_executable(
   naim-hostd-install-layout-support-tests
   hostd/src/app/hostd_install_layout_support.cpp
   hostd/src/app/hostd_install_layout_support_tests.cpp
@@ -1191,6 +1202,7 @@ add_executable(
   hostd/src/app/hostd_reporting_support.cpp
   hostd/src/app/hostd_repo_root_support.cpp
   hostd/src/app/hostd_runtime_http_proxy.cpp
+  hostd/src/app/hostd_self_update_support.cpp
   hostd/src/app/hostd_runtime_telemetry_support.cpp
   hostd/src/app/hostd_system_telemetry_collector.cpp
   hostd/src/app/hostd_desired_state_apply_support_tests.cpp
@@ -1435,6 +1447,7 @@ add_executable(
   hostd/src/app/hostd_reporting_support.cpp
   hostd/src/app/hostd_repo_root_support.cpp
   hostd/src/app/hostd_runtime_http_proxy.cpp
+  hostd/src/app/hostd_self_update_support.cpp
   hostd/src/app/hostd_runtime_telemetry_support.cpp
   hostd/src/app/hostd_system_telemetry_collector.cpp
   hostd/src/backend/hostd_backend_factory.cpp

--- a/hostd/include/app/hostd_app_assignment_support.h
+++ b/hostd/include/app/hostd_app_assignment_support.h
@@ -27,6 +27,7 @@
 #include "app/hostd_post_deploy_support.h"
 #include "app/hostd_reporting_support.h"
 #include "app/hostd_runtime_http_proxy.h"
+#include "app/hostd_self_update_support.h"
 #include "backend/hostd_backend.h"
 #include "cli/hostd_command_line.h"
 #include "naim/state/models.h"
@@ -158,6 +159,7 @@ class HostdAppAssignmentSupport final : public IHostdAssignmentSupport {
   HostdPostDeploySupport post_deploy_support_;
   HostdReportingSupport reporting_support_;
   HostdRuntimeHttpProxy runtime_http_proxy_;
+  HostdSelfUpdateSupport self_update_support_;
   HostdModelArtifactRequestSupport model_artifact_request_support_;
   HostdContainerNameSupport container_name_support_;
   HostdBootstrapTransferSupport model_library_transfer_support_;

--- a/hostd/include/app/hostd_self_update_support.h
+++ b/hostd/include/app/hostd_self_update_support.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+#include "app/hostd_command_support.h"
+
+namespace naim::hostd {
+
+struct HostdSelfUpdateRequest {
+  std::string release_tag;
+  std::string node_name;
+  std::string hostd_image;
+  std::filesystem::path hostd_root;
+  std::filesystem::path compose_file;
+  std::filesystem::path registry_config_dir;
+  std::filesystem::path update_script;
+  std::filesystem::path update_log;
+  bool registry_config_available = false;
+};
+
+struct HostdSelfUpdatePlan {
+  std::string script_content;
+  std::string launch_command;
+  std::string helper_container_name;
+};
+
+class HostdSelfUpdateSupport final {
+ public:
+  HostdSelfUpdatePlan BuildPlan(const HostdSelfUpdateRequest& request) const;
+
+ private:
+  static bool IsPathWithin(
+      const std::filesystem::path& child,
+      const std::filesystem::path& parent);
+  static std::string SanitizeContainerNamePart(const std::string& value);
+  static std::string BuildHelperContainerName(
+      const std::string& node_name,
+      const std::string& release_tag);
+
+  HostdCommandSupport command_support_;
+};
+
+}  // namespace naim::hostd

--- a/hostd/src/app/hostd_app_assignment_support.cpp
+++ b/hostd/src/app/hostd_app_assignment_support.cpp
@@ -657,27 +657,20 @@ void HostdAppAssignmentSupport::ExecuteHostSelfUpdate(
   const std::filesystem::path update_log =
       hostd_root / "logs" / ("hostd-self-update-" + release_tag + ".log");
 
-  std::string script = "#!/usr/bin/env bash\n"
-                       "set -euo pipefail\n";
-  if (std::filesystem::exists(registry_config_dir / "config.json")) {
-    script += "export DOCKER_CONFIG=" +
-              command_support_.ShellQuote(registry_config_dir.string()) + "\n";
-  }
-  const std::string sed_expression =
-      "s#^([[:space:]]*image:[[:space:]]*)chainzano.com/naim/hostd"
-      "(:[^[:space:]]+|@sha256:[a-f0-9]+)?#\\1" +
-      hostd_image + "#";
-  script += "sed -i -E " + command_support_.ShellQuote(sed_expression) + " " +
-            command_support_.ShellQuote(compose_file.string()) + "\n"
-            "grep -F " + command_support_.ShellQuote("image: " + hostd_image) + " " +
-            command_support_.ShellQuote(compose_file.string()) + " >/dev/null\n"
-            "sleep 2\n"
-            "docker compose -f " + command_support_.ShellQuote(compose_file.string()) +
-            " pull naim-hostd\n"
-            "docker compose -f " + command_support_.ShellQuote(compose_file.string()) +
-            " up -d --remove-orphans naim-hostd\n";
+  const auto update_plan = self_update_support_.BuildPlan(
+      HostdSelfUpdateRequest{
+          release_tag,
+          node_name,
+          hostd_image,
+          hostd_root,
+          compose_file,
+          registry_config_dir,
+          update_script,
+          update_log,
+          std::filesystem::exists(registry_config_dir / "config.json"),
+      });
 
-  file_support_.WriteTextFile(update_script.string(), script);
+  file_support_.WriteTextFile(update_script.string(), update_plan.script_content);
   if (!command_support_.RunCommandOk(
           "chmod 0700 " + command_support_.ShellQuote(update_script.string()))) {
     throw std::runtime_error("failed to chmod hostd self-update script");
@@ -695,13 +688,11 @@ void HostdAppAssignmentSupport::ExecuteHostSelfUpdate(
           {"hostd_image", hostd_image},
           {"compose_file_path", compose_file.string()},
           {"script_path", update_script.string()},
-          {"log_path", update_log.string()}});
+          {"log_path", update_log.string()},
+          {"helper_container", update_plan.helper_container_name}});
 
-  const std::string launch_command =
-      "nohup bash " + command_support_.ShellQuote(update_script.string()) + " >" +
-      command_support_.ShellQuote(update_log.string()) + " 2>&1 < /dev/null &";
-  if (!command_support_.RunCommandOk(launch_command)) {
-    throw std::runtime_error("failed to launch hostd self-update background job");
+  if (!command_support_.RunCommandOk(update_plan.launch_command)) {
+    throw std::runtime_error("failed to launch hostd self-update helper container");
   }
 }
 

--- a/hostd/src/app/hostd_self_update_support.cpp
+++ b/hostd/src/app/hostd_self_update_support.cpp
@@ -1,0 +1,138 @@
+#include "app/hostd_self_update_support.h"
+
+#include <algorithm>
+#include <cctype>
+#include <vector>
+
+namespace naim::hostd {
+
+namespace {
+
+std::string PathString(const std::filesystem::path& path) {
+  return path.lexically_normal().string();
+}
+
+}  // namespace
+
+bool HostdSelfUpdateSupport::IsPathWithin(
+    const std::filesystem::path& child,
+    const std::filesystem::path& parent) {
+  const auto normalized_child = child.lexically_normal();
+  const auto normalized_parent = parent.lexically_normal();
+  auto child_it = normalized_child.begin();
+  auto parent_it = normalized_parent.begin();
+  for (; parent_it != normalized_parent.end(); ++parent_it, ++child_it) {
+    if (child_it == normalized_child.end() || *child_it != *parent_it) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string HostdSelfUpdateSupport::SanitizeContainerNamePart(
+    const std::string& value) {
+  std::string sanitized;
+  sanitized.reserve(value.size());
+  for (const char ch : value) {
+    const unsigned char uch = static_cast<unsigned char>(ch);
+    if (std::isalnum(uch) != 0 || ch == '_' || ch == '.' || ch == '-') {
+      sanitized.push_back(static_cast<char>(std::tolower(uch)));
+    } else {
+      sanitized.push_back('-');
+    }
+  }
+  while (!sanitized.empty() && sanitized.front() == '-') {
+    sanitized.erase(sanitized.begin());
+  }
+  while (!sanitized.empty() && sanitized.back() == '-') {
+    sanitized.pop_back();
+  }
+  if (sanitized.empty()) {
+    return "unknown";
+  }
+  return sanitized;
+}
+
+std::string HostdSelfUpdateSupport::BuildHelperContainerName(
+    const std::string& node_name,
+    const std::string& release_tag) {
+  std::string name = "naim-hostd-self-update-" +
+                     SanitizeContainerNamePart(node_name) + "-" +
+                     SanitizeContainerNamePart(release_tag);
+  constexpr std::size_t kMaxNameLength = 96;
+  if (name.size() > kMaxNameLength) {
+    name.resize(kMaxNameLength);
+    while (!name.empty() && name.back() == '-') {
+      name.pop_back();
+    }
+  }
+  return name.empty() ? "naim-hostd-self-update" : name;
+}
+
+HostdSelfUpdatePlan HostdSelfUpdateSupport::BuildPlan(
+    const HostdSelfUpdateRequest& request) const {
+  const std::string sed_expression =
+      "s#^([[:space:]]*image:[[:space:]]*)chainzano.com/naim/hostd"
+      "(:[^[:space:]]+|@sha256:[a-f0-9]+)?#\\1" +
+      request.hostd_image + "#";
+
+  std::string script = "#!/usr/bin/env bash\n"
+                       "set -euo pipefail\n";
+  if (request.registry_config_available) {
+    script += "export DOCKER_CONFIG=" +
+              command_support_.ShellQuote(PathString(request.registry_config_dir)) + "\n";
+  }
+  script += "sed -i -E " + command_support_.ShellQuote(sed_expression) + " " +
+            command_support_.ShellQuote(PathString(request.compose_file)) + "\n"
+            "grep -F " + command_support_.ShellQuote("image: " + request.hostd_image) +
+            " " + command_support_.ShellQuote(PathString(request.compose_file)) +
+            " >/dev/null\n"
+            "sleep 2\n"
+            "docker compose -f " + command_support_.ShellQuote(PathString(request.compose_file)) +
+            " pull naim-hostd\n"
+            "docker compose -f " + command_support_.ShellQuote(PathString(request.compose_file)) +
+            " up -d --remove-orphans --force-recreate naim-hostd\n";
+
+  const std::string helper_container_name =
+      BuildHelperContainerName(request.node_name, request.release_tag);
+
+  std::vector<std::string> mounts{
+      "/var/run/docker.sock:/var/run/docker.sock",
+      PathString(request.hostd_root) + ":" + PathString(request.hostd_root),
+  };
+  const std::filesystem::path compose_parent = request.compose_file.parent_path();
+  if (!compose_parent.empty() && !IsPathWithin(compose_parent, request.hostd_root)) {
+    mounts.push_back(PathString(compose_parent) + ":" + PathString(compose_parent));
+  }
+  if (request.registry_config_available &&
+      !IsPathWithin(request.registry_config_dir, request.hostd_root)) {
+    mounts.push_back(PathString(request.registry_config_dir) + ":" +
+                     PathString(request.registry_config_dir) + ":ro");
+  }
+
+  std::string launch_command = command_support_.ResolvedDockerCommand();
+  if (request.registry_config_available) {
+    launch_command += " --config " +
+                      command_support_.ShellQuote(PathString(request.registry_config_dir));
+  }
+  launch_command += " run --rm --detach --name " +
+                    command_support_.ShellQuote(helper_container_name) +
+                    " --entrypoint " + command_support_.ShellQuote("/usr/bin/env");
+  for (const std::string& mount : mounts) {
+    launch_command += " -v " + command_support_.ShellQuote(mount);
+  }
+  launch_command += " " + command_support_.ShellQuote(request.hostd_image) +
+                    " bash -lc " +
+                    command_support_.ShellQuote(
+                        "bash " + command_support_.ShellQuote(PathString(request.update_script)) +
+                        " >>" + command_support_.ShellQuote(PathString(request.update_log)) +
+                        " 2>&1");
+
+  return HostdSelfUpdatePlan{
+      script,
+      launch_command,
+      helper_container_name,
+  };
+}
+
+}  // namespace naim::hostd

--- a/hostd/src/app/hostd_self_update_support_tests.cpp
+++ b/hostd/src/app/hostd_self_update_support_tests.cpp
@@ -1,0 +1,98 @@
+#include "app/hostd_self_update_support.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void Expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+bool Contains(const std::string& text, const std::string& needle) {
+  return text.find(needle) != std::string::npos;
+}
+
+}  // namespace
+
+int main() {
+  using naim::hostd::HostdSelfUpdateRequest;
+  using naim::hostd::HostdSelfUpdateSupport;
+
+  try {
+    HostdSelfUpdateSupport support;
+    const auto plan = support.BuildPlan(
+        HostdSelfUpdateRequest{
+            "release/ABC@1234567890",
+            "Storage 1",
+            "chainzano.com/naim/hostd@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "/opt/naim/hostd",
+            "/opt/naim/hostd/docker-compose.yml",
+            "/opt/naim/hostd/install-state/registry-docker",
+            "/opt/naim/hostd/install-state/hostd-self-update.sh",
+            "/opt/naim/hostd/logs/hostd-self-update-release.log",
+            true,
+        });
+
+    Expect(
+        plan.helper_container_name == "naim-hostd-self-update-storage-1-release-abc-1234567890",
+        "helper container name should be deterministic and docker-safe");
+    Expect(
+        Contains(plan.script_content, "export DOCKER_CONFIG='/opt/naim/hostd/install-state/registry-docker'"),
+        "script should export registry config when available");
+    Expect(
+        Contains(plan.script_content, "docker compose -f '/opt/naim/hostd/docker-compose.yml' pull naim-hostd"),
+        "script should pull the hostd service image");
+    Expect(
+        Contains(
+            plan.script_content,
+            "docker compose -f '/opt/naim/hostd/docker-compose.yml' up -d --remove-orphans --force-recreate naim-hostd"),
+        "script should force-recreate and start naim-hostd");
+    Expect(
+        !Contains(plan.launch_command, "nohup"),
+        "launcher must not keep the updater inside the old hostd container");
+    Expect(
+        Contains(plan.launch_command, " run --rm --detach --name 'naim-hostd-self-update-storage-1-release-abc-1234567890' "),
+        "launcher should start a detached helper container");
+    Expect(
+        Contains(plan.launch_command, "-v '/var/run/docker.sock:/var/run/docker.sock'"),
+        "launcher should mount docker socket into helper");
+    Expect(
+        Contains(plan.launch_command, "-v '/opt/naim/hostd:/opt/naim/hostd'"),
+        "launcher should mount hostd root into helper");
+    Expect(
+        Contains(plan.launch_command, "--entrypoint '/usr/bin/env'"),
+        "launcher should bypass the hostd image default entrypoint");
+    Expect(
+        Contains(plan.launch_command, "bash -lc 'bash '\"'\"'/opt/naim/hostd/install-state/hostd-self-update.sh'\"'\"' >>'\"'\"'/opt/naim/hostd/logs/hostd-self-update-release.log'\"'\"' 2>&1'"),
+        "launcher should write helper script output to the hostd log path");
+
+    const auto external_plan = support.BuildPlan(
+        HostdSelfUpdateRequest{
+            "abc",
+            "hpc1",
+            "chainzano.com/naim/hostd:abc",
+            "/opt/naim/hostd",
+            "/etc/naim/hostd/docker-compose.yml",
+            "/run/naim/registry",
+            "/opt/naim/hostd/install-state/hostd-self-update.sh",
+            "/opt/naim/hostd/logs/hostd-self-update-abc.log",
+            true,
+        });
+    Expect(
+        Contains(external_plan.launch_command, "-v '/etc/naim/hostd:/etc/naim/hostd'"),
+        "launcher should mount an external compose parent directory");
+    Expect(
+        Contains(external_plan.launch_command, "-v '/run/naim/registry:/run/naim/registry:ro'"),
+        "launcher should mount an external registry config directory read-only");
+
+    std::cout << "ok: hostd-self-update-helper-container-plan" << '\n';
+  } catch (const std::exception& error) {
+    std::cerr << "FAIL: " << error.what() << '\n';
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
- run hostd self-update through a detached helper container instead of a background process inside the old hostd container
- keep registry config, compose file, and hostd root mounted into the helper so it can pull and force-recreate naim-hostd after the old container stops
- add a unit test for the generated self-update helper plan

## Validation
- hpc1: cmake --build /tmp/naim-node-kv-fixes-build --target naim-hostd-self-update-support-tests naim-hostd -j 12
- hpc1: ./naim-hostd-self-update-support-tests
- hpc1: cmake --build /tmp/naim-node-kv-fixes-build --target naim-hostd-desired-state-apply-support-tests -j 12
- hpc1: ./naim-hostd-desired-state-apply-support-tests