### PR TITLE
Add app model attachments for voice ASR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build-turboquant/
 dist/
 var/
 vcpkg_installed/

--- a/common/include/naim/state/desired_state_v2_renderer.h
+++ b/common/include/naim/state/desired_state_v2_renderer.h
@@ -72,6 +72,11 @@ class DesiredStateV2Renderer final {
   std::string InferInstanceNameForWorker(int worker_index) const;
   std::string BuildPlaneSharedHostPath() const;
   std::string BuildInstancePrivateHostPath(const std::string& instance_name) const;
+  std::string BuildAppModelHostPath(
+      const std::string& instance_name,
+      const std::string& model_name,
+      const std::string& mount_path,
+      const std::string& source_path) const;
   std::string BuildAppCommandFromScriptRef(const std::string& script_ref) const;
   std::string BuildCommandFromStartSpec(
       const nlohmann::json& start,

--- a/common/include/naim/state/models.h
+++ b/common/include/naim/state/models.h
@@ -95,6 +95,17 @@ struct DiskSpec {
   int size_gb = 0;
 };
 
+struct AppModelMountSpec {
+  std::string name;
+  std::string source_path;
+  std::string source_node_name;
+  std::vector<std::string> source_paths;
+  std::string host_path;
+  std::string mount_path;
+  std::string env_var;
+  bool required = true;
+};
+
 struct InstanceSpec {
   std::string name;
   InstanceRole role;
@@ -116,6 +127,7 @@ struct InstanceSpec {
   bool preemptible = false;
   std::optional<int> memory_cap_mb;
   int private_disk_size_gb = 0;
+  std::vector<AppModelMountSpec> app_model_mounts;
 };
 
 struct NodeInventory {

--- a/common/src/planning/execution_plan.cpp
+++ b/common/src/planning/execution_plan.cpp
@@ -15,6 +15,17 @@ namespace naim {
 
 namespace {
 
+std::string JoinStrings(const std::vector<std::string>& values, const std::string& separator) {
+  std::ostringstream out;
+  for (std::size_t index = 0; index < values.size(); ++index) {
+    if (index > 0) {
+      out << separator;
+    }
+    out << values[index];
+  }
+  return out.str();
+}
+
 std::string DiskKey(const DiskSpec& disk) {
   return disk.name + "@" + disk.node_name;
 }
@@ -63,6 +74,30 @@ std::string PublishedPortsSignature(const std::vector<PublishedPort>& ports) {
   return out.str();
 }
 
+std::string AppModelMountsSignature(const std::vector<AppModelMountSpec>& mounts) {
+  std::vector<std::string> entries;
+  entries.reserve(mounts.size());
+  for (const auto& mount : mounts) {
+    std::vector<std::string> source_paths = mount.source_paths;
+    std::sort(source_paths.begin(), source_paths.end());
+    entries.push_back(
+        mount.name + "|" + mount.source_path + "|" + mount.source_node_name + "|" +
+        JoinStrings(source_paths, ",") + "|" + mount.host_path + "|" + mount.mount_path + "|" +
+        mount.env_var + "|" + std::to_string(mount.required ? 1 : 0));
+  }
+  std::sort(entries.begin(), entries.end());
+  std::ostringstream out;
+  bool first = true;
+  for (const auto& entry : entries) {
+    if (!first) {
+      out << ";";
+    }
+    first = false;
+    out << entry;
+  }
+  return out.str();
+}
+
 std::string InstanceSignature(const InstanceSpec& instance) {
   return instance.node_name + "|" + instance.image + "|" + instance.command + "|" +
          instance.private_disk_name + "|" + instance.shared_disk_name + "|" +
@@ -71,6 +106,7 @@ std::string InstanceSignature(const InstanceSpec& instance) {
          std::to_string(instance.preemptible ? 1 : 0) + "|" +
          std::to_string(instance.memory_cap_mb.value_or(0)) + "|" +
          PublishedPortsSignature(instance.published_ports) + "|" +
+         AppModelMountsSignature(instance.app_model_mounts) + "|" +
          MapSignature(instance.environment) + "|" + MapSignature(instance.labels);
 }
 

--- a/common/src/planning/planner.cpp
+++ b/common/src/planning/planner.cpp
@@ -304,6 +304,12 @@ ComposeService BuildComposeService(
       direct_model_cache.has_value()) {
     service.volumes.push_back(*direct_model_cache);
   }
+  for (const auto& model_mount : instance.app_model_mounts) {
+    if (!model_mount.host_path.empty() && !model_mount.mount_path.empty()) {
+      service.volumes.push_back(
+          ComposeVolume{model_mount.host_path, model_mount.mount_path, true});
+    }
+  }
 
   return service;
 }

--- a/common/src/planning/reconcile.cpp
+++ b/common/src/planning/reconcile.cpp
@@ -78,6 +78,21 @@ std::string PublishedPortsSignature(const std::vector<PublishedPort>& ports) {
   return JoinStrings(entries, ";");
 }
 
+std::string AppModelMountsSignature(const std::vector<AppModelMountSpec>& mounts) {
+  std::vector<std::string> entries;
+  entries.reserve(mounts.size());
+  for (const auto& mount : mounts) {
+    std::vector<std::string> source_paths = mount.source_paths;
+    std::sort(source_paths.begin(), source_paths.end());
+    entries.push_back(
+        mount.name + "|" + mount.source_path + "|" + mount.source_node_name + "|" +
+        JoinStrings(source_paths, ",") + "|" + mount.host_path + "|" + mount.mount_path + "|" +
+        mount.env_var + "|" + std::to_string(mount.required ? 1 : 0));
+  }
+  std::sort(entries.begin(), entries.end());
+  return JoinStrings(entries, ";");
+}
+
 std::string InstanceSignature(const InstanceSpec& instance) {
   std::vector<std::string> dependencies = instance.depends_on;
   std::sort(dependencies.begin(), dependencies.end());
@@ -92,6 +107,7 @@ std::string InstanceSignature(const InstanceSpec& instance) {
          std::to_string(instance.gpu_fraction) + "|" +
          std::to_string(instance.private_disk_size_gb) + "|" +
          PublishedPortsSignature(instance.published_ports) + "|" +
+         AppModelMountsSignature(instance.app_model_mounts) + "|" +
          JoinStrings(dependencies, ",") + "|" + MapSignature(instance.environment) + "|" +
          MapSignature(instance.labels);
 }

--- a/common/src/state/desired_state_v2_projector.cpp
+++ b/common/src/state/desired_state_v2_projector.cpp
@@ -445,9 +445,42 @@ void DesiredStateV2Projector::ProjectApp() {
     if (!start.is_null()) {
       app["start"] = start;
     }
-    const auto env = ProjectorSupport::ProjectCustomEnv(instance, true);
+    auto env = ProjectorSupport::ProjectCustomEnv(instance, true);
+    for (const auto& model_mount : instance.app_model_mounts) {
+      if (!model_mount.env_var.empty()) {
+        env.erase(model_mount.env_var);
+      }
+    }
     if (!env.empty()) {
       app["env"] = env;
+    }
+    if (!instance.app_model_mounts.empty()) {
+      nlohmann::json models = nlohmann::json::array();
+      for (const auto& model_mount : instance.app_model_mounts) {
+        nlohmann::json source = {
+            {"type", "library"},
+            {"path", model_mount.source_path},
+        };
+        if (!model_mount.source_node_name.empty()) {
+          source["node"] = model_mount.source_node_name;
+        }
+        if (!model_mount.source_paths.empty() &&
+            !(model_mount.source_paths.size() == 1 &&
+              model_mount.source_paths.front() == model_mount.source_path)) {
+          source["paths"] = model_mount.source_paths;
+        }
+        nlohmann::json model = {
+            {"name", model_mount.name},
+            {"source", source},
+            {"mount_path", model_mount.mount_path},
+            {"required", model_mount.required},
+        };
+        if (!model_mount.env_var.empty()) {
+          model["env"] = model_mount.env_var;
+        }
+        models.push_back(std::move(model));
+      }
+      app["models"] = std::move(models);
     }
     const auto publish = ProjectorSupport::ProjectPublishedPorts(instance);
     if (!publish.empty()) {

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <filesystem>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -805,6 +806,33 @@ void DesiredStateV2Renderer::RenderAppInstance() {
     }
     app.environment["NAIM_APP_NAME"] = app_name;
     app.environment["NAIM_APP_PRIMARY"] = primary ? "true" : "false";
+    if (app_entry.contains("models") && app_entry.at("models").is_array()) {
+      for (const auto& model_entry : app_entry.at("models")) {
+        const auto& source = model_entry.at("source");
+        AppModelMountSpec model_mount;
+        model_mount.name = model_entry.value("name", std::string{});
+        model_mount.source_path = source.value("path", std::string{});
+        model_mount.source_node_name = source.value("node", std::string{});
+        if (source.contains("paths") && source.at("paths").is_array()) {
+          model_mount.source_paths = source.at("paths").get<std::vector<std::string>>();
+        }
+        if (model_mount.source_paths.empty()) {
+          model_mount.source_paths.push_back(model_mount.source_path);
+        }
+        model_mount.mount_path = model_entry.value("mount_path", std::string{});
+        model_mount.env_var = model_entry.value("env", std::string{});
+        model_mount.required = model_entry.value("required", true);
+        model_mount.host_path = BuildAppModelHostPath(
+            app.name,
+            model_mount.name,
+            model_mount.mount_path,
+            model_mount.source_path);
+        if (!model_mount.env_var.empty()) {
+          app.environment[model_mount.env_var] = model_mount.mount_path;
+        }
+        app.app_model_mounts.push_back(std::move(model_mount));
+      }
+    }
     app.labels = {
         {"naim.plane", state_.plane_name},
         {"naim.role", "app"},
@@ -1338,6 +1366,22 @@ std::string DesiredStateV2Renderer::BuildPlaneSharedHostPath() const {
 std::string DesiredStateV2Renderer::BuildInstancePrivateHostPath(
     const std::string& instance_name) const {
   return "/var/lib/naim/disks/instances/" + instance_name + "/private";
+}
+
+std::string DesiredStateV2Renderer::BuildAppModelHostPath(
+    const std::string& instance_name,
+    const std::string& model_name,
+    const std::string& mount_path,
+    const std::string& source_path) const {
+  std::string filename = std::filesystem::path(mount_path).filename().string();
+  if (filename.empty()) {
+    filename = std::filesystem::path(source_path).filename().string();
+  }
+  if (filename.empty()) {
+    filename = "model";
+  }
+  return BuildPlaneSharedHostPath() + "/app-models/" + instance_name + "/" +
+         NormalizeAppNameToken(model_name) + "/" + filename;
 }
 
 std::string DesiredStateV2Renderer::BuildAppCommandFromScriptRef(

--- a/common/src/state/desired_state_v2_validator.cpp
+++ b/common/src/state/desired_state_v2_validator.cpp
@@ -44,6 +44,29 @@ std::optional<std::string> PlacementExecutionNodeName(const nlohmann::json& plac
   return std::nullopt;
 }
 
+bool IsAbsolutePath(const std::string& value) {
+  return !value.empty() && value.front() == '/';
+}
+
+bool IsValidEnvName(const std::string& value) {
+  if (value.empty()) {
+    return false;
+  }
+  const auto is_alpha = [](char ch) {
+    return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z');
+  };
+  const auto is_digit = [](char ch) { return ch >= '0' && ch <= '9'; };
+  if (!is_alpha(value.front()) && value.front() != '_') {
+    return false;
+  }
+  for (const char ch : value) {
+    if (!is_alpha(ch) && !is_digit(ch) && ch != '_') {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace
 
 void DesiredStateV2Validator::ValidateOrThrow(const nlohmann::json& value) {
@@ -659,6 +682,67 @@ void DesiredStateV2Validator::ValidateSingleAppSpec(
     }
     if (app.at("volumes").size() > 1) {
       throw std::runtime_error("desired-state v2 currently supports at most one app volume");
+    }
+  }
+  if (app.contains("models")) {
+    if (!app.at("models").is_array()) {
+      throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models must be an array");
+    }
+    std::set<std::string> seen_names;
+    std::set<std::string> seen_mount_paths;
+    for (const auto& model : app.at("models")) {
+      if (!model.is_object()) {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models items must be objects");
+      }
+      const std::string name = model.value("name", std::string{});
+      if (name.empty()) {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[] requires name");
+      }
+      if (!seen_names.insert(name).second) {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[] names must be unique");
+      }
+      if (!model.contains("source") || !model.at("source").is_object()) {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[].source must be an object");
+      }
+      const auto& source = model.at("source");
+      const std::string source_type = source.value("type", std::string{});
+      if (source_type != "library") {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[].source.type must be library");
+      }
+      const std::string source_path = source.value("path", std::string{});
+      if (!IsAbsolutePath(source_path)) {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[].source.path must be an absolute path");
+      }
+      if (source.contains("paths")) {
+        if (!source.at("paths").is_array()) {
+          throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[].source.paths must be an array");
+        }
+        for (const auto& path : source.at("paths")) {
+          if (!path.is_string() || !IsAbsolutePath(path.get<std::string>())) {
+            throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[].source.paths items must be absolute paths");
+          }
+        }
+      }
+      if (source.contains("node") && !source.at("node").is_string()) {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[].source.node must be a string");
+      }
+      const std::string mount_path = model.value("mount_path", std::string{});
+      if (!IsAbsolutePath(mount_path)) {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[].mount_path must be an absolute path");
+      }
+      if (!seen_mount_paths.insert(mount_path).second) {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[].mount_path values must be unique");
+      }
+      if (model.contains("env") && !model.at("env").is_string()) {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[].env must be a string");
+      }
+      const std::string env_name = model.value("env", std::string{});
+      if (!env_name.empty() && !IsValidEnvName(env_name)) {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[].env must be a valid environment variable name");
+      }
+      if (model.contains("required") && !model.at("required").is_boolean()) {
+        throw std::runtime_error(std::string("desired-state v2 ") + field_name + ".models[].required must be a boolean");
+      }
     }
   }
 }

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -1881,6 +1881,72 @@ int main() {
       std::cout << "ok: multi-app-plane" << '\n';
     }
 
+    {
+      const json app_model_plane{
+          {"version", 2},
+          {"plane_name", "app-model-plane"},
+          {"plane_mode", "llm"},
+          {"model",
+           {
+               {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+               {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+               {"served_model_name", "qwen-app-model"},
+           }},
+          {"runtime",
+           {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+          {"infer", {{"replicas", 1}}},
+          {"apps",
+           json::array(
+               {{{"name", "chat"},
+                 {"primary", true},
+                 {"enabled", true},
+                 {"image", "example/app:dev"}},
+                {{"name", "voice-asr"},
+                 {"enabled", true},
+                 {"image", "example/voice-asr:dev"},
+                 {"models",
+                  json::array(
+                      {{{"name", "whisper"},
+                        {"source",
+                         {{"type", "library"},
+                          {"path", "/mnt/shared-storage/models/whisper/ggml-base.bin"}}},
+                        {"mount_path", "/models/whisper/ggml-base.bin"},
+                        {"env", "WHISPER_MODEL_PATH"},
+                        {"required", true}}})}}})},
+      };
+      const auto state = RenderValid(app_model_plane, "app-model-plane");
+      const auto voice = FindInstance(state, "app-app-model-plane-voice-asr");
+      Expect(voice.app_model_mounts.size() == 1,
+             "app-model-plane: voice app should have one model mount");
+      Expect(voice.environment.at("WHISPER_MODEL_PATH") == "/models/whisper/ggml-base.bin",
+             "app-model-plane: model env should point to container mount path");
+      Expect(voice.app_model_mounts.front().source_path ==
+                 "/mnt/shared-storage/models/whisper/ggml-base.bin",
+             "app-model-plane: source path should be retained");
+      const auto compose_plans = naim::BuildNodeComposePlans(state);
+      const auto& service = *std::find_if(
+          compose_plans.front().services.begin(),
+          compose_plans.front().services.end(),
+          [](const naim::ComposeService& candidate) {
+            return candidate.name == "app-app-model-plane-voice-asr";
+          });
+      const auto mount_it = std::find_if(
+          service.volumes.begin(),
+          service.volumes.end(),
+          [](const naim::ComposeVolume& volume) {
+            return volume.target == "/models/whisper/ggml-base.bin";
+          });
+      Expect(mount_it != service.volumes.end(),
+             "app-model-plane: compose should include model mount");
+      Expect(mount_it->read_only, "app-model-plane: model mount should be read-only");
+      const auto projected = naim::DesiredStateV2Projector::Project(state);
+      Expect(projected.at("apps").at(1).contains("models"),
+             "app-model-plane: projector should preserve app models");
+      Expect(!projected.at("apps").at(1).value("env", json::object()).contains("WHISPER_MODEL_PATH"),
+             "app-model-plane: projector should not duplicate generated model env");
+      std::cout << "ok: app-model-plane" << '\n';
+    }
+
     ExpectInvalid(
         json{
             {"version", 2},
@@ -1893,6 +1959,23 @@ int main() {
                   {{"name", "collector"}, {"enabled", true}, {"image", "example/app:dev"}}})},
         },
         "duplicate-app-names");
+
+    ExpectInvalid(
+        json{
+            {"version", 2},
+            {"plane_name", "bad-app-model-source"},
+            {"plane_mode", "compute"},
+            {"runtime", {{"engine", "custom"}, {"workers", 1}}},
+            {"app",
+             {{"enabled", true},
+              {"image", "example/app:dev"},
+              {"models",
+               json::array(
+                   {{{"name", "whisper"},
+                     {"source", {{"type", "url"}, {"path", "/models/ggml-base.bin"}}},
+                     {"mount_path", "/models/whisper/ggml-base.bin"}}})}}},
+        },
+        "bad-app-model-source");
 
     return 0;
   } catch (const std::exception& ex) {

--- a/common/src/state/state_json_runtime_codecs.cpp
+++ b/common/src/state/state_json_runtime_codecs.cpp
@@ -181,6 +181,7 @@ json StateJsonRuntimeCodecs::ToJson(const InstanceSpec& instance) {
       {"priority", instance.priority},
       {"preemptible", instance.preemptible},
       {"private_disk_size_gb", instance.private_disk_size_gb},
+      {"app_model_mounts", json::array()},
   };
   if (instance.gpu_device.has_value()) {
     result["gpu_device"] = *instance.gpu_device;
@@ -190,6 +191,18 @@ json StateJsonRuntimeCodecs::ToJson(const InstanceSpec& instance) {
   }
   for (const auto& port : instance.published_ports) {
     result["published_ports"].push_back(ToJson(port));
+  }
+  for (const auto& mount : instance.app_model_mounts) {
+    result["app_model_mounts"].push_back(json{
+        {"name", mount.name},
+        {"source_path", mount.source_path},
+        {"source_node_name", mount.source_node_name},
+        {"source_paths", mount.source_paths},
+        {"host_path", mount.host_path},
+        {"mount_path", mount.mount_path},
+        {"env_var", mount.env_var},
+        {"required", mount.required},
+    });
   }
   return result;
 }
@@ -352,6 +365,23 @@ InstanceSpec StateJsonRuntimeCodecs::InstanceSpecFromJson(
     instance.memory_cap_mb = value.at("memory_cap_mb").get<int>();
   }
   instance.private_disk_size_gb = value.value("private_disk_size_gb", 0);
+  if (value.contains("app_model_mounts") && value.at("app_model_mounts").is_array()) {
+    for (const auto& item : value.at("app_model_mounts")) {
+      if (!item.is_object()) {
+        continue;
+      }
+      AppModelMountSpec mount;
+      mount.name = item.value("name", std::string{});
+      mount.source_path = item.value("source_path", std::string{});
+      mount.source_node_name = item.value("source_node_name", std::string{});
+      mount.source_paths = item.value("source_paths", std::vector<std::string>{});
+      mount.host_path = item.value("host_path", std::string{});
+      mount.mount_path = item.value("mount_path", std::string{});
+      mount.env_var = item.value("env_var", std::string{});
+      mount.required = item.value("required", true);
+      instance.app_model_mounts.push_back(std::move(mount));
+    }
+  }
   return instance;
 }
 

--- a/controller/src/model/model_conversion_service.cpp
+++ b/controller/src/model/model_conversion_service.cpp
@@ -23,6 +23,7 @@ namespace {
 
 constexpr std::string_view kFormatGguf = "gguf";
 constexpr std::string_view kFormatSafetensors = "safetensors";
+constexpr std::string_view kFormatWhisperCpp = "whisper.cpp";
 constexpr std::string_view kFormatUnknown = "unknown";
 constexpr std::array<std::string_view, 5> kKnownQuantizations = {
     "FP16",
@@ -99,10 +100,16 @@ std::string ModelConversionService::DetectSourceFormat(
   }
   bool saw_safetensors = false;
   bool saw_gguf = false;
+  bool saw_whisper_cpp = false;
   for (const auto& source_url : source_urls) {
     const auto lowered = Lowercase(FilenameFromUrl(source_url));
     if (lowered.ends_with(".gguf")) {
       saw_gguf = true;
+      continue;
+    }
+    if (lowered.ends_with(".bin") &&
+        (lowered.starts_with("ggml-") || lowered.find("whisper") != std::string::npos)) {
+      saw_whisper_cpp = true;
       continue;
     }
     if (lowered.ends_with(".safetensors")) {
@@ -120,6 +127,9 @@ std::string ModelConversionService::DetectSourceFormat(
   if (saw_gguf && !saw_safetensors) {
     return std::string(kFormatGguf);
   }
+  if (saw_whisper_cpp && !saw_gguf && !saw_safetensors) {
+    return std::string(kFormatWhisperCpp);
+  }
   return std::string(kFormatUnknown);
 }
 
@@ -130,6 +140,10 @@ std::string ModelConversionService::NormalizeOutputFormat(const std::string& val
   }
   if (normalized == kFormatSafetensors) {
     return std::string(kFormatSafetensors);
+  }
+  if (normalized == kFormatWhisperCpp || normalized == "whisper" ||
+      normalized == "whisper.cpp-bin") {
+    return std::string(kFormatWhisperCpp);
   }
   return normalized.empty() ? std::string(kFormatUnknown) : normalized;
 }

--- a/controller/src/model/model_library_service.cpp
+++ b/controller/src/model/model_library_service.cpp
@@ -514,11 +514,12 @@ HttpResponse ModelLibraryService::EnqueueDownload(
              {"message", "failed to detect source format from source_urls"}},
         {});
   }
-  if (desired_output_format != "gguf" && desired_output_format != "safetensors") {
+  if (desired_output_format != "gguf" && desired_output_format != "safetensors" &&
+      desired_output_format != "whisper.cpp") {
     return support_.build_json_response(
         400,
         json{{"status", "bad_request"},
-             {"message", "format must be gguf, safetensors, or source"}},
+             {"message", "format must be gguf, safetensors, whisper.cpp, or source"}},
         {});
   }
   if (detected_source_format == "gguf" && desired_output_format != "gguf") {
@@ -526,6 +527,13 @@ HttpResponse ModelLibraryService::EnqueueDownload(
         400,
         json{{"status", "bad_request"},
              {"message", "gguf sources can only retain GGUF output format"}},
+        {});
+  }
+  if (detected_source_format == "whisper.cpp" && desired_output_format != "whisper.cpp") {
+    return support_.build_json_response(
+        400,
+        json{{"status", "bad_request"},
+             {"message", "whisper.cpp sources can only retain whisper.cpp output format"}},
         {});
   }
 
@@ -1662,16 +1670,28 @@ ModelLibraryService::BuildReferenceMap(const std::string& db_path) const {
   const auto desired_states = store.LoadDesiredStates();
   std::map<std::string, std::vector<std::string>> references;
   for (const auto& desired_state : desired_states) {
-    if (!desired_state.bootstrap_model.has_value() ||
-        !desired_state.bootstrap_model->local_path.has_value()) {
-      continue;
+    if (desired_state.bootstrap_model.has_value() &&
+        desired_state.bootstrap_model->local_path.has_value()) {
+      const std::string& local_path = *desired_state.bootstrap_model->local_path;
+      if (IsUsableAbsoluteHostPath(local_path)) {
+        references[NormalizePathString(local_path)].push_back(
+            desired_state.plane_name);
+      }
     }
-    const std::string& local_path = *desired_state.bootstrap_model->local_path;
-    if (!IsUsableAbsoluteHostPath(local_path)) {
-      continue;
+    for (const auto& instance : desired_state.instances) {
+      for (const auto& mount : instance.app_model_mounts) {
+        if (IsUsableAbsoluteHostPath(mount.source_path)) {
+          references[NormalizePathString(mount.source_path)].push_back(
+              desired_state.plane_name + ":" + instance.name);
+        }
+        for (const auto& source_path : mount.source_paths) {
+          if (IsUsableAbsoluteHostPath(source_path)) {
+            references[NormalizePathString(source_path)].push_back(
+                desired_state.plane_name + ":" + instance.name);
+          }
+        }
+      }
     }
-    references[NormalizePathString(local_path)].push_back(
-        desired_state.plane_name);
   }
   return references;
 }
@@ -1913,11 +1933,33 @@ ModelLibraryService::ScanEntries(const std::string& db_path) const {
         continue;
       }
       error.clear();
-      if (!EndsWithIgnoreCase(current_name, ".gguf")) {
+      const bool current_is_whisper_cpp =
+          EndsWithIgnoreCase(current_name, ".bin") &&
+          (Lowercase(current_name).rfind("ggml-", 0) == 0 ||
+           Lowercase(current_name).find("whisper") != std::string::npos);
+      if (!EndsWithIgnoreCase(current_name, ".gguf") && !current_is_whisper_cpp) {
         continue;
       }
       const auto normalized_file_path = NormalizePathString(current_path);
       if (pending_downloads.target_paths.count(normalized_file_path) != 0) {
+        continue;
+      }
+      if (current_is_whisper_cpp) {
+        ModelLibraryEntry entry;
+        entry.path = normalized_file_path;
+        entry.name = current_name;
+        entry.kind = "file";
+        entry.format = "whisper.cpp";
+        entry.quantization = "base";
+        entry.root = root_text;
+        entry.paths = {entry.path};
+        entry.size_bytes = iterator->file_size(error);
+        const auto reference_it = reference_map.find(entry.path);
+        if (reference_it != reference_map.end()) {
+          entry.referenced_by = reference_it->second;
+          entry.deletable = false;
+        }
+        entries_by_path[entry.path] = std::move(entry);
         continue;
       }
       std::string multipart_prefix;

--- a/hostd/src/app/hostd_desired_state_apply_support.cpp
+++ b/hostd/src/app/hostd_desired_state_apply_support.cpp
@@ -1,17 +1,329 @@
 #include "app/hostd_desired_state_apply_support.h"
 
 #include <algorithm>
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
+#include <map>
+#include <optional>
+#include <sstream>
 #include <stdexcept>
+#include <thread>
 
 #include "app/hostd_file_support.h"
 #include "app/hostd_runtime_telemetry_support.h"
+#include "naim/core/platform_compat.h"
+#include "naim/security/crypto_utils.h"
 #include "naim/state/state_json.h"
 #include "naim/planning/planner.h"
+
+#include <netdb.h>
 
 namespace naim::hostd {
 
 namespace {
+
+constexpr std::uintmax_t kAppModelChunkBytes = 4ULL * 1024ULL * 1024ULL;
+constexpr std::uintmax_t kAppModelPeerChunkBytes = 64ULL * 1024ULL * 1024ULL;
+constexpr int kAppModelPollAttempts = 600;
+constexpr std::chrono::milliseconds kAppModelPollInterval(500);
+
+struct PeerHttpResponse {
+  int status_code = 0;
+  std::map<std::string, std::string> headers;
+  std::string body;
+};
+
+struct PeerEndpoint {
+  std::string raw;
+  std::string host;
+  int port = 29999;
+};
+
+PeerEndpoint ParsePeerEndpoint(std::string endpoint) {
+  PeerEndpoint parsed;
+  parsed.raw = endpoint;
+  if (endpoint.rfind("http://", 0) == 0) {
+    endpoint = endpoint.substr(7);
+  }
+  const std::size_t slash = endpoint.find('/');
+  if (slash != std::string::npos) {
+    endpoint = endpoint.substr(0, slash);
+  }
+  const std::size_t colon = endpoint.rfind(':');
+  if (colon == std::string::npos) {
+    parsed.host = endpoint;
+  } else {
+    parsed.host = endpoint.substr(0, colon);
+    parsed.port = std::stoi(endpoint.substr(colon + 1));
+  }
+  if (parsed.host.empty()) {
+    throw std::runtime_error("invalid peer endpoint: " + parsed.raw);
+  }
+  return parsed;
+}
+
+PeerHttpResponse SendPeerHttpRawRequest(
+    const std::string& endpoint,
+    const std::string& path,
+    const std::string& body,
+    const std::string& content_type) {
+  const PeerEndpoint target = ParsePeerEndpoint(endpoint);
+  naim::platform::EnsureSocketsInitialized();
+  addrinfo hints{};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  addrinfo* results = nullptr;
+  const std::string port_text = std::to_string(target.port);
+  const int lookup = getaddrinfo(target.host.c_str(), port_text.c_str(), &hints, &results);
+  if (lookup != 0) {
+    throw std::runtime_error("failed to resolve peer endpoint: " + target.raw);
+  }
+  naim::platform::SocketHandle fd = naim::platform::kInvalidSocket;
+  for (addrinfo* candidate = results; candidate != nullptr; candidate = candidate->ai_next) {
+    fd = socket(candidate->ai_family, candidate->ai_socktype, candidate->ai_protocol);
+    if (!naim::platform::IsSocketValid(fd)) {
+      continue;
+    }
+    if (connect(fd, candidate->ai_addr, candidate->ai_addrlen) == 0) {
+      break;
+    }
+    naim::platform::CloseSocket(fd);
+    fd = naim::platform::kInvalidSocket;
+  }
+  freeaddrinfo(results);
+  if (!naim::platform::IsSocketValid(fd)) {
+    throw std::runtime_error("failed to connect to peer endpoint: " + target.raw);
+  }
+  std::ostringstream request;
+  request << "POST " << path << " HTTP/1.1\r\n";
+  request << "Host: " << target.host << ":" << target.port << "\r\n";
+  request << "Connection: close\r\n";
+  request << "Content-Type: " << content_type << "\r\n";
+  request << "Content-Length: " << body.size() << "\r\n\r\n";
+  request << body;
+  const std::string request_text = request.str();
+  const char* data = request_text.data();
+  std::size_t remaining = request_text.size();
+  while (remaining > 0) {
+    const ssize_t written = send(fd, data, remaining, 0);
+    if (written <= 0) {
+      naim::platform::CloseSocket(fd);
+      throw std::runtime_error("failed to write peer request");
+    }
+    data += written;
+    remaining -= static_cast<std::size_t>(written);
+  }
+  std::string response_text;
+  std::array<char, 8192> buffer{};
+  while (true) {
+    const ssize_t read_count = recv(fd, buffer.data(), buffer.size(), 0);
+    if (read_count < 0) {
+      naim::platform::CloseSocket(fd);
+      throw std::runtime_error("failed to read peer response");
+    }
+    if (read_count == 0) {
+      break;
+    }
+    response_text.append(buffer.data(), static_cast<std::size_t>(read_count));
+  }
+  naim::platform::CloseSocket(fd);
+  const std::size_t headers_end = response_text.find("\r\n\r\n");
+  const std::string headers =
+      headers_end == std::string::npos ? response_text : response_text.substr(0, headers_end);
+  PeerHttpResponse response;
+  std::istringstream status(headers.substr(0, headers.find("\r\n")));
+  std::string version;
+  status >> version >> response.status_code;
+  std::istringstream header_lines(headers);
+  std::string header_line;
+  bool first_header = true;
+  while (std::getline(header_lines, header_line)) {
+    if (!header_line.empty() && header_line.back() == '\r') {
+      header_line.pop_back();
+    }
+    if (first_header) {
+      first_header = false;
+      continue;
+    }
+    const std::size_t colon = header_line.find(':');
+    if (colon == std::string::npos) {
+      continue;
+    }
+    std::string key = header_line.substr(0, colon);
+    std::transform(key.begin(), key.end(), key.begin(), [](unsigned char ch) {
+      return static_cast<char>(std::tolower(ch));
+    });
+    std::string value = header_line.substr(colon + 1);
+    while (!value.empty() && value.front() == ' ') {
+      value.erase(value.begin());
+    }
+    response.headers[key] = value;
+  }
+  response.body =
+      headers_end == std::string::npos ? std::string{} : response_text.substr(headers_end + 4);
+  if (response.status_code >= 400) {
+    throw std::runtime_error(
+        "peer request failed with status " + std::to_string(response.status_code));
+  }
+  return response;
+}
+
+PeerHttpResponse SendPeerHttpRequest(
+    const std::string& endpoint,
+    const std::string& path,
+    const nlohmann::json& payload) {
+  return SendPeerHttpRawRequest(endpoint, path, payload.dump(), "application/json");
+}
+
+std::optional<std::uintmax_t> JsonUintmax(
+    const nlohmann::json& value,
+    const std::string& key) {
+  if (!value.contains(key) || !value.at(key).is_number_unsigned()) {
+    return std::nullopt;
+  }
+  return value.at(key).get<std::uintmax_t>();
+}
+
+std::string Lowercase(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return value;
+}
+
+bool FileMatchesManifest(
+    const std::string& path,
+    std::uintmax_t expected_size,
+    const std::string& expected_sha256) {
+  std::error_code error;
+  if (!std::filesystem::exists(path, error) || error ||
+      !std::filesystem::is_regular_file(path, error) || error) {
+    return false;
+  }
+  const auto size = std::filesystem::file_size(path, error);
+  if (error || size != expected_size) {
+    return false;
+  }
+  return expected_sha256.empty() ||
+         Lowercase(naim::ComputeFileSha256Hex(path)) == Lowercase(expected_sha256);
+}
+
+bool TryMaterializeAppModelMountDirectly(
+    const std::string& node_name,
+    const naim::AppModelMountSpec& mount,
+    const std::vector<std::string>& source_paths,
+    HostdBackend* backend,
+    const std::function<void(const std::string&, const std::string&, int)>& publish) {
+  if (backend == nullptr || mount.source_node_name.empty()) {
+    return false;
+  }
+
+  const nlohmann::json ticket =
+      backend->RequestFileTransferTicket(node_name, mount.source_node_name, source_paths);
+  if (ticket.value("status", std::string{}) != "issued") {
+    return false;
+  }
+  const std::string ticket_id = ticket.value("ticket_id", std::string{});
+  const std::string peer_endpoint = ticket.value("source_endpoint", std::string{});
+  if (ticket_id.empty() || peer_endpoint.empty()) {
+    return false;
+  }
+
+  publish(
+      "app-model-direct",
+      "Checking direct app model transfer from storage node " + mount.source_node_name + ".",
+      20);
+  const PeerHttpResponse manifest_response = SendPeerHttpRequest(
+      peer_endpoint,
+      "/peer/v1/files/manifest",
+      nlohmann::json{
+          {"ticket_id", ticket_id},
+          {"source_paths", source_paths},
+          {"defer_sha256", true},
+      });
+  const nlohmann::json manifest = nlohmann::json::parse(manifest_response.body, nullptr, false);
+  if (manifest.is_discarded() || manifest.value("phase", std::string{}) != "manifest-ready" ||
+      !manifest.contains("files") || !manifest.at("files").is_array()) {
+    return false;
+  }
+  const auto files = manifest.at("files").get<std::vector<nlohmann::json>>();
+  if (files.size() != 1) {
+    return false;
+  }
+  const auto expected_size = JsonUintmax(files.front(), "size_bytes");
+  if (!expected_size.has_value()) {
+    return false;
+  }
+  if (FileMatchesManifest(mount.host_path, *expected_size, files.front().value("sha256", ""))) {
+    publish("app-model-ready", "Using cached app model artifact.", 72);
+    return true;
+  }
+
+  std::error_code error;
+  std::filesystem::create_directories(std::filesystem::path(mount.host_path).parent_path(), error);
+  if (error) {
+    throw std::runtime_error("failed to create app model target directory: " + mount.host_path);
+  }
+  const std::string temp_path = mount.host_path + ".part";
+  std::filesystem::remove(temp_path, error);
+  std::ofstream output(temp_path, std::ios::binary | std::ios::trunc);
+  if (!output.is_open()) {
+    throw std::runtime_error("failed to open app model direct target: " + temp_path);
+  }
+
+  std::uintmax_t offset = 0;
+  while (offset < *expected_size) {
+    const PeerHttpResponse chunk = SendPeerHttpRequest(
+        peer_endpoint,
+        "/peer/v1/files/chunk",
+        nlohmann::json{
+            {"ticket_id", ticket_id},
+            {"source_path", files.front().value("source_path", source_paths.front())},
+            {"offset", offset},
+            {"max_bytes", kAppModelPeerChunkBytes},
+        });
+    if (chunk.body.empty() && offset < *expected_size) {
+      throw std::runtime_error("direct app model transfer returned an empty non-final chunk");
+    }
+    const auto chunk_sha256_it = chunk.headers.find("x-naim-chunk-sha256");
+    if (chunk_sha256_it != chunk.headers.end() &&
+        Lowercase(naim::ComputeSha256Hex(chunk.body)) != Lowercase(chunk_sha256_it->second)) {
+      throw std::runtime_error("direct app model transfer chunk checksum mismatch");
+    }
+    output.write(chunk.body.data(), static_cast<std::streamsize>(chunk.body.size()));
+    if (!output.good()) {
+      throw std::runtime_error("failed to write app model direct target: " + temp_path);
+    }
+    offset += chunk.body.size();
+    const int percent =
+        *expected_size > 0
+            ? 20 + static_cast<int>(
+                       (static_cast<double>(offset) / static_cast<double>(*expected_size)) * 50.0)
+            : 60;
+    publish(
+        "app-model-direct",
+        "Copying app model artifact directly from storage node " + mount.source_node_name + ".",
+        percent);
+  }
+  output.close();
+  if (!output.good()) {
+    throw std::runtime_error("failed to close app model direct target: " + temp_path);
+  }
+  std::filesystem::rename(temp_path, mount.host_path, error);
+  if (error) {
+    throw std::runtime_error("failed to finalize app model direct target: " + error.message());
+  }
+  const auto final_size = std::filesystem::file_size(mount.host_path, error);
+  if (error || final_size != *expected_size) {
+    throw std::runtime_error("direct app model transfer size mismatch: " + mount.host_path);
+  }
+  publish("app-model-ready", "App model artifact is ready.", 72);
+  return true;
+}
 
 void WriteDesiredStateSnapshot(
     const HostdDesiredStatePathSupport& path_support,
@@ -25,6 +337,277 @@ void WriteDesiredStateSnapshot(
   HostdFileSupport().WriteTextFile(
       *snapshot_path,
       naim::SerializeDesiredStateJson(desired_node_state));
+}
+
+void MaterializeAppModelMount(
+    const naim::DesiredState& desired_node_state,
+    const std::string& node_name,
+    const naim::InstanceSpec& instance,
+    const naim::AppModelMountSpec& mount,
+    HostdBackend* backend,
+    const HostdDesiredStateApplySupport::ProgressPublisher& publish_progress) {
+  if (mount.host_path.empty() || mount.mount_path.empty() || mount.source_path.empty()) {
+    if (mount.required) {
+      throw std::runtime_error(
+          "app model mount '" + mount.name + "' for instance '" + instance.name +
+          "' is missing source, host, or mount path");
+    }
+    return;
+  }
+
+  const std::vector<std::string> source_paths =
+      mount.source_paths.empty() ? std::vector<std::string>{mount.source_path}
+                                 : mount.source_paths;
+  if (source_paths.size() != 1) {
+    if (mount.required) {
+      throw std::runtime_error(
+          "app model mount '" + mount.name +
+          "' currently supports one retained file path; got " +
+          std::to_string(source_paths.size()));
+    }
+    return;
+  }
+  const std::string& source_path = source_paths.front();
+
+  auto publish = [&](const std::string& phase, const std::string& detail, int percent) {
+    if (publish_progress) {
+      publish_progress(
+          phase,
+          "Materializing app model",
+          detail,
+          percent,
+          desired_node_state.plane_name,
+          node_name);
+    }
+  };
+
+  std::error_code error;
+  if (std::filesystem::exists(source_path, error) && !error &&
+      std::filesystem::is_regular_file(source_path, error) && !error) {
+    std::filesystem::create_directories(std::filesystem::path(mount.host_path).parent_path(), error);
+    if (error) {
+      throw std::runtime_error("failed to create app model target directory: " + mount.host_path);
+    }
+    if (std::filesystem::equivalent(source_path, mount.host_path, error) && !error) {
+      return;
+    }
+    error.clear();
+    std::filesystem::copy_file(
+        source_path,
+        mount.host_path,
+        std::filesystem::copy_options::overwrite_existing,
+        error);
+    if (error) {
+      throw std::runtime_error(
+          "failed to copy local app model artifact from '" + source_path +
+          "' to '" + mount.host_path + "': " + error.message());
+    }
+    publish("app-model-ready", "Using app model artifact from local storage.", 72);
+    return;
+  }
+
+  if (backend == nullptr) {
+    if (mount.required) {
+      throw std::runtime_error(
+          "app model mount '" + mount.name +
+          "' requires controller relay because the source path is not local");
+    }
+    return;
+  }
+
+  try {
+    if (TryMaterializeAppModelMountDirectly(
+            node_name,
+            mount,
+            source_paths,
+            backend,
+            publish)) {
+      return;
+    }
+  } catch (const std::exception& direct_error) {
+    publish(
+        "app-model-relay",
+        "Direct app model transfer is unavailable; falling back to controller relay: " +
+            std::string(direct_error.what()),
+        20);
+  }
+
+  publish("app-model-manifest", "Requesting app model manifest from storage node.", 20);
+  const nlohmann::json manifest_request = backend->RequestModelArtifactManifest(
+      node_name,
+      mount.source_node_name,
+      source_paths);
+  if (manifest_request.value("status", std::string{}) != "queued") {
+    throw std::runtime_error(
+        "controller did not queue app model manifest relay: " +
+        manifest_request.value("message", std::string("unknown error")));
+  }
+  const int manifest_assignment_id = manifest_request.value("assignment_id", 0);
+  if (manifest_assignment_id <= 0) {
+    throw std::runtime_error("controller returned invalid app model manifest assignment id");
+  }
+
+  nlohmann::json manifest = nlohmann::json::object();
+  bool manifest_ready = false;
+  for (int attempt = 0; attempt < kAppModelPollAttempts; ++attempt) {
+    const nlohmann::json poll = backend->LoadModelArtifactManifest(node_name, manifest_assignment_id);
+    const std::string status = poll.value("status", std::string{});
+    if (status == "failed" || status == "superseded") {
+      throw std::runtime_error(
+          "app model manifest relay failed: " +
+          poll.value("status_message", std::string("unknown error")));
+    }
+    if (status == "applied") {
+      manifest = poll.contains("progress") && poll.at("progress").is_object()
+                     ? poll.at("progress")
+                     : nlohmann::json::object();
+      if (manifest.value("phase", std::string{}) != "manifest-ready" ||
+          !manifest.contains("files") ||
+          !manifest.at("files").is_array()) {
+        throw std::runtime_error("app model manifest relay applied without manifest payload");
+      }
+      manifest_ready = true;
+      break;
+    }
+    std::this_thread::sleep_for(kAppModelPollInterval);
+  }
+  if (!manifest_ready) {
+    throw std::runtime_error("timed out waiting for app model manifest relay");
+  }
+
+  const auto files = manifest.at("files").get<std::vector<nlohmann::json>>();
+  if (files.size() != 1) {
+    throw std::runtime_error("app model mount currently supports one manifest file");
+  }
+  const auto expected_size = JsonUintmax(files.front(), "size_bytes");
+  if (!expected_size.has_value()) {
+    throw std::runtime_error("app model manifest is missing file size metadata");
+  }
+  const std::string expected_sha256 = files.front().value("sha256", std::string{});
+  if (expected_sha256.empty()) {
+    throw std::runtime_error("app model manifest is missing file checksum metadata");
+  }
+  if (FileMatchesManifest(mount.host_path, *expected_size, expected_sha256)) {
+    publish("app-model-ready", "Using cached app model artifact.", 72);
+    return;
+  }
+
+  std::filesystem::create_directories(std::filesystem::path(mount.host_path).parent_path(), error);
+  if (error) {
+    throw std::runtime_error("failed to create app model target directory: " + mount.host_path);
+  }
+  const std::string temp_path = mount.host_path + ".part";
+  std::filesystem::remove(temp_path, error);
+  std::ofstream output(temp_path, std::ios::binary | std::ios::trunc);
+  if (!output.is_open()) {
+    throw std::runtime_error("failed to open app model relay target: " + temp_path);
+  }
+
+  std::uintmax_t offset = 0;
+  bool eof = false;
+  while (!eof) {
+    const nlohmann::json request = backend->RequestModelArtifactChunk(
+        node_name,
+        mount.source_node_name,
+        files.front().value("source_path", source_path),
+        offset,
+        kAppModelChunkBytes);
+    if (request.value("status", std::string{}) != "queued") {
+      throw std::runtime_error(
+          "controller did not queue app model chunk relay: " +
+          request.value("message", std::string("unknown error")));
+    }
+    const int chunk_assignment_id = request.value("assignment_id", 0);
+    if (chunk_assignment_id <= 0) {
+      throw std::runtime_error("controller returned invalid app model chunk assignment id");
+    }
+
+    bool chunk_ready = false;
+    for (int attempt = 0; attempt < kAppModelPollAttempts; ++attempt) {
+      const nlohmann::json poll = backend->LoadModelArtifactChunk(node_name, chunk_assignment_id);
+      const std::string status = poll.value("status", std::string{});
+      if (status == "failed" || status == "superseded") {
+        throw std::runtime_error(
+            "app model chunk relay failed: " +
+            poll.value("status_message", std::string("unknown error")));
+      }
+      if (status == "applied") {
+        const nlohmann::json progress =
+            poll.contains("progress") && poll.at("progress").is_object()
+                ? poll.at("progress")
+                : nlohmann::json::object();
+        if (progress.value("phase", std::string{}) != "chunk-ready") {
+          throw std::runtime_error("app model chunk relay applied without chunk payload");
+        }
+        const auto progress_offset = JsonUintmax(progress, "offset").value_or(offset);
+        if (progress_offset != offset) {
+          throw std::runtime_error("app model chunk relay returned an unexpected offset");
+        }
+        const std::vector<unsigned char> bytes =
+            naim::DecodeBytesBase64(progress.value("bytes_base64", std::string{}));
+        if (bytes.empty() && !progress.value("eof", false)) {
+          throw std::runtime_error("app model chunk relay returned an empty non-final chunk");
+        }
+        if (!bytes.empty()) {
+          output.write(
+              reinterpret_cast<const char*>(bytes.data()),
+              static_cast<std::streamsize>(bytes.size()));
+          if (!output.good()) {
+            throw std::runtime_error("failed to write app model relay target: " + temp_path);
+          }
+        }
+        const auto next_offset = JsonUintmax(progress, "next_offset").value_or(offset + bytes.size());
+        offset = next_offset;
+        eof = progress.value("eof", false);
+        const int percent = *expected_size > 0
+                                ? 20 + static_cast<int>((static_cast<double>(offset) /
+                                                         static_cast<double>(*expected_size)) *
+                                                        50.0)
+                                : 60;
+        publish("app-model-copy", "Copying app model artifact through controller relay.", percent);
+        chunk_ready = true;
+        break;
+      }
+      std::this_thread::sleep_for(kAppModelPollInterval);
+    }
+    if (!chunk_ready) {
+      throw std::runtime_error("timed out waiting for app model chunk relay");
+    }
+  }
+
+  output.close();
+  if (!output.good()) {
+    throw std::runtime_error("failed to close app model relay target: " + temp_path);
+  }
+  std::filesystem::rename(temp_path, mount.host_path, error);
+  if (error) {
+    throw std::runtime_error("failed to finalize app model relay target: " + error.message());
+  }
+  if (!FileMatchesManifest(mount.host_path, *expected_size, expected_sha256)) {
+    throw std::runtime_error("app model artifact checksum mismatch: " + mount.host_path);
+  }
+  publish("app-model-ready", "App model artifact is ready.", 72);
+}
+
+void MaterializeAppModelMounts(
+    const naim::DesiredState& desired_node_state,
+    const std::string& node_name,
+    HostdBackend* backend,
+    const HostdDesiredStateApplySupport::ProgressPublisher& publish_progress) {
+  for (const auto& instance : desired_node_state.instances) {
+    if (instance.node_name != node_name || instance.role != naim::InstanceRole::App) {
+      continue;
+    }
+    for (const auto& mount : instance.app_model_mounts) {
+      MaterializeAppModelMount(
+          desired_node_state,
+          node_name,
+          instance,
+          mount,
+          backend,
+          publish_progress);
+    }
+  }
 }
 
 }  // namespace
@@ -136,6 +719,11 @@ void HostdDesiredStateApplySupport::ApplyDesiredNodeState(
         storage_root,
         runtime_root,
         "disk runtime verified by hostd");
+    MaterializeAppModelMounts(
+        desired_node_state,
+        node_name,
+        backend,
+        maybe_publish_progress);
     if (HostdDesiredStateApplyPlanSupport::IsDesiredNodeStateEmpty(desired_node_state)) {
       local_state_repository_.RemoveLocalAppliedPlaneState(
           state_root,
@@ -177,6 +765,11 @@ void HostdDesiredStateApplySupport::ApplyDesiredNodeState(
       node_name,
       backend,
       assignment_id);
+  MaterializeAppModelMounts(
+      desired_node_state,
+      node_name,
+      backend,
+      maybe_publish_progress);
 
   apply_plan_support_.ApplyNodePlan(
       execution_plan,

--- a/hostd/src/app/hostd_desired_state_path_support.cpp
+++ b/hostd/src/app/hostd_desired_state_path_support.cpp
@@ -75,6 +75,15 @@ naim::DesiredState HostdDesiredStatePathSupport::RebaseStateForRuntimeRoot(
         naim::IsNodeLocalDiskKind(disk.kind) ? std::optional<std::string>(disk.node_name)
                                               : std::nullopt);
   }
+  for (auto& instance : state.instances) {
+    for (auto& model_mount : instance.app_model_mounts) {
+      model_mount.host_path = RebaseManagedPath(
+          model_mount.host_path,
+          storage_root,
+          runtime_root,
+          instance.node_name);
+    }
+  }
   return state;
 }
 


### PR DESCRIPTION
## Summary
- add desired-state app model attachments and read-only compose mounts
- materialize app model artifacts through local, peer direct, or controller relay paths
- classify whisper.cpp ggml bin models in Model Library

## Tests
- hpc1: cmake --build build/linux/x64 --target naim-state-v2-tests naim-state-v2-projector-tests naim-model-library-tests naim-hostd-desired-state-apply-support-tests -j 24
- hpc1: ./naim-state-v2-tests && ./naim-state-v2-projector-tests && ./naim-model-library-tests && ./naim-hostd-desired-state-apply-support-tests