### PR TITLE
Speed up PR gate builds

### DIFF
--- a/.github/workflows/naim-pr-ci.yml
+++ b/.github/workflows/naim-pr-ci.yml
@@ -29,8 +29,9 @@ env:
   NAIM_HPC1_REPO_PATH: ${{ vars.NAIM_HPC1_REPO_PATH || '/mnt/shared-storage/naim/repos/naim-node' }}
   NAIM_HPC1_PR_REPO_ROOT: ${{ vars.NAIM_HPC1_PR_REPO_ROOT || '/tmp/naim-pr-gate/naim-node' }}
   NAIM_BUILD_TYPE: ${{ vars.NAIM_BUILD_TYPE || 'Release' }}
-  NAIM_CUDA_ARCHITECTURES: ${{ vars.NAIM_CUDA_ARCHITECTURES || '' }}
+  NAIM_CUDA_ARCHITECTURES: ${{ vars.NAIM_CUDA_ARCHITECTURES || '120a-real' }}
   NAIM_CUDA_NVCC_JOBS: ${{ vars.NAIM_CUDA_NVCC_JOBS || '1' }}
+  NAIM_COMPILER_CACHE: ${{ vars.NAIM_COMPILER_CACHE || 'auto' }}
   NAIM_CMAKE_ARGS: ${{ vars.NAIM_CMAKE_ARGS || '' }}
 
 jobs:
@@ -92,8 +93,12 @@ jobs:
     timeout-minutes: 10
     needs: hpc1-checkout
     outputs:
+      native_build_required: ${{ steps.scope.outputs.native_build_required }}
+      native_build_reason: ${{ steps.scope.outputs.native_build_reason }}
+      native_matched_file: ${{ steps.scope.outputs.native_matched_file }}
       turboquant_required: ${{ steps.scope.outputs.turboquant_required }}
       turboquant_reason: ${{ steps.scope.outputs.turboquant_reason }}
+      turboquant_matched_file: ${{ steps.scope.outputs.turboquant_matched_file }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -112,6 +117,21 @@ jobs:
           set -euo pipefail
           bash scripts/ci/detect-release-scope.sh
 
+  lightweight-checks:
+    name: lightweight checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.NAIM_RELEASE_SHA }}
+          fetch-depth: 0
+      - name: Run lightweight PR checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/ci/pr-lightweight-checks.sh
+
   hpc1-build:
     name: hpc1 build
     runs-on: ubuntu-latest
@@ -119,6 +139,7 @@ jobs:
     needs:
       - hpc1-checkout
       - detect-release-scope
+    if: needs.detect-release-scope.outputs.native_build_required == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
@@ -130,7 +151,7 @@ jobs:
           set -euo pipefail
           repo_q="$(printf '%q' "${{ needs.hpc1-checkout.outputs.pr_repo_path }}")"
           ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
-            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build.sh"
+            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build.sh"
 
   ui-checks:
     name: operator UI checks
@@ -161,6 +182,8 @@ jobs:
     needs:
       - hpc1-checkout
       - hpc1-build
+      - detect-release-scope
+    if: needs.detect-release-scope.outputs.native_build_required == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
@@ -182,7 +205,9 @@ jobs:
       - hpc1-checkout
       - hpc1-build
       - detect-release-scope
-    if: needs.detect-release-scope.outputs.turboquant_required == 'true'
+    if: >-
+      needs.detect-release-scope.outputs.native_build_required == 'true' &&
+      needs.detect-release-scope.outputs.turboquant_required == 'true'
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-naim-ssh
@@ -194,7 +219,7 @@ jobs:
           set -euo pipefail
           repo_q="$(printf '%q' "${{ needs.hpc1-checkout.outputs.pr_repo_path }}")"
           ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
-            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build-turboquant.sh"
+            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build-turboquant.sh"
 
   summary:
     name: summary
@@ -204,6 +229,7 @@ jobs:
     needs:
       - hpc1-checkout
       - detect-release-scope
+      - lightweight-checks
       - hpc1-build
       - ui-checks
       - hpc1-knowledge-vault-release-gate
@@ -226,14 +252,24 @@ jobs:
 
           needs = json.loads(os.environ["NEEDS_JSON"])
           report_path = sys.argv[1]
