### PR TITLE
Stop hostd loop after scheduling self-update

### DIFF
--- a/hostd/src/state_apply/hostd_assignment_service.cpp
+++ b/hostd/src/state_apply/hostd_assignment_service.cpp
@@ -1,5 +1,6 @@
 #include "state_apply/hostd_assignment_service.h"
 
+#include <fstream>
 #include <iostream>
 #include <stdexcept>
 
@@ -9,6 +10,29 @@
 #include "state_apply/hostd_assignment_lock.h"
 
 namespace naim::hostd {
+
+namespace {
+
+std::filesystem::path SelfUpdateMarkerPath(
+    const std::string& state_root,
+    const std::string& node_name) {
+  return std::filesystem::path(state_root) / "control" /
+         ("hostd-self-update-scheduled-" + node_name);
+}
+
+void WriteSelfUpdateMarker(
+    const std::string& state_root,
+    const std::string& node_name,
+    int assignment_id) {
+  const auto marker_path = SelfUpdateMarkerPath(state_root, node_name);
+  std::filesystem::create_directories(marker_path.parent_path());
+  std::ofstream out(marker_path, std::ios::binary | std::ios::trunc);
+  if (out.is_open()) {
+    out << assignment_id << "\n";
+  }
+}
+
+}  // namespace
 
 HostdAssignmentService::HostdAssignmentService(
     const IHostdBackendFactory& backend_factory,
@@ -296,6 +320,7 @@ void HostdAssignmentService::ApplyNextAssignment(
           assignment->id,
           std::nullopt,
           "info");
+      WriteSelfUpdateMarker(state_root, node_name, assignment->id);
       return;
     }
 

--- a/launcher/src/run/launcher_run_service.cpp
+++ b/launcher/src/run/launcher_run_service.cpp
@@ -99,6 +99,12 @@ void StopChildProcess(pid_t pid) {
 }
 #endif
 
+std::filesystem::path HostdSelfUpdateMarkerPath(
+    const std::filesystem::path& state_root,
+    const std::string& node_name) {
+  return state_root / "control" / ("hostd-self-update-scheduled-" + node_name);
+}
+
 bool IsPrivateIpv4Address(const std::string& candidate) {
   if (!IsIpv4Address(candidate)) {
     return false;
@@ -420,6 +426,10 @@ int LauncherRunService::RunHostdLoop(
   std::cout
       << "next_step=leave hostd running so it can receive assignments and upload telemetry\n";
   auto next_inventory_report_at = std::chrono::steady_clock::now();
+  const auto self_update_marker =
+      HostdSelfUpdateMarkerPath(options.state_root, options.node_name);
+  std::error_code marker_error;
+  std::filesystem::remove(self_update_marker, marker_error);
   HostdPeerService peer_service(options);
   peer_service.Start();
   if (peer_service.enabled()) {
@@ -497,18 +507,24 @@ int LauncherRunService::RunHostdLoop(
 
 #if !defined(_WIN32)
   pid_t apply_pid = -1;
-  const auto reap_apply_if_finished = [&]() {
+  const auto reap_apply_if_finished = [&]() -> bool {
     if (apply_pid <= 0) {
-      return;
+      return false;
     }
     const std::optional<int> apply_code = PollChildExitCode(apply_pid);
     if (!apply_code.has_value()) {
-      return;
+      return false;
     }
     if (*apply_code != 0) {
       std::cerr << "naim-node: hostd apply-next-assignment exit=" << *apply_code << "\n";
     }
     apply_pid = -1;
+    if (std::filesystem::exists(self_update_marker)) {
+      std::filesystem::remove(self_update_marker, marker_error);
+      std::cout << "hostd_self_update_scheduled=stopping\n";
+      return true;
+    }
+    return false;
   };
 #endif
 
@@ -518,8 +534,17 @@ int LauncherRunService::RunHostdLoop(
     if (apply_code != 0) {
       std::cerr << "naim-node: hostd apply-next-assignment exit=" << apply_code << "\n";
     }
+    if (std::filesystem::exists(self_update_marker)) {
+      std::filesystem::remove(self_update_marker, marker_error);
+      std::cout << "hostd_self_update_scheduled=stopping\n";
+      peer_service.Stop();
+      return 0;
+    }
 #else
-    reap_apply_if_finished();
+    if (reap_apply_if_finished()) {
+      peer_service.Stop();
+      return 0;
+    }
     if (apply_pid <= 0) {
       apply_pid = static_cast<pid_t>(process_runner_.SpawnCommand(build_apply_args()));
     }
@@ -532,7 +557,10 @@ int LauncherRunService::RunHostdLoop(
          ++second) {
       std::this_thread::sleep_for(std::chrono::seconds(1));
 #if !defined(_WIN32)
-      reap_apply_if_finished();
+      if (reap_apply_if_finished()) {
+        peer_service.Stop();
+        return 0;
+      }
 #endif
       run_report_if_due();
     }


### PR DESCRIPTION
## Summary
- write a hostd self-update marker after scheduling the detached updater helper
- make the naim-node hostd supervisor stop when that marker appears after apply-next-assignment exits
- clear stale self-update markers when hostd starts, so one-shot apply commands do not poison future runs

## Why
The old hostd can otherwise claim the next assignment during the updater helper's short delay before Docker recreates naim-hostd. In production this left a knowledge-vault-apply assignment in claimed state while the new hostd saw no pending assignments.

## Validation
- hpc1: cmake --build /tmp/naim-node-kv-fixes-build --target naim-hostd-self-update-support-tests naim-hostd naim-node -j 12
- hpc1: ./naim-hostd-self-update-support-tests