### PR TITLE
Add PR gate and release rollback automation

### DIFF
--- a/.github/workflows/naim-pr-ci.yml
+++ b/.github/workflows/naim-pr-ci.yml
@@ -1,0 +1,281 @@
+name: NAIM PR Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: naim-pr-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NAIM_RELEASE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  NAIM_RELEASE_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+  NAIM_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+  NAIM_HPC1_SSH: ${{ vars.NAIM_HPC1_SSH || 'baal@195.168.22.186' }}
+  NAIM_HPC1_SSH_PORT: ${{ vars.NAIM_HPC1_SSH_PORT || '2222' }}
+  NAIM_HPC1_REPO_PATH: ${{ vars.NAIM_HPC1_REPO_PATH || '/mnt/shared-storage/naim/repos/naim-node' }}
+  NAIM_HPC1_PR_REPO_ROOT: ${{ vars.NAIM_HPC1_PR_REPO_ROOT || '/tmp/naim-pr-gate/naim-node' }}
+  NAIM_BUILD_TYPE: ${{ vars.NAIM_BUILD_TYPE || 'Release' }}
+  NAIM_CUDA_ARCHITECTURES: ${{ vars.NAIM_CUDA_ARCHITECTURES || '' }}
+  NAIM_CUDA_NVCC_JOBS: ${{ vars.NAIM_CUDA_NVCC_JOBS || '1' }}
+  NAIM_CMAKE_ARGS: ${{ vars.NAIM_CMAKE_ARGS || '' }}
+
+jobs:
+  hpc1-checkout:
+    name: hpc1 checkout
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      pr_repo_path: ${{ steps.checkout.outputs.pr_repo_path }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
+      - id: checkout
+        name: Checkout PR head on hpc1
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.run_id }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${NAIM_CI_SSH_KEY:-}" || ! -s "${NAIM_CI_SSH_KEY}" ]]; then
+            echo "NAIM_DEPLOY_SSH_KEY is required for privileged PR gate jobs" >&2
+            exit 1
+          fi
+          if [[ "${PR_HEAD_REPO}" != "${REPOSITORY}" ]]; then
+            echo "Fork PRs cannot run privileged hpc1 gate jobs; push a same-repository branch." >&2
+            exit 1
+          fi
+          pr_repo_path="${NAIM_HPC1_PR_REPO_ROOT}/pr-${PR_NUMBER}"
+          echo "pr_repo_path=${pr_repo_path}" >> "${GITHUB_OUTPUT}"
+          ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
+            "NAIM_HPC1_REPO_PATH='${NAIM_HPC1_REPO_PATH}' PR_REPO_PATH='${pr_repo_path}' PR_HEAD_REF='${PR_HEAD_REF}' NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' bash -s" <<'REMOTE'
+          set -euo pipefail
+          mkdir -p "$(dirname -- "${PR_REPO_PATH}")"
+          origin_url="$(git -C "${NAIM_HPC1_REPO_PATH}" config --get remote.origin.url)"
+          if [[ ! -d "${PR_REPO_PATH}/.git" ]]; then
+            git clone --no-checkout "${origin_url}" "${PR_REPO_PATH}"
+          fi
+          cd "${PR_REPO_PATH}"
+          git config --global --add safe.directory "${PR_REPO_PATH}" >/dev/null 2>&1 || true
+          git fetch --prune origin "+refs/heads/${PR_HEAD_REF}:refs/remotes/origin/${PR_HEAD_REF}"
+          git checkout -f --detach "${NAIM_RELEASE_SHA}"
+          git clean -fdx -e build -e build-turboquant -e var
+          current_sha="$(git rev-parse HEAD)"
+          if [[ "${current_sha}" != "${NAIM_RELEASE_SHA}" ]]; then
+            echo "error: PR workspace is at ${current_sha}, expected ${NAIM_RELEASE_SHA}" >&2
+            exit 1
+          fi
+          echo "hpc1 PR workspace is at ${current_sha}"
+          REMOTE
+
+  detect-release-scope:
+    name: detect release scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: hpc1-checkout
+    outputs:
+      turboquant_required: ${{ steps.scope.outputs.turboquant_required }}
+      turboquant_reason: ${{ steps.scope.outputs.turboquant_reason }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.NAIM_RELEASE_SHA }}
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
+      - id: scope
+        name: Detect TurboQuant-sensitive changes
+        shell: bash
+        env:
+          GITHUB_EVENT_NAME: pull_request
+          NAIM_RELEASE_BEFORE: ${{ env.NAIM_BASE_SHA }}
+        run: |
+          set -euo pipefail
+          bash scripts/ci/detect-release-scope.sh
+
+  hpc1-build:
+    name: hpc1 build
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    needs:
+      - hpc1-checkout
+      - detect-release-scope
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
+      - name: Build on hpc1 PR workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo_q="$(printf '%q' "${{ needs.hpc1-checkout.outputs.pr_repo_path }}")"
+          ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
+            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build.sh"
+
+  ui-checks:
+    name: operator UI checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.NAIM_RELEASE_SHA }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: ui/operator-react/package-lock.json
+      - name: Test and build operator UI
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd ui/operator-react
+          npm ci
+          npm test
+          npm run build
+
+  hpc1-knowledge-vault-release-gate:
+    name: hpc1 Knowledge Vault release gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+      - hpc1-checkout
+      - hpc1-build
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
+      - name: Run Knowledge Vault release gate on hpc1
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo_q="$(printf '%q' "${{ needs.hpc1-checkout.outputs.pr_repo_path }}")"
+          ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
+            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' bash scripts/ci/knowledge-vault-release-gate.sh"
+
+  hpc1-build-turboquant:
+    name: hpc1 TurboQuant build
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    needs:
+      - hpc1-checkout
+      - hpc1-build
+      - detect-release-scope
+    if: needs.detect-release-scope.outputs.turboquant_required == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
+      - name: Build TurboQuant runtime on hpc1
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo_q="$(printf '%q' "${{ needs.hpc1-checkout.outputs.pr_repo_path }}")"
+          ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
+            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build-turboquant.sh"
+
+  summary:
+    name: summary
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: always()
+    needs:
+      - hpc1-checkout
+      - detect-release-scope
+      - hpc1-build
+      - ui-checks
+      - hpc1-knowledge-vault-release-gate
+      - hpc1-build-turboquant
+    steps:
+      - name: Write PR gate report
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          report_path="${RUNNER_TEMP}/naim-pr-gate-report.md"
+          python3 - "${report_path}" <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          report_path = sys.argv[1]
+          required_success = {
+              "hpc1-checkout",
+              "detect-release-scope",
+              "hpc1-build",
+              "ui-checks",
+              "hpc1-knowledge-vault-release-gate",
+          }
+          allowed_skipped = {"hpc1-build-turboquant"}
+          failures = []
+          lines = [
+              "## NAIM PR Gate",
+              "",
+              f"- run: {os.environ.get('RUN_URL', '')}",
+              "",
+              "| Stage | Result |",
+              "| --- | --- |",
+          ]
+          for name, payload in needs.items():
+              result = payload.get("result", "unknown")
+              lines.append(f"| `{name}` | `{result}` |")
+              if name in required_success and result != "success":
+                  failures.append((name, result))
+              elif name not in allowed_skipped and result not in {"success", "skipped"}:
+                  failures.append((name, result))
+          turbo = needs.get("detect-release-scope", {}).get("outputs", {})
+          if turbo:
+              lines.extend([
+                  "",
+                  "### Release Scope",
+                  f"- TurboQuant required: `{turbo.get('turboquant_required', 'unknown')}`",
+                  f"- Reason: `{turbo.get('turboquant_reason', 'unknown')}`",
+              ])
+          if failures:
+              lines.extend(["", "### Failed Stages"])
+              for name, result in failures:
+                  lines.append(f"- `{name}` ended with `{result}`")
+          else:
+              lines.extend(["", "All required PR gate stages passed."])
+          with open(report_path, "w", encoding="utf-8") as handle:
+              handle.write("\n".join(lines) + "\n")
+          print("failed=" + ("true" if failures else "false"))
+          PY
+          cat "${report_path}" >> "${GITHUB_STEP_SUMMARY}"
+          failed="$(python3 - "${report_path}" <<'PY'
+          import sys
+          text = open(sys.argv[1], encoding="utf-8").read()
+          print("true" if "### Failed Stages" in text else "false")
+          PY
+          )"
+          if [[ "${failed}" == "true" && -n "${PR_NUMBER}" ]]; then
+            gh pr comment "${PR_NUMBER}" --body-file "${report_path}" || true
+          fi
+          [[ "${failed}" != "true" ]]

