### PR TITLE
Run hostd self-update helper as root

### DIFF
--- a/hostd/src/app/hostd_self_update_support.cpp
+++ b/hostd/src/app/hostd_self_update_support.cpp
@@ -117,7 +117,8 @@ HostdSelfUpdatePlan HostdSelfUpdateSupport::BuildPlan(
   }
   launch_command += " run --rm --detach --name " +
                     command_support_.ShellQuote(helper_container_name) +
-                    " --entrypoint " + command_support_.ShellQuote("/usr/bin/env");
+                    " --user 0:0 --entrypoint " +
+                    command_support_.ShellQuote("/usr/bin/env");
   for (const std::string& mount : mounts) {
     launch_command += " -v " + command_support_.ShellQuote(mount);
   }

--- a/hostd/src/app/hostd_self_update_support_tests.cpp
+++ b/hostd/src/app/hostd_self_update_support_tests.cpp
@@ -67,6 +67,9 @@ int main() {
         Contains(plan.launch_command, "--entrypoint '/usr/bin/env'"),
         "launcher should bypass the hostd image default entrypoint");
     Expect(
+        Contains(plan.launch_command, "--user 0:0"),
+        "launcher should run as root so it can access the mounted docker socket");
+    Expect(
         Contains(plan.launch_command, "bash -lc 'bash '\"'\"'/opt/naim/hostd/install-state/hostd-self-update.sh'\"'\"' >>'\"'\"'/opt/naim/hostd/logs/hostd-self-update-release.log'\"'\"' 2>&1'"),
         "launcher should write helper script output to the hostd log path");
 


### PR DESCRIPTION
## Summary
- run the detached hostd self-update helper container as root so it can access the mounted Docker socket on all nodes
- extend the self-update support test to cover the root user flag

## Validation
- hpc1: cmake --build /tmp/naim-node-kv-fixes-build --target naim-hostd-self-update-support-tests naim-hostd -j 12
- hpc1: ./naim-hostd-self-update-support-tests

## Operational note
- PR #161 introduced the helper container; production validation showed hpc1 denied Docker socket access without an explicit root user. storage1 succeeded, hpc1 did not. This patch closes that gap.