### PR TITLE
Grant hostd self-update helper Docker socket access

### DIFF
--- a/hostd/include/app/hostd_self_update_support.h
+++ b/hostd/include/app/hostd_self_update_support.h
@@ -16,6 +16,7 @@ struct HostdSelfUpdateRequest {
   std::filesystem::path registry_config_dir;
   std::filesystem::path update_script;
   std::filesystem::path update_log;
+  std::string docker_socket_group_id;
   bool registry_config_available = false;
 };
 

--- a/hostd/src/app/hostd_app_assignment_support.cpp
+++ b/hostd/src/app/hostd_app_assignment_support.cpp
@@ -656,6 +656,8 @@ void HostdAppAssignmentSupport::ExecuteHostSelfUpdate(
       hostd_root / "install-state" / "hostd-self-update.sh";
   const std::filesystem::path update_log =
       hostd_root / "logs" / ("hostd-self-update-" + release_tag + ".log");
+  const std::string docker_socket_group_id = command_support_.Trim(
+      command_support_.RunCommandCapture("stat -c %g /var/run/docker.sock 2>/dev/null"));
 
   const auto update_plan = self_update_support_.BuildPlan(
       HostdSelfUpdateRequest{
@@ -667,6 +669,7 @@ void HostdAppAssignmentSupport::ExecuteHostSelfUpdate(
           registry_config_dir,
           update_script,
           update_log,
+          docker_socket_group_id,
           std::filesystem::exists(registry_config_dir / "config.json"),
       });
 

--- a/hostd/src/app/hostd_self_update_support.cpp
+++ b/hostd/src/app/hostd_self_update_support.cpp
@@ -115,10 +115,14 @@ HostdSelfUpdatePlan HostdSelfUpdateSupport::BuildPlan(
     launch_command += " --config " +
                       command_support_.ShellQuote(PathString(request.registry_config_dir));
   }
-  launch_command += " run --rm --detach --name " +
+  launch_command += " run --rm --detach --privileged --name " +
                     command_support_.ShellQuote(helper_container_name) +
-                    " --user 0:0 --entrypoint " +
-                    command_support_.ShellQuote("/usr/bin/env");
+                    " --user 0:0";
+  if (!request.docker_socket_group_id.empty()) {
+    launch_command += " --group-add " +
+                      command_support_.ShellQuote(request.docker_socket_group_id);
+  }
+  launch_command += " --entrypoint " + command_support_.ShellQuote("/usr/bin/env");
   for (const std::string& mount : mounts) {
     launch_command += " -v " + command_support_.ShellQuote(mount);
   }

--- a/hostd/src/app/hostd_self_update_support_tests.cpp
+++ b/hostd/src/app/hostd_self_update_support_tests.cpp
@@ -34,6 +34,7 @@ int main() {
             "/opt/naim/hostd/install-state/registry-docker",
             "/opt/naim/hostd/install-state/hostd-self-update.sh",
             "/opt/naim/hostd/logs/hostd-self-update-release.log",
+            "112",
             true,
         });
 
@@ -55,8 +56,13 @@ int main() {
         !Contains(plan.launch_command, "nohup"),
         "launcher must not keep the updater inside the old hostd container");
     Expect(
-        Contains(plan.launch_command, " run --rm --detach --name 'naim-hostd-self-update-storage-1-release-abc-1234567890' "),
+        Contains(
+            plan.launch_command,
+            " run --rm --detach --privileged --name 'naim-hostd-self-update-storage-1-release-abc-1234567890' "),
         "launcher should start a detached helper container");
+    Expect(
+        Contains(plan.launch_command, "--privileged"),
+        "launcher should be privileged so Docker socket access works under host userns policies");
     Expect(
         Contains(plan.launch_command, "-v '/var/run/docker.sock:/var/run/docker.sock'"),
         "launcher should mount docker socket into helper");
@@ -69,6 +75,9 @@ int main() {
     Expect(
         Contains(plan.launch_command, "--user 0:0"),
         "launcher should run as root so it can access the mounted docker socket");
+    Expect(
+        Contains(plan.launch_command, "--group-add '112'"),
+        "launcher should include the docker socket group when it is known");
     Expect(
         Contains(plan.launch_command, "bash -lc 'bash '\"'\"'/opt/naim/hostd/install-state/hostd-self-update.sh'\"'\"' >>'\"'\"'/opt/naim/hostd/logs/hostd-self-update-release.log'\"'\"' 2>&1'"),
         "launcher should write helper script output to the hostd log path");
@@ -83,6 +92,7 @@ int main() {
             "/run/naim/registry",
             "/opt/naim/hostd/install-state/hostd-self-update.sh",
             "/opt/naim/hostd/logs/hostd-self-update-abc.log",
+            "",
             true,
         });
     Expect(


### PR DESCRIPTION
## Summary
- pass the host Docker socket group id into the detached self-update helper
- launch the helper with --privileged, --user 0:0, and --group-add <docker.sock gid>
- cover the generated launch command in the self-update support test

## Validation
- hpc1: cmake --build /tmp/naim-node-kv-fixes-build --target naim-hostd-self-update-support-tests naim-hostd -j 12
- hpc1: ./naim-hostd-self-update-support-tests
- hpc1 manual repro: docker helper can access /var/run/docker.sock only with --privileged --user 0:0 --group-add 

## Operational note
- PR #162 still failed hpc1 helper access because this host requires privileged socket access in addition to root/group. This patch matches the hostd service privilege model for the short-lived updater helper.