--- a/.github/workflows/naim-production-release.yml
+++ b/.github/workflows/naim-production-release.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: naim-production-main
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -258,10 +258,13 @@ jobs:
     name: 4. main register Harbor release
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: hpc1-build-push-harbor
+    needs:
+      - hpc1-build-push-harbor
+      - main-capture-release-state
     if: >-
       always() &&
-      needs.hpc1-build-push-harbor.result == 'success'
+      needs.hpc1-build-push-harbor.result == 'success' &&
+      needs.main-capture-release-state.result == 'success'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
@@ -285,6 +288,35 @@ jobs:
           bash scripts/ci/register-release-on-main.sh \
             --manifest "${RUNNER_TEMP}/release-manifest.json" \
             --tag "${NAIM_RELEASE_TAG}"
+
+  main-capture-release-state:
+    name: 3a. main capture rollback snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: hpc1-build-push-harbor
+    if: >-
+      always() &&
+      needs.hpc1-build-push-harbor.result == 'success'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
+      - name: Capture main rollback snapshot
+        shell: bash
+        run: |
+          set -euo pipefail
+          export NAIM_SSH_OPTS="${NAIM_CI_SSH_OPTS}"
+          export NAIM_MAIN_SSH
+          export NAIM_RELEASE_TAG
+          bash scripts/ci/capture-main-release-state.sh \
+            --tag "${NAIM_RELEASE_TAG}" \
+            --output "${RUNNER_TEMP}/main-release-snapshot.json"
+      - uses: actions/upload-artifact@v6
+        with:
+          name: main-release-snapshot
+          path: ${{ runner.temp }}/main-release-snapshot.json
+          if-no-files-found: error
 
   main-bootstrap-controller-update:
     name: 5. main bootstrap controller update
