### PR TITLE
Fix single-node model library target selection

### DIFF
--- a/controller/src/model/model_library_service.cpp
+++ b/controller/src/model/model_library_service.cpp
@@ -343,7 +343,7 @@ HttpResponse ModelLibraryService::EnqueueDownload(
     const HttpRequest& request) const {
   const json body = support_.parse_json_request_body(request);
   std::string target_root = body.value("target_root", std::string{});
-  const std::string target_node_name = body.value("target_node_name", std::string{});
+  std::string target_node_name = body.value("target_node_name", std::string{});
   const std::string target_subdir = body.value("target_subdir", std::string{});
   const std::string model_id = body.value("model_id", std::string{});
   const std::string source_url = body.value("source_url", std::string{});
@@ -371,10 +371,13 @@ HttpResponse ModelLibraryService::EnqueueDownload(
   const std::string desired_output_format = NormalizeModelOutputFormat(requested_output_format);
   const std::vector<std::string> quantizations;
   const bool keep_base_gguf = true;
+  const bool requires_controller_local_conversion =
+      detected_source_format == "safetensors" && desired_output_format == "gguf";
   naim::ControllerStore store(db_path);
   store.Initialize();
-  if (!target_node_name.empty()) {
-    const auto host = store.LoadRegisteredHost(target_node_name);
+  auto apply_target_node =
+      [&](const std::string& node_name) -> std::optional<HttpResponse> {
+    const auto host = store.LoadRegisteredHost(node_name);
     if (!host.has_value()) {
       return support_.build_json_response(
           404,
@@ -407,6 +410,7 @@ HttpResponse ModelLibraryService::EnqueueDownload(
                {"message", "target_node_name does not advertise a usable storage_root"}},
           {});
     }
+    target_node_name = summary.node_name;
     target_root = summary.storage_root;
     std::uintmax_t required_bytes = 0;
     bool have_required_bytes = !source_urls.empty();
@@ -427,6 +431,66 @@ HttpResponse ModelLibraryService::EnqueueDownload(
                {"required_bytes", required_bytes},
                {"available_bytes", summary.storage_free_bytes}},
           {});
+    }
+    return std::nullopt;
+  };
+  if (!target_node_name.empty()) {
+    if (auto error_response = apply_target_node(target_node_name)) {
+      return *error_response;
+    }
+  } else if (!requires_controller_local_conversion) {
+    std::vector<ModelLibraryNodeSummary> eligible_nodes;
+    for (const auto& host : store.LoadRegisteredHosts()) {
+      const auto summary = ModelLibraryNodePlacement::BuildSummary(host);
+      if (summary.registration_state != "registered" ||
+          summary.session_state != "connected") {
+        continue;
+      }
+      if (!ModelLibraryNodePlacement::AllowsModelPlacementRole(
+              summary.derived_role,
+              summary.storage_role_enabled,
+              false)) {
+        continue;
+      }
+      if (summary.storage_root.empty() ||
+          !IsUsableAbsoluteHostPath(summary.storage_root)) {
+        continue;
+      }
+      eligible_nodes.push_back(summary);
+    }
+    if (target_root.empty()) {
+      if (eligible_nodes.size() == 1) {
+        if (auto error_response = apply_target_node(eligible_nodes.front().node_name)) {
+          return *error_response;
+        }
+      } else if (eligible_nodes.size() > 1) {
+        return support_.build_json_response(
+            409,
+            json{{"status", "conflict"},
+                 {"message", "target_node_name is required when multiple storage-capable nodes are available"}},
+            {});
+      }
+    } else if (IsUsableAbsoluteHostPath(target_root)) {
+      std::vector<ModelLibraryNodeSummary> matching_nodes;
+      const auto normalized_target_root =
+          NormalizePathString(std::filesystem::path(target_root));
+      for (const auto& summary : eligible_nodes) {
+        if (NormalizePathString(std::filesystem::path(summary.storage_root)) ==
+            normalized_target_root) {
+          matching_nodes.push_back(summary);
+        }
+      }
+      if (matching_nodes.size() == 1) {
+        if (auto error_response = apply_target_node(matching_nodes.front().node_name)) {
+          return *error_response;
+        }
+      } else if (matching_nodes.size() > 1) {
+        return support_.build_json_response(
+            409,
+            json{{"status", "conflict"},
+                 {"message", "target_node_name is required because target_root matches multiple nodes"}},
+            {});
+      }
     }
   }
   if (target_root.empty() || !IsUsableAbsoluteHostPath(target_root)) {

--- a/controller/src/model/model_library_service_tests.cpp
+++ b/controller/src/model/model_library_service_tests.cpp
@@ -328,9 +328,88 @@ int main() {
 	            item.at("size_bytes").get<std::uintmax_t>() == source_payload_size;
 	      }
 	    }
-	    Expect(
-	        found_remote_storage_item,
-	        "completed storage-node downloads should remain visible without controller-local files");
+    Expect(
+        found_remote_storage_item,
+        "completed storage-node downloads should remain visible without controller-local files");
+
+    const auto implicit_storage_root_response = service.EnqueueDownload(
+        db_path.string(),
+        JsonRequest(
+            "POST",
+            "/api/v1/model-library/download",
+            nlohmann::json{
+                {"model_id", "model-implicit-storage-root"},
+                {"target_root", storage_root.string()},
+                {"target_subdir", "implicit-storage-root"},
+                {"source_urls", nlohmann::json::array({FileUrlForPath(source_path)})},
+                {"format", "gguf"},
+            }));
+    Expect(
+        implicit_storage_root_response.status_code == 202,
+        "download with a target_root matching one storage node should be accepted");
+    const auto implicit_storage_root_job_id =
+        nlohmann::json::parse(implicit_storage_root_response.body)
+            .at("job")
+            .at("id")
+            .get<std::string>();
+    const auto implicit_storage_root_job =
+        store.LoadModelLibraryDownloadJob(implicit_storage_root_job_id);
+    Expect(
+        implicit_storage_root_job.has_value() &&
+            implicit_storage_root_job->node_name == "storage-node-a",
+        "matching storage_root should resolve to the storage node assignment target");
+
+    const auto ambiguous_storage_response = service.EnqueueDownload(
+        db_path.string(),
+        JsonRequest(
+            "POST",
+            "/api/v1/model-library/download",
+            nlohmann::json{
+                {"model_id", "model-ambiguous-storage"},
+                {"source_urls", nlohmann::json::array({FileUrlForPath(source_path)})},
+                {"format", "gguf"},
+            }));
+    Expect(
+        ambiguous_storage_response.status_code == 409,
+        "download without an explicit target should reject multiple storage-capable nodes");
+
+    const fs::path single_db_path = temp_root / "single-controller.sqlite";
+    const fs::path single_storage_root = temp_root / "single-storage";
+    fs::create_directories(single_storage_root);
+    naim::ControllerStore single_store(single_db_path.string());
+    single_store.Initialize();
+    UpsertHost(
+        single_store,
+        "local-hostd",
+        "worker",
+        single_storage_root,
+        500ULL * 1024ULL * 1024ULL * 1024ULL);
+    const auto implicit_single_node_response = service.EnqueueDownload(
+        single_db_path.string(),
+        JsonRequest(
+            "POST",
+            "/api/v1/model-library/download",
+            nlohmann::json{
+                {"model_id", "model-single-node-default"},
+                {"target_subdir", "single-node-default"},
+                {"source_urls", nlohmann::json::array({FileUrlForPath(source_path)})},
+                {"format", "gguf"},
+            }));
+    Expect(
+        implicit_single_node_response.status_code == 202,
+        "single-node download should default to the only storage-capable node");
+    const auto implicit_single_node_job_id =
+        nlohmann::json::parse(implicit_single_node_response.body)
+            .at("job")
+            .at("id")
+            .get<std::string>();
+    const auto implicit_single_node_job =
+        single_store.LoadModelLibraryDownloadJob(implicit_single_node_job_id);
+    Expect(
+        implicit_single_node_job.has_value() &&
+            implicit_single_node_job->node_name == "local-hostd" &&
+            implicit_single_node_job->status == "queued",
+        "single-node default download should be queued for local-hostd");
 
     const fs::path storage_safetensors_source = src_root / "storage-model.safetensors";
     const fs::path storage_chat_template = src_root / "chat_template.jinja";

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -22,6 +22,8 @@ import {
 import { formatPlaneDashboardSkillsSummary } from "./planeSkills.js";
 import {
   detectModelSourceFormat,
+  defaultModelDownloadTarget,
+  eligibleModelStorageNodes,
   MODEL_LIBRARY_FORMAT_OPTIONS,
   MODEL_LIBRARY_GGUF_QUANTIZATIONS,
   MODEL_LIBRARY_QUANTIZATION_FILTERS,
@@ -2028,6 +2030,7 @@ function App() {
     sourceUrls: "",
     format: "unknown",
     formatLocked: false,
+    targetSelectionTouched: false,
   });
   const [quantizationSearch, setQuantizationSearch] = useState("");
   const [quantizationFilter, setQuantizationFilter] = useState("all");
@@ -3865,13 +3868,7 @@ function App() {
   const visibleModelItems = (modelLibrary.items || []).slice(0, visibleModelCount);
   const hasMoreModelItems = activeModelCount > visibleModelCount;
   const modelLibraryNodes = Array.isArray(modelLibrary.nodes) ? modelLibrary.nodes : [];
-  const storageModelNodes = modelLibraryNodes.filter(
-    (node) =>
-      node?.role_eligible === true &&
-      node?.registration_state === "registered" &&
-      node?.session_state === "connected" &&
-      node?.storage_root,
-  );
+  const storageModelNodes = eligibleModelStorageNodes(modelLibraryNodes);
   const modelLibraryJobs = Array.isArray(modelLibrary.jobs) ? modelLibrary.jobs : [];
   const downloadModelJobs = modelLibraryJobs.filter(
     (job) => normalizeModelLibraryJobKind(job?.job_kind) === "download",
@@ -6222,7 +6219,11 @@ function App() {
           type="text"
           value={modelDownloadForm.targetRoot}
           onChange={(event) =>
-            setModelDownloadForm((current) => ({ ...current, targetRoot: event.target.value }))
+            setModelDownloadForm((current) => ({
+              ...current,
+              targetRoot: event.target.value,
+              targetSelectionTouched: true,
+            }))
           }
           placeholder="/abs/path/to/model/library"
           disabled={Boolean(modelDownloadForm.targetNodeName)}
@@ -6240,6 +6241,7 @@ function App() {
               ...current,
               targetNodeName: event.target.value,
               targetRoot: event.target.value ? "" : current.targetRoot,
+              targetSelectionTouched: true,
             }))
           }
         >
@@ -7355,14 +7357,28 @@ function App() {
   }, [desiredState, interactionStatus]);
 
   useEffect(() => {
-    if (modelDownloadForm.targetRoot || !Array.isArray(modelLibrary.roots) || modelLibrary.roots.length === 0) {
+    if (
+      modelDownloadForm.targetRoot ||
+      modelDownloadForm.targetNodeName ||
+      modelDownloadForm.targetSelectionTouched
+    ) {
+      return;
+    }
+    const nextDefault = defaultModelDownloadTarget(modelLibrary);
+    if (!nextDefault) {
       return;
     }
     setModelDownloadForm((current) => ({
       ...current,
-      targetRoot: modelLibrary.roots[0],
+      targetRoot: nextDefault.targetRoot,
+      targetNodeName: nextDefault.targetNodeName,
     }));
-  }, [modelDownloadForm.targetRoot, modelLibrary.roots]);
+  }, [
+    modelDownloadForm.targetNodeName,
+    modelDownloadForm.targetRoot,
+    modelDownloadForm.targetSelectionTouched,
+    modelLibrary,
+  ]);
 
   useEffect(() => {
     const detectedSourceFormat = detectModelSourceFormat(modelDownloadForm.sourceUrls);

--- a/ui/operator-react/src/modelLibrary.js
+++ b/ui/operator-react/src/modelLibrary.js
@@ -74,6 +74,37 @@ export function shouldShowGgufConversionOptions(detectedSourceFormat, desiredFor
   );
 }
 
+export function eligibleModelStorageNodes(nodes) {
+  if (!Array.isArray(nodes)) {
+    return [];
+  }
+  return nodes.filter(
+    (node) =>
+      node?.role_eligible === true &&
+      node?.registration_state === "registered" &&
+      node?.session_state === "connected" &&
+      node?.node_name &&
+      node?.storage_root,
+  );
+}
+
+export function defaultModelDownloadTarget(modelLibrary) {
+  const storageNodes = eligibleModelStorageNodes(modelLibrary?.nodes);
+  if (storageNodes.length === 1) {
+    return {
+      targetNodeName: String(storageNodes[0].node_name || ""),
+      targetRoot: "",
+    };
+  }
+  if (Array.isArray(modelLibrary?.roots) && modelLibrary.roots.length > 0) {
+    return {
+      targetNodeName: "",
+      targetRoot: String(modelLibrary.roots[0] || ""),
+    };
+  }
+  return null;
+}
+
 export function modelLibraryJobProgress(job) {
   const bytesDone = Number(job?.bytes_done ?? 0);
   const bytesTotal = Number(job?.bytes_total ?? NaN);

--- a/ui/operator-react/src/modelLibrary.test.js
+++ b/ui/operator-react/src/modelLibrary.test.js
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  defaultModelDownloadTarget,
   detectModelSourceFormat,
+  eligibleModelStorageNodes,
   modelLibraryJobProgress,
   normalizeModelDownloadSourceUrls,
   shouldShowGgufConversionOptions,
@@ -41,6 +43,47 @@ describe("model library uploader helpers", () => {
     expect(shouldShowGgufConversionOptions("safetensors", "gguf")).toBe(true);
     expect(shouldShowGgufConversionOptions("gguf", "gguf")).toBe(false);
     expect(shouldShowGgufConversionOptions("safetensors", "safetensors")).toBe(false);
+  });
+
+  it("selects the only connected storage-capable node as the default target", () => {
+    expect(
+      defaultModelDownloadTarget({
+        roots: ["/models"],
+        nodes: [
+          {
+            node_name: "local-hostd",
+            role_eligible: true,
+            registration_state: "registered",
+            session_state: "connected",
+            storage_root: "/srv/naim",
+          },
+        ],
+      }),
+    ).toEqual({ targetNodeName: "local-hostd", targetRoot: "" });
+  });
+
+  it("falls back to a manual root when storage node selection is ambiguous", () => {
+    const nodes = [
+      {
+        node_name: "node-a",
+        role_eligible: true,
+        registration_state: "registered",
+        session_state: "connected",
+        storage_root: "/srv/a",
+      },
+      {
+        node_name: "node-b",
+        role_eligible: true,
+        registration_state: "registered",
+        session_state: "connected",
+        storage_root: "/srv/b",
+      },
+    ];
+    expect(eligibleModelStorageNodes(nodes)).toHaveLength(2);
+    expect(defaultModelDownloadTarget({ roots: ["/models"], nodes })).toEqual({
+      targetNodeName: "",
+      targetRoot: "/models",
+    });
   });
 
   it("calculates progress for acquiring model download jobs", () => {


### PR DESCRIPTION
## Summary
- resolve implicit model-library download targets to the single connected storage-capable node
- auto-select the only eligible storage node in the operator UI
- add controller and UI regression coverage for single-node and ambiguous-node flows

## Tests
- cmake --build /home/baal/.cache/naim/wsl-build-mirror/naim-node-dc8357c491bb617e/build/linux/x64 --target naim-model-library-tests
- /home/baal/.cache/naim/wsl-build-mirror/naim-node-dc8357c491bb617e/build/linux/x64/naim-model-library-tests
- cd ui/operator-react && npm test
- cd ui/operator-react && npm run build