+          scope_outputs = needs.get("detect-release-scope", {}).get("outputs", {})
+          native_required = scope_outputs.get("native_build_required") == "true"
+          turbo_required = scope_outputs.get("turboquant_required") == "true"
           required_success = {
               "hpc1-checkout",
               "detect-release-scope",
-              "hpc1-build",
+              "lightweight-checks",
               "ui-checks",
-              "hpc1-knowledge-vault-release-gate",
           }
-          allowed_skipped = {"hpc1-build-turboquant"}
+          if native_required:
+              required_success.add("hpc1-build")
+              required_success.add("hpc1-knowledge-vault-release-gate")
+          allowed_skipped = set()
+          if not native_required:
+              allowed_skipped.add("hpc1-build")
+              allowed_skipped.add("hpc1-knowledge-vault-release-gate")
+          if not turbo_required or not native_required:
+              allowed_skipped.add("hpc1-build-turboquant")
           failures = []
           lines = [
               "## NAIM PR Gate",
@@ -248,15 +284,22 @@ jobs:
               lines.append(f"| `{name}` | `{result}` |")
               if name in required_success and result != "success":
                   failures.append((name, result))
+              elif result in {"failure", "cancelled", "timed_out", "action_required"}:
+                  failures.append((name, result))
+              elif name in allowed_skipped and result == "skipped":
+                  continue
               elif name not in allowed_skipped and result not in {"success", "skipped"}:
                   failures.append((name, result))
-          turbo = needs.get("detect-release-scope", {}).get("outputs", {})
-          if turbo:
+          if scope_outputs:
               lines.extend([
                   "",
                   "### Release Scope",
-                  f"- TurboQuant required: `{turbo.get('turboquant_required', 'unknown')}`",
-                  f"- Reason: `{turbo.get('turboquant_reason', 'unknown')}`",
+                  f"- Native hpc1 build required: `{scope_outputs.get('native_build_required', 'unknown')}`",
+                  f"- Native reason: `{scope_outputs.get('native_build_reason', 'unknown')}`",
+                  f"- Native matched path: `{scope_outputs.get('native_matched_file', '')}`",
+                  f"- TurboQuant required: `{scope_outputs.get('turboquant_required', 'unknown')}`",
+                  f"- TurboQuant reason: `{scope_outputs.get('turboquant_reason', 'unknown')}`",
+                  f"- TurboQuant matched path: `{scope_outputs.get('turboquant_matched_file', '')}`",
               ])
           if failures:
               lines.extend(["", "### Failed Stages"])

--- a/.github/workflows/naim-production-release.yml
+++ b/.github/workflows/naim-production-release.yml
@@ -23,8 +23,9 @@ env:
   NAIM_REGISTRY_PROJECT: ${{ vars.NAIM_REGISTRY_PROJECT || 'naim' }}
   NAIM_REGISTRY_USERNAME: ${{ secrets.NAIM_REGISTRY_USERNAME || vars.NAIM_REGISTRY_USERNAME || 'admin' }}
   NAIM_BUILD_TYPE: ${{ vars.NAIM_BUILD_TYPE || 'Release' }}
-  NAIM_CUDA_ARCHITECTURES: ${{ vars.NAIM_CUDA_ARCHITECTURES || '' }}
+  NAIM_CUDA_ARCHITECTURES: ${{ vars.NAIM_CUDA_ARCHITECTURES || '120a-real' }}
   NAIM_CUDA_NVCC_JOBS: ${{ vars.NAIM_CUDA_NVCC_JOBS || '1' }}
+  NAIM_COMPILER_CACHE: ${{ vars.NAIM_COMPILER_CACHE || 'auto' }}
   NAIM_CMAKE_ARGS: ${{ vars.NAIM_CMAKE_ARGS || '' }}
   NAIM_MIGRATION_TIMEOUT_SEC: ${{ vars.NAIM_MIGRATION_TIMEOUT_SEC || '600' }}
 
@@ -103,8 +104,12 @@ jobs:
     timeout-minutes: 10
     needs: hpc1-pull
     outputs:
+      native_build_required: ${{ steps.scope.outputs.native_build_required }}
+      native_build_reason: ${{ steps.scope.outputs.native_build_reason }}
+      native_matched_file: ${{ steps.scope.outputs.native_matched_file }}
       turboquant_required: ${{ steps.scope.outputs.turboquant_required }}
       turboquant_reason: ${{ steps.scope.outputs.turboquant_reason }}
+      turboquant_matched_file: ${{ steps.scope.outputs.turboquant_matched_file }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -118,6 +123,7 @@ jobs:
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           NAIM_RELEASE_BEFORE: ${{ github.event.before }}
+          NAIM_TURBOQUANT_ARTIFACT_CHECK: always
         run: |
           set -euo pipefail
           bash scripts/ci/detect-release-scope.sh
@@ -148,7 +154,7 @@ jobs:
           set -euo pipefail
           repo_q="$(printf '%q' "${NAIM_HPC1_REPO_PATH}")"
           ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
-            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build.sh"
+            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build.sh"
 
   hpc1-build-turboquant:
     name: 2b. hpc1 TurboQuant build
@@ -177,7 +183,7 @@ jobs:
           set -euo pipefail
           repo_q="$(printf '%q' "${NAIM_HPC1_REPO_PATH}")"
           ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
-            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build-turboquant.sh"
+            "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build-turboquant.sh"
 
   hpc1-knowledge-vault-release-gate:
     name: 2a. hpc1 Knowledge Vault release gate

--- a/scripts/ci/detect-release-scope.sh
+++ b/scripts/ci/detect-release-scope.sh
@@ -11,10 +11,41 @@ set -euo pipefail
 event_name="${GITHUB_EVENT_NAME:-}"
 before_sha="${NAIM_RELEASE_BEFORE:-}"
 zero_sha='0000000000000000000000000000000000000000'
+turboquant_artifact_check="${NAIM_TURBOQUANT_ARTIFACT_CHECK:-native}"
+
+native_build_required="false"
+native_build_reason="lightweight"
+native_matched_file=""
 turboquant_required="false"
 turboquant_reason="cache-reuse"
-matched_file=""
+turboquant_matched_file=""
 changed_files=""
+
+is_native_build_sensitive_path() {
+  local path="$1"
+  case "${path}" in
+    CMakeLists.txt|vcpkg.json|vcpkg-configuration.json)
+      return 0
+      ;;
+    cmake/*|cmake/**)
+      return 0
+      ;;
+    *.c|*.cc|*.cpp|*.cxx|*.cu|*.cuh|*.h|*.hh|*.hpp|*.hxx)
+      return 0
+      ;;
+    common/*|common/**|controller/*|controller/**|hostd/*|hostd/**|launcher/*|launcher/**)
+      return 0
+      ;;
+    runtime/*|runtime/**)
+      return 0
+      ;;
+    Dockerfile|*/Dockerfile|**/Dockerfile|docker/*|docker/**)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
 
 is_turboquant_sensitive_path() {
   local path="$1"
@@ -28,39 +59,42 @@ is_turboquant_sensitive_path() {
     runtime/infer/*|runtime/infer/**|runtime/worker/*|runtime/worker/**)
       return 0
       ;;
-    scripts/build-context.sh|scripts/build-runtime-images.sh|scripts/build-turboquant-runtime.sh|scripts/configure-build.sh|scripts/detect-host-target.sh|scripts/find-cmake.sh|scripts/find-ninja.sh|scripts/find-vcpkg.sh|scripts/resolve-build-target.sh)
-      return 0
-      ;;
-    scripts/ci/hpc1-build.sh|scripts/ci/hpc1-build-common.sh|scripts/ci/hpc1-build-turboquant.sh)
-      return 0
-      ;;
   esac
 
   return 1
 }
 
 if [[ "${event_name}" == "workflow_dispatch" ]]; then
+  native_build_required="true"
+  native_build_reason="workflow_dispatch"
   turboquant_required="true"
   turboquant_reason="workflow_dispatch"
 else
   if [[ -z "${before_sha}" || "${before_sha}" == "${zero_sha}" ]]; then
+    native_build_required="true"
+    native_build_reason="missing_base_sha"
     turboquant_required="true"
     turboquant_reason="missing_base_sha"
   else
     changed_files="$(git diff --name-only "${before_sha}" "${NAIM_RELEASE_SHA}")"
     while IFS= read -r path; do
       [[ -n "${path}" ]] || continue
-      if is_turboquant_sensitive_path "${path}"; then
+      if [[ "${native_build_required}" != "true" ]] && is_native_build_sensitive_path "${path}"; then
+        native_build_required="true"
+        native_build_reason="path_change"
+        native_matched_file="${path}"
+      fi
+      if [[ "${turboquant_required}" != "true" ]] && is_turboquant_sensitive_path "${path}"; then
         turboquant_required="true"
         turboquant_reason="path_change"
-        matched_file="${path}"
-        break
+        turboquant_matched_file="${path}"
       fi
     done <<< "${changed_files}"
   fi
 fi
 
-if [[ "${turboquant_required}" != "true" ]]; then
+if [[ "${turboquant_required}" != "true" ]] \
+  && [[ "${native_build_required}" == "true" || "${turboquant_artifact_check}" == "always" ]]; then
   turboquant_bin_dir="${NAIM_HPC1_REPO_PATH}/build-turboquant/linux/x64/bin"
   if ! ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
       "test -x $(printf '%q' "${turboquant_bin_dir}/llama-server") && test -x $(printf '%q' "${turboquant_bin_dir}/rpc-server")"; then
@@ -70,14 +104,23 @@ if [[ "${turboquant_required}" != "true" ]]; then
 fi
 
 {
+  printf 'native_build_required=%s\n' "${native_build_required}"
+  printf 'native_build_reason=%s\n' "${native_build_reason}"
+  printf 'native_matched_file=%s\n' "${native_matched_file}"
   printf 'turboquant_required=%s\n' "${turboquant_required}"
   printf 'turboquant_reason=%s\n' "${turboquant_reason}"
+  printf 'turboquant_matched_file=%s\n' "${turboquant_matched_file}"
 } >> "${GITHUB_OUTPUT}"
 
+echo "Native hpc1 build required: ${native_build_required}"
+echo "Native reason: ${native_build_reason}"
+if [[ -n "${native_matched_file}" ]]; then
+  echo "Native matched path: ${native_matched_file}"
+fi
 echo "TurboQuant build required: ${turboquant_required}"
-echo "Reason: ${turboquant_reason}"
-if [[ -n "${matched_file}" ]]; then
-  echo "Matched path: ${matched_file}"
+echo "TurboQuant reason: ${turboquant_reason}"
+if [[ -n "${turboquant_matched_file}" ]]; then
+  echo "TurboQuant matched path: ${turboquant_matched_file}"
 fi
 if [[ -n "${changed_files}" ]]; then
   echo "Changed files:"
@@ -88,10 +131,15 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   {
     echo "## Release Scope"
     echo
+    echo "- Native hpc1 build required: \`${native_build_required}\`"
+    echo "- Native reason: \`${native_build_reason}\`"
+    if [[ -n "${native_matched_file}" ]]; then
+      echo "- Native matched path: \`${native_matched_file}\`"
+    fi
     echo "- TurboQuant build required: \`${turboquant_required}\`"
-    echo "- Reason: \`${turboquant_reason}\`"
-    if [[ -n "${matched_file}" ]]; then
-      echo "- Matched path: \`${matched_file}\`"
+    echo "- TurboQuant reason: \`${turboquant_reason}\`"
+    if [[ -n "${turboquant_matched_file}" ]]; then
+      echo "- TurboQuant matched path: \`${turboquant_matched_file}\`"
     fi
   } >> "${GITHUB_STEP_SUMMARY}"
 fi

--- a/scripts/ci/hpc1-build-common.sh
+++ b/scripts/ci/hpc1-build-common.sh
@@ -37,7 +37,7 @@ naim_ci_ensure_writable_dir() {
       sudo chown -R "$(id -u):$(id -g)" "${path}"
     else
       echo "error: directory is not writable by $(id -un): ${path}" >&2
-      exit 1
+      return 1
     fi
   fi
 
@@ -57,4 +57,42 @@ naim_ci_prepare_shared_vcpkg_cache() {
       naim_ci_ensure_writable_dir "$(realpath -e "${candidate_path}")"
     fi
   done
+}
+
+naim_ci_prepare_compiler_cache() {
+  local repo_root="$1"
+  local cache_dir="${NAIM_CCACHE_DIR:-/mnt/shared-storage/naim/cache/ccache/naim-node}"
+  local cache_dir_explicit="0"
+  local fallback_cache_dir="/tmp/naim-ccache/naim-node"
+
+  if [[ -n "${NAIM_CCACHE_DIR:-}" ]]; then
+    cache_dir_explicit="1"
+  fi
+
+  if [[ "${NAIM_COMPILER_CACHE:-auto}" =~ ^(OFF|off|0|false|FALSE|no|NO|none|NONE)$ ]]; then
+    return 0
+  fi
+
+  if ! command -v ccache >/dev/null 2>&1 && ! command -v sccache >/dev/null 2>&1; then
+    echo "warning: no compiler cache launcher found on hpc1; install ccache or sccache to enable caching" >&2
+    return 0
+  fi
+
+  if command -v ccache >/dev/null 2>&1; then
+    if ! mkdir -p "${cache_dir}" 2>/dev/null || ! naim_ci_ensure_writable_dir "${cache_dir}"; then
+      if [[ "${cache_dir_explicit}" == "1" ]]; then
+        echo "error: explicit NAIM_CCACHE_DIR is not writable: ${cache_dir}" >&2
+        return 1
+      fi
+      echo "warning: ccache directory is not writable, falling back to ${fallback_cache_dir}: ${cache_dir}" >&2
+      cache_dir="${fallback_cache_dir}"
+      mkdir -p "${cache_dir}"
+      naim_ci_ensure_writable_dir "${cache_dir}"
+    fi
+    export CCACHE_DIR="${cache_dir}"
+    export CCACHE_BASEDIR="${repo_root}"
+    export CCACHE_COMPRESS="${CCACHE_COMPRESS:-true}"
+    export CCACHE_SLOPPINESS="${CCACHE_SLOPPINESS:-include_file_ctime,include_file_mtime,time_macros,file_macro}"
+    ccache --set-config=max_size="${NAIM_CCACHE_MAX_SIZE:-20G}" >/dev/null 2>&1 || true
+  fi
 }

--- a/scripts/ci/hpc1-build-turboquant.sh
+++ b/scripts/ci/hpc1-build-turboquant.sh
@@ -12,6 +12,7 @@ naim_ci_prepare_repo
 naim_ci_ensure_writable_dir build-turboquant
 naim_ci_ensure_writable_dir var/turboquant
 naim_ci_prepare_shared_vcpkg_cache "$(pwd)"
+naim_ci_prepare_compiler_cache "$(pwd)"
 
 export NAIM_BUILD_TYPE
 bash "$(pwd)/scripts/build-turboquant-runtime.sh" linux x64 "${NAIM_BUILD_TYPE}"

--- a/scripts/ci/hpc1-build.sh
+++ b/scripts/ci/hpc1-build.sh
@@ -11,6 +11,7 @@ naim_ci_prepare_repo
 
 naim_ci_ensure_writable_dir build
 naim_ci_prepare_shared_vcpkg_cache "$(pwd)"
+naim_ci_prepare_compiler_cache "$(pwd)"
 
 export NAIM_BUILD_TYPE
 "$(pwd)/scripts/build-target.sh" "${NAIM_BUILD_TYPE}"

--- a/scripts/ci/pr-lightweight-checks.sh
+++ b/scripts/ci/pr-lightweight-checks.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+zero_sha='0000000000000000000000000000000000000000'
+if [[ -n "${NAIM_BASE_SHA:-}" && -n "${NAIM_RELEASE_SHA:-}" && "${NAIM_BASE_SHA}" != "${zero_sha}" ]]; then
+  git diff --check "${NAIM_BASE_SHA}" "${NAIM_RELEASE_SHA}"
+else
+  git diff --check
+fi
+
+while IFS= read -r -d '' script_path; do
+  bash -n "${script_path}"
+done < <(find scripts -type f -name '*.sh' -print0)
+
+python3 - <<'PY'
+from pathlib import Path
+import sys
+
+try:
+    import yaml
+except Exception as exc:
+    print(f"PyYAML unavailable; skipped workflow YAML parse: {exc}")
+    raise SystemExit(0)
+
+paths = sorted(Path(".github").glob("**/*.yml")) + sorted(Path(".github").glob("**/*.yaml"))
+for path in paths:
+    yaml.safe_load(path.read_text(encoding="utf-8"))
+print(f"parsed {len(paths)} GitHub YAML files")
+PY

--- a/scripts/configure-build.sh
+++ b/scripts/configure-build.sh
@@ -41,6 +41,7 @@ openmp_library=""
 : "${NAIM_CUDA_NATIVE:=OFF}"
 : "${NAIM_CUDA_ARCHITECTURES:=}"
 : "${NAIM_CUDA_NVCC_JOBS:=1}"
+: "${NAIM_COMPILER_CACHE:=auto}"
 
 detect_cuda_root() {
   local candidate=""
@@ -141,6 +142,42 @@ if detect_macos_openmp; then
   :
 elif [[ "${TARGET_OS}" == "macos" ]]; then
   echo "[cmake] OpenMP runtime was not found for macOS; building without OpenMP (install with 'brew install libomp' to enable it)" >&2
+fi
+
+compiler_cache_launcher=""
+case "${NAIM_COMPILER_CACHE}" in
+  ""|auto|AUTO)
+    if command -v ccache >/dev/null 2>&1; then
+      compiler_cache_launcher="$(command -v ccache)"
+    elif command -v sccache >/dev/null 2>&1; then
+      compiler_cache_launcher="$(command -v sccache)"
+    fi
+    ;;
+  OFF|off|0|false|FALSE|no|NO|none|NONE)
+    compiler_cache_launcher=""
+    ;;
+  ccache|sccache)
+    if command -v "${NAIM_COMPILER_CACHE}" >/dev/null 2>&1; then
+      compiler_cache_launcher="$(command -v "${NAIM_COMPILER_CACHE}")"
+    else
+      echo "[cmake] requested compiler cache '${NAIM_COMPILER_CACHE}' was not found on PATH" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    if [[ -x "${NAIM_COMPILER_CACHE}" ]]; then
+      compiler_cache_launcher="${NAIM_COMPILER_CACHE}"
+    else
+      echo "[cmake] NAIM_COMPILER_CACHE must be auto, off, ccache, sccache, or an executable path" >&2
+      exit 1
+    fi
+    ;;
+esac
+
+if [[ -n "${compiler_cache_launcher}" ]]; then
+  echo "[cmake] compiler cache launcher: ${compiler_cache_launcher}" >&2
+else
+  echo "[cmake] compiler cache launcher: disabled" >&2
 fi
 
 vcpkg_root="$("${script_dir}/find-vcpkg.sh" --root)"
@@ -264,9 +301,11 @@ cmake_args=(
 )
 
 cmake_args+=("-DNAIM_ENABLE_CUDA=${NAIM_ENABLE_CUDA}")
+cmake_args+=("-DCMAKE_CXX_COMPILER_LAUNCHER=${compiler_cache_launcher}")
 if [[ "${NAIM_ENABLE_CUDA}" == "ON" ]]; then
   cmake_args+=("-DCUDAToolkit_ROOT=${cuda_root}")
   cmake_args+=("-DCMAKE_CUDA_COMPILER=${cuda_nvcc}")
+  cmake_args+=("-DCMAKE_CUDA_COMPILER_LAUNCHER=${compiler_cache_launcher}")
   cmake_args+=("-DNAIM_CUDA_NATIVE=${NAIM_CUDA_NATIVE}")
   cmake_args+=("-DNAIM_CUDA_ARCHITECTURES=${NAIM_CUDA_ARCHITECTURES}")
   cmake_args+=("-DNAIM_CUDA_NVCC_JOBS=${NAIM_CUDA_NVCC_JOBS}")


### PR DESCRIPTION
## Summary
- Add lightweight PR checks and skip hpc1 native CUDA/KV/TurboQuant jobs when changes do not affect native/runtime/container code.
- Default CI CUDA architecture to hpc1's 120a-real instead of llama.cpp's broad default architecture set.
- Add optional compiler-cache launcher support and prepare ccache on hpc1 CI builds.
- Keep production release as the full native build and rollout path.

## Validation
- bash -n for changed CI/build scripts
- workflow YAML parse
- lightweight PR checks
- release-scope simulation for lightweight and workflow_dispatch paths