@@ -356,3 +388,122 @@ jobs:
             --manifest "${RUNNER_TEMP}/release-manifest.json" \
             --output "${RUNNER_TEMP}/migration-report.md"
           cat "${RUNNER_TEMP}/migration-report.md" >> "${GITHUB_STEP_SUMMARY}"
+
+  release-report-and-rollback:
+    name: 7. release report and rollback
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    needs:
+      - hpc1-pull
+      - detect-release-scope
+      - hpc1-build
+      - hpc1-build-turboquant
+      - hpc1-knowledge-vault-release-gate
+      - hpc1-build-push-harbor
+      - main-capture-release-state
+      - main-register-release
+      - main-bootstrap-controller-update
+      - migration-report
+    if: always()
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
+      - name: Download rollback snapshot
+        if: needs.main-capture-release-state.result == 'success'
+        uses: actions/download-artifact@v6
+        with:
+          name: main-release-snapshot
+          path: ${{ runner.temp }}
+      - name: Write release report and rollback on failure
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+          NAIM_REGISTRY_PASSWORD: ${{ secrets.NAIM_REGISTRY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          report_path="${RUNNER_TEMP}/release-final-report.md"
+          snapshot_path="${RUNNER_TEMP}/main-release-snapshot.json"
+          export NAIM_SSH_OPTS="${NAIM_CI_SSH_OPTS}"
+          export NAIM_MAIN_SSH
+          export NAIM_HPC1_SSH
+          export NAIM_HPC1_SSH_PORT
+          export NAIM_REGISTRY
+          export NAIM_REGISTRY_PROJECT
+          export NAIM_REGISTRY_USERNAME
+          export NAIM_RELEASE_TAG
+          export NAIM_MIGRATION_TIMEOUT_SEC
+          password_file=""
+          if [[ -n "${NAIM_REGISTRY_PASSWORD}" ]]; then
+            password_file="${RUNNER_TEMP}/registry-password-rollback"
+            printf '%s' "${NAIM_REGISTRY_PASSWORD}" > "${password_file}"
+            chmod 0600 "${password_file}"
+            export NAIM_REGISTRY_PASSWORD_FILE="${password_file}"
+          fi
+          python3 - "${report_path}" <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          report_path = sys.argv[1]
+          failed = []
+          lines = [
+              "## NAIM production release final report",
+              "",
+              f"- release tag: `{os.environ.get('NAIM_RELEASE_TAG', '')}`",
+              "",
+              "| Stage | Result |",
+              "| --- | --- |",
+          ]
+          for name, payload in needs.items():
+              result = payload.get("result", "unknown")
+              lines.append(f"| `{name}` | `{result}` |")
+              if name == "hpc1-build-turboquant" and result == "skipped":
+                  continue
+              if result not in {"success", "skipped"}:
+                  failed.append((name, result))
+          if failed:
+              lines.extend(["", "### Failed Stages"])
+              for name, result in failed:
+                  lines.append(f"- `{name}` ended with `{result}`")
+          else:
+              lines.extend(["", "All release stages passed. Rollback was not required."])
+          with open(report_path, "w", encoding="utf-8") as handle:
+              handle.write("\n".join(lines) + "\n")
+          print("failed=" + ("true" if failed else "false"))
+          PY
+          cat "${report_path}" >> "${GITHUB_STEP_SUMMARY}"
+          failed="$(python3 - "${report_path}" <<'PY'
+          import sys
+          text = open(sys.argv[1], encoding="utf-8").read()
+          print("true" if "### Failed Stages" in text else "false")
+          PY
+          )"
+          deploy_attempted="$(python3 - <<'PY'
+          import json
+          import os
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          result = needs.get("main-register-release", {}).get("result", "skipped")
+          print("true" if result != "skipped" else "false")
+          PY
+          )"
+          if [[ "${failed}" == "true" && "${deploy_attempted}" == "true" && -f "${snapshot_path}" ]]; then
+            rollback_report="${RUNNER_TEMP}/rollback-report.md"
+            if bash scripts/ci/rollback-main-release.sh \
+                --snapshot "${snapshot_path}" \
+                --failed-tag "${NAIM_RELEASE_TAG}" \
+                --output "${rollback_report}"; then
+              cat "${rollback_report}" >> "${GITHUB_STEP_SUMMARY}"
+            else
+              rollback_status=$?
+              cat "${rollback_report}" >> "${GITHUB_STEP_SUMMARY}" 2>/dev/null || true
+              echo "rollback command exited with ${rollback_status}" >> "${GITHUB_STEP_SUMMARY}"
+              exit "${rollback_status}"
+            fi
+          elif [[ "${failed}" == "true" && "${deploy_attempted}" == "true" ]]; then
+            echo "rollback skipped: deploy was attempted but rollback snapshot is unavailable" >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi
+          [[ "${failed}" != "true" ]]

--- a/scripts/ci/capture-main-release-state.sh
+++ b/scripts/ci/capture-main-release-state.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+source "${repo_root}/scripts/deploy/naim-production-env.sh"
+
+release_tag="${NAIM_RELEASE_TAG:-${NAIM_IMAGE_TAG:-}}"
+output_path=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  capture-main-release-state.sh --tag <tag> --output <path>
+
+Captures the production state needed to roll back a post-merge release.
+The snapshot metadata is written locally; heavy backups remain on main.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      release_tag="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output_path="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${release_tag}" || -z "${output_path}" ]]; then
+  echo "error: --tag and --output are required" >&2
+  usage >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname -- "${output_path}")"
+
+snapshot_text="$(
+  remote_main_bash \
+    "${NAIM_MAIN_ROOT}" \
+    "${release_tag}" \
+    "${NAIM_MAIN_CONTROLLER_LOCAL_PORT}" \
+    "${NAIM_MAIN_WEB_UI_LOCAL_PORT}" <<'REMOTE'
+set -euo pipefail
+
+main_root="$1"
+release_tag="$2"
+controller_port="$3"
+web_ui_port="$4"
+release_dir="${main_root}/releases"
+backup_root="${main_root}/release-rollbacks/${release_tag}"
+compose_path="${main_root}/docker-compose.yml"
+db_path="${main_root}/state/controller.sqlite"
+
+install -d -m 0750 "${backup_root}"
+
+previous_tag=""
+if [[ -f "${release_dir}/current-tag" ]]; then
+  previous_tag="$(cat "${release_dir}/current-tag")"
+fi
+
+previous_manifest_path=""
+if [[ -n "${previous_tag}" && -f "${release_dir}/${previous_tag}.json" ]]; then
+  previous_manifest_path="${release_dir}/${previous_tag}.json"
+  cp "${previous_manifest_path}" "${backup_root}/previous-release-manifest.json"
+fi
+
+compose_backup_path=""
+if [[ -f "${compose_path}" ]]; then
+  compose_backup_path="${backup_root}/docker-compose.before.yml"
+  cp "${compose_path}" "${compose_backup_path}"
+fi
+
+db_backup_path=""
+if [[ -f "${db_path}" ]]; then
+  db_backup_path="${backup_root}/controller.sqlite.before"
+  if command -v sqlite3 >/dev/null 2>&1; then
+    sqlite3 "${db_path}" ".backup '${db_backup_path}'"
+  else
+    cp "${db_path}" "${db_backup_path}"
+    for suffix in -wal -shm; do
+      if [[ -f "${db_path}${suffix}" ]]; then
+        cp "${db_path}${suffix}" "${db_backup_path}${suffix}"
+      fi
+    done
+  fi
+fi
+
+docker_state_path="${backup_root}/docker-ps.before.txt"
+if command -v docker >/dev/null 2>&1; then
+  docker ps --format '{{.Names}}|{{.Image}}|{{.Status}}' > "${docker_state_path}" || true
+fi
+
+python3 - \
+  "${main_root}" \
+  "${release_tag}" \
+  "${backup_root}" \
+  "${previous_tag}" \
+  "${previous_manifest_path}" \
+  "${compose_backup_path}" \
+  "${db_backup_path}" \
+  "${docker_state_path}" \
+  "${controller_port}" \
+  "${web_ui_port}" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+
+(
+    main_root,
+    release_tag,
+    backup_root,
+    previous_tag,
+    previous_manifest_path,
+    compose_backup_path,
+    db_backup_path,
+    docker_state_path,
+    controller_port,
+    web_ui_port,
+) = sys.argv[1:11]
+
+print(json.dumps({
+    "captured_at": datetime.now(timezone.utc).isoformat(),
+    "main_root": main_root,
+    "release_tag": release_tag,
+    "backup_root": backup_root,
+    "previous_tag": previous_tag,
+    "previous_manifest_path": previous_manifest_path,
+    "compose_backup_path": compose_backup_path,
+    "db_backup_path": db_backup_path,
+    "docker_state_path": docker_state_path,
+    "controller_port": controller_port,
+    "web_ui_port": web_ui_port,
+}, indent=2, sort_keys=True))
+PY
+REMOTE
+)"
+
+printf '%s\n' "${snapshot_text}" > "${output_path}"
+cat "${output_path}"

--- a/scripts/ci/configure-main-ruleset.sh
+++ b/scripts/ci/configure-main-ruleset.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dry_run="no"
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  cat <<'EOF'
+Usage:
+  configure-main-ruleset.sh [--dry-run] [owner/repo]
+
+Adds the NAIM PR Gate summary job as a required status check on the main
+repository ruleset. Run this only after naim-pr-ci.yml has landed on main.
+EOF
+  exit 0
+fi
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  dry_run="yes"
+  shift
+fi
+
+repo="${1:-RayGron/naim-node}"
+ruleset_name="${NAIM_MAIN_RULESET_NAME:-main}"
+required_check="${NAIM_REQUIRED_PR_CHECK:-NAIM PR Gate / summary}"
+
+ruleset_json="$(gh api "repos/${repo}/rulesets" --jq ".[] | select(.name == \"${ruleset_name}\")")"
+if [[ -z "${ruleset_json}" ]]; then
+  echo "error: ruleset '${ruleset_name}' not found in ${repo}" >&2
+  exit 1
+fi
+
+ruleset_id="$(
+  RULESET_JSON="${ruleset_json}" python3 - <<'PY'
+import json
+import os
+
+print(json.loads(os.environ["RULESET_JSON"])["id"])
+PY
+)"
+
+ruleset_full_json="$(gh api "repos/${repo}/rulesets/${ruleset_id}")"
+payload="$(
+  RULESET_JSON="${ruleset_full_json}" python3 - "${required_check}" <<'PY'
+import json
+import os
+import sys
+
+required_check = sys.argv[1]
+ruleset = json.loads(os.environ["RULESET_JSON"])
+rules = ruleset.get("rules") or []
+rules = [rule for rule in rules if rule.get("type") != "required_status_checks"]
+rules.append({
+    "type": "required_status_checks",
+    "parameters": {
+        "strict_required_status_checks_policy": True,
+        "required_status_checks": [
+            {
+                "context": required_check,
+                "integration_id": 15368,
+            }
+        ],
+    },
+})
+payload = {
+    "name": ruleset["name"],
+    "target": ruleset["target"],
+    "enforcement": ruleset["enforcement"],
+    "conditions": ruleset.get("conditions") or {},
+    "rules": rules,
+    "bypass_actors": ruleset.get("bypass_actors") or [],
+}
+print(json.dumps(payload))
+PY
+)"
+
+if [[ "${dry_run}" == "yes" ]]; then
+  printf '%s\n' "${payload}"
+  exit 0
+fi
+
+printf '%s\n' "${payload}" | gh api \
+  --method PUT \
+  "repos/${repo}/rulesets/${ruleset_id}" \
+  --input - >/dev/null
+
+echo "ruleset ${ruleset_name} now requires status check: ${required_check}"

--- a/scripts/ci/rollback-main-release.sh
+++ b/scripts/ci/rollback-main-release.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+source "${repo_root}/scripts/deploy/naim-production-env.sh"
+
+snapshot_path=""
+failed_tag="${NAIM_RELEASE_TAG:-${NAIM_IMAGE_TAG:-}}"
+output_path=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  rollback-main-release.sh --snapshot <path> --failed-tag <tag> [--output <path>]
+
+Rolls production back to the previous release captured before a post-merge
+deployment. It first attempts a logical rollback through the controller, then
+falls back to the captured compose and SQLite snapshot if needed.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --snapshot)
+      snapshot_path="${2:-}"
+      shift 2
+      ;;
+    --failed-tag)
+      failed_tag="${2:-}"
+      shift 2
+      ;;
+    --output)
+      output_path="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${snapshot_path}" || -z "${failed_tag}" ]]; then
+  echo "error: --snapshot and --failed-tag are required" >&2
+  usage >&2
+  exit 1
+fi
+if [[ ! -f "${snapshot_path}" ]]; then
+  echo "error: snapshot not found: ${snapshot_path}" >&2
+  exit 1
+fi
+
+previous_tag="$(
+  python3 - "${snapshot_path}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    snapshot = json.load(handle)
+print(snapshot.get("previous_tag") or "")
+PY
+)"
+
+if [[ -z "${previous_tag}" ]]; then
+  report="rollback skipped: no previous release tag was captured before ${failed_tag}"
+  printf '%s\n' "${report}"
+  if [[ -n "${output_path}" ]]; then
+    printf '%s\n' "${report}" > "${output_path}"
+  fi
+  exit 2
+fi
+
+rollback_status="success"
+rollback_detail=""
+
+if ! NAIM_RELEASE_TAG="${previous_tag}" NAIM_IMAGE_TAG="${previous_tag}" \
+    bash "${script_dir}/main-bootstrap-controller-update.sh" --tag "${previous_tag}"; then
+  rollback_status="fallback-attempted"
+  rollback_detail="logical rollback to ${previous_tag} failed; restoring captured compose/database"
+  snapshot_b64="$(base64 -w0 "${snapshot_path}")"
+  if ! remote_main_bash "${snapshot_b64}" <<'REMOTE'
+set -euo pipefail
+
+snapshot_b64="$1"
+snapshot_path="$(mktemp)"
+printf '%s' "${snapshot_b64}" | base64 -d > "${snapshot_path}"
+
+eval "$(
+  python3 - "${snapshot_path}" <<'PY'
+import json
+import shlex
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    snapshot = json.load(handle)
+for key in [
+    "main_root",
+    "previous_tag",
+    "compose_backup_path",
+    "db_backup_path",
+    "controller_port",
+    "web_ui_port",
+]:
+    print(f"{key}=" + shlex.quote(str(snapshot.get(key) or "")))
+PY
+)"
+
+if [[ -z "${main_root}" || -z "${previous_tag}" ]]; then
+  echo "rollback fallback snapshot is missing main_root or previous_tag" >&2
+  exit 1
+fi
+
+release_dir="${main_root}/releases"
+compose_path="${main_root}/docker-compose.yml"
+db_path="${main_root}/state/controller.sqlite"
+
+if [[ -n "${compose_backup_path}" && -f "${compose_backup_path}" ]]; then
+  cp "${compose_backup_path}" "${compose_path}"
+else
+  echo "captured compose backup is unavailable: ${compose_backup_path}" >&2
+  exit 1
+fi
+
+if [[ -n "${db_backup_path}" && -f "${db_backup_path}" ]]; then
+  docker compose -f "${compose_path}" down >/dev/null 2>&1 || true
+  cp "${db_backup_path}" "${db_path}"
+  rm -f "${db_path}-wal" "${db_path}-shm"
+fi
+
+if [[ -f "${release_dir}/${previous_tag}.json" ]]; then
+  ln -sfn "${previous_tag}.json" "${release_dir}/current.json"
+  printf '%s\n' "${previous_tag}" > "${release_dir}/current-tag"
+  chmod 0640 "${release_dir}/current-tag"
+fi
+
+docker compose -f "${compose_path}" up -d --remove-orphans >/dev/null
+
+wait_for_http() {
+  local url="$1"
+  local attempts="${2:-90}"
+  for _ in $(seq 1 "${attempts}"); do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timed out waiting for ${url}" >&2
+  return 1
+}
+
+wait_for_http "http://127.0.0.1:${controller_port}/health" 90
+wait_for_http "http://127.0.0.1:${web_ui_port}/health" 90
+REMOTE
+  then
+    rollback_status="failed"
+    rollback_detail="logical rollback and captured-state fallback both failed"
+  else
+    rollback_status="fallback-success"
+  fi
+fi
+
+if [[ "${rollback_status}" != "failed" ]]; then
+  remote_main_bash "${NAIM_MAIN_ROOT}" "${previous_tag}" <<'REMOTE'
+set -euo pipefail
+main_root="$1"
+previous_tag="$2"
+release_dir="${main_root}/releases"
+if [[ -f "${release_dir}/${previous_tag}.json" ]]; then
+  ln -sfn "${previous_tag}.json" "${release_dir}/current.json"
+  printf '%s\n' "${previous_tag}" > "${release_dir}/current-tag"
+  chmod 0640 "${release_dir}/current-tag"
+else
+  echo "previous release manifest is missing: ${release_dir}/${previous_tag}.json" >&2
+  exit 1
+fi
+REMOTE
+fi
+
+report="$(
+  python3 - "${snapshot_path}" "${failed_tag}" "${previous_tag}" "${rollback_status}" "${rollback_detail}" <<'PY'
+import json
+import sys
+
+snapshot_path, failed_tag, previous_tag, status, detail = sys.argv[1:6]
+with open(snapshot_path, "r", encoding="utf-8") as handle:
+    snapshot = json.load(handle)
+
+lines = [
+    "## Rollback",
+    "",
+    f"- failed release: `{failed_tag}`",
+    f"- restored release: `{previous_tag}`",
+    f"- status: `{status}`",
+    f"- captured at: `{snapshot.get('captured_at', 'n/a')}`",
+    f"- backup root: `{snapshot.get('backup_root', 'n/a')}`",
+]
+if detail:
+    lines.append(f"- detail: {detail}")
+print("\n".join(lines))
+PY
+)"
+
+printf '%s\n' "${report}"
+if [[ -n "${output_path}" ]]; then
+  printf '%s\n' "${report}" > "${output_path}"
+fi
+
+[[ "${rollback_status}" != "failed" ]]


### PR DESCRIPTION
## Summary
- add a privileged PR gate workflow that runs hpc1 build, Knowledge Vault gate, conditional TurboQuant, and operator UI checks before merge
- capture production rollback snapshots before post-merge deploy
- add final production release reporting and rollback automation when deploy has started and a release stage fails
- add a helper to enable the NAIM PR Gate / summary required status check after this workflow lands on main

## Verification
- bash -n scripts/ci/capture-main-release-state.sh scripts/ci/rollback-main-release.sh scripts/ci/configure-main-ruleset.sh
- workflow YAML parse and needs validation with python3/yaml
- git diff --check
- configure-main-ruleset.sh --dry-run RayGron/naim-node