### PR TITLE
Fix New plane local node defaults

### DIFF
--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -13,7 +13,9 @@ import {
 } from "recharts";
 import {
   buildDesiredStateV2FromForm,
+  buildHostNodeOptions,
   buildNewPlaneFormState,
+  buildNewPlaneFormStateWithNodes,
   buildPlaneFormStateFromDesiredStateV2,
   isDesiredStateV2,
   PlaneV2FormBuilder,
@@ -3127,7 +3129,22 @@ function App() {
     setApiError("");
     try {
       if (mode === "new") {
-        const form = buildNewPlaneFormState();
+        let latestHostdHosts = hostdHosts || [];
+        if (!Array.isArray(latestHostdHosts) || latestHostdHosts.length === 0) {
+          try {
+            const hostdHostsPayload = await fetchJson(hostdHostsPath());
+            latestHostdHosts = Array.isArray(hostdHostsPayload.items) ? hostdHostsPayload.items : [];
+            setHostdHosts(latestHostdHosts);
+          } catch {
+            latestHostdHosts = [];
+          }
+        }
+        const form = buildNewPlaneFormStateWithNodes(
+          buildHostNodeOptions([
+            ...(Array.isArray(latestHostdHosts) ? latestHostdHosts : []),
+            ...(Array.isArray(modelLibrary.nodes) ? modelLibrary.nodes : []),
+          ]),
+        );
         setPlaneDialog({
           open: true,
           mode,
@@ -3868,6 +3885,10 @@ function App() {
   const visibleModelItems = (modelLibrary.items || []).slice(0, visibleModelCount);
   const hasMoreModelItems = activeModelCount > visibleModelCount;
   const modelLibraryNodes = Array.isArray(modelLibrary.nodes) ? modelLibrary.nodes : [];
+  const planeNodeOptions = buildHostNodeOptions([
+    ...(Array.isArray(hostdHosts) ? hostdHosts : []),
+    ...modelLibraryNodes,
+  ]);
   const storageModelNodes = eligibleModelStorageNodes(modelLibraryNodes);
   const modelLibraryJobs = Array.isArray(modelLibrary.jobs) ? modelLibrary.jobs : [];
   const downloadModelJobs = modelLibraryJobs.filter(
@@ -7914,7 +7935,7 @@ function App() {
         }
         onSave={savePlaneDialog}
         modelLibraryItems={modelLibrary.items || []}
-        hostdHosts={hostdHosts || []}
+        hostdHosts={planeNodeOptions}
         peerLinks={dashboard?.peer_links || null}
         skillsFactoryItems={skillsFactory.items || []}
         skillsFactoryGroups={skillsFactory.groups || []}

--- a/ui/operator-react/src/planeV2Form.jsx
+++ b/ui/operator-react/src/planeV2Form.jsx
@@ -376,7 +376,7 @@ function hostHasStorageCapability(host) {
   return (
     roles.includes("storage") ||
     host?.role_eligible === true ||
-    Boolean(host?.storage_root || host?.capabilities?.storage_root)
+    Boolean(host?.storage_root || host?.capabilities?.storage_root || host?.capacity_summary?.storage_root)
   );
 }
 
@@ -391,6 +391,28 @@ function hostHasExecutionCapability(host) {
   );
 }
 
+function hostPurposeRank(host, purpose) {
+  const roles = hostRoles(host);
+  if (purpose === "storage") {
+    if (roles.includes("storage") || host?.storage_role_enabled === true) {
+      return 0;
+    }
+    if (Boolean(host?.storage_root || host?.capabilities?.storage_root || host?.capacity_summary?.storage_root)) {
+      return 1;
+    }
+    return 2;
+  }
+  if (
+    roles.includes("worker") ||
+    roles.includes("infer") ||
+    roles.includes("compute") ||
+    hostGpuCount(host) > 0
+  ) {
+    return 0;
+  }
+  return 1;
+}
+
 export function chooseDefaultPlaneNode(hostdHosts, purpose = "execution") {
   const hosts = buildHostNodeOptions(hostdHosts);
   const connectedLocal = hosts.find((host) => hostConnected(host) && isLocalNodeName(hostName(host)));
@@ -400,7 +422,16 @@ export function chooseDefaultPlaneNode(hostdHosts, purpose = "execution") {
   const matchesPurpose = (host) =>
     purpose === "storage" ? hostHasStorageCapability(host) : hostHasExecutionCapability(host);
   const candidates = hosts.filter(matchesPurpose);
-  const connectedCandidates = candidates.filter(hostConnected);
+  const connectedCandidates = candidates
+    .filter(hostConnected)
+    .sort((left, right) => {
+      const leftRank = hostPurposeRank(left, purpose);
+      const rightRank = hostPurposeRank(right, purpose);
+      if (leftRank !== rightRank) {
+        return leftRank - rightRank;
+      }
+      return hostName(left).localeCompare(hostName(right));
+    });
   if (connectedCandidates.length > 0) {
     return hostName(connectedCandidates[0]);
   }
@@ -444,8 +475,11 @@ function applyLtCypherPresetToForm(form, modelLibraryItems, hostdHosts = []) {
   const sourcePath = String(modelItem?.path || sourcePaths[0] || form.modelPath || "").trim();
   const sourceFormat = inferModelFormat(modelItem) || "gguf";
   const sourceQuantization = inferModelQuantization(modelItem) || "Q8_0";
-  const storageNode = normalizeNodeName(modelItem?.node_name) || chooseDefaultPlaneNode(hostdHosts, "storage");
-  const executionNode = chooseDefaultPlaneNode(hostdHosts, "execution");
+  const executionNode = normalizeNodeName(form.executionNode) || chooseDefaultPlaneNode(hostdHosts, "execution");
+  const storageNode =
+    normalizeNodeName(form.materializationSourceNodeName) ||
+    chooseDefaultPlaneNode(hostdHosts, "storage") ||
+    normalizeNodeName(modelItem?.node_name);
   const appEnv = {
     CYPHER_ACTION_AUDIT_LOG_FILE: "/naim/private/action-audit.log",
     CYPHER_API_BASE: "http://interaction-lt-cypher-ai:18110/v1",
@@ -507,7 +541,7 @@ function applyLtCypherPresetToForm(form, modelLibraryItems, hostdHosts = []) {
     inferNode: "",
     workerNode: "",
     appNode: "",
-    workerGpuDevice: "0",
+    workerGpuDevice: form.workerGpuDevice || "0",
     workerAssignmentsEnabled: false,
     workerAssignments: [],
     placementMode: "manual",
@@ -783,6 +817,18 @@ export function buildNewPlaneFormState() {
     sharedDiskGb: 40,
     postDeployScript: "bundle://deploy/scripts/post-deploy.sh",
   });
+}
+
+export function buildNewPlaneFormStateWithNodes(hostdHosts = []) {
+  const form = buildNewPlaneFormState();
+  const executionNode = chooseDefaultPlaneNode(hostdHosts, "execution");
+  const storageNode = chooseDefaultPlaneNode(hostdHosts, "storage");
+  return {
+    ...form,
+    executionNode,
+    materializationSourceNodeName: storageNode,
+    modelWritebackTargetNodeName: storageNode,
+  };
 }
 
 export function buildPlaneFormStateFromDesiredStateV2(value) {
@@ -1691,6 +1737,12 @@ function hostRoles(host) {
   if (host?.role) {
     roles.push(host.role);
   }
+  if (host?.derived_role) {
+    roles.push(host.derived_role);
+  }
+  if (host?.storage_role_enabled) {
+    roles.push("storage");
+  }
   if (host?.is_worker || host?.worker) {
     roles.push("Worker");
   }
@@ -1728,10 +1780,22 @@ function hostConnected(host) {
     return false;
   }
   const state = String(host.state || host.status || host.health || "").toLowerCase();
-  if (["offline", "missing", "stale", "critical", "error"].includes(state)) {
+  const sessionState = String(host.session_state || "").toLowerCase();
+  if (
+    ["offline", "missing", "stale", "critical", "error"].includes(state) ||
+    ["offline", "missing", "stale", "disconnected", "expired"].includes(sessionState)
+  ) {
     return false;
   }
-  return host.connected === true || host.ready === true || state === "connected" || state === "ready" || Boolean(host.last_seen_at || host.updated_at);
+  return (
+    host.connected === true ||
+    host.ready === true ||
+    state === "connected" ||
+    state === "ready" ||
+    state === "online" ||
+    sessionState === "connected" ||
+    Boolean(host.last_seen_at || host.updated_at || host.last_heartbeat_at || host.last_session_at)
+  );
 }
 
 function peerLinkIsDirect(peerLinks, leftNode, rightNode) {

--- a/ui/operator-react/src/skillsFactory.test.js
+++ b/ui/operator-react/src/skillsFactory.test.js
@@ -6,6 +6,7 @@ import {
   buildDesiredStateV2FromForm,
   buildHostNodeOptions,
   buildNewPlaneFormState,
+  buildNewPlaneFormStateWithNodes,
   buildPlaneFormStateFromDesiredStateV2,
   chooseDefaultPlaneNode,
   validatePlaneV2Form,
@@ -447,6 +448,36 @@ describe("planeV2Form SkillsFactory mapping", () => {
 
     expect(chooseDefaultPlaneNode(hosts, "execution")).toBe("local-hostd");
     expect(chooseDefaultPlaneNode(hosts, "storage")).toBe("local-hostd");
+  });
+
+  it("uses role-specific defaults for distributed production nodes", () => {
+    const hosts = [
+      {
+        node_name: "hpc1",
+        session_state: "connected",
+        derived_role: "worker",
+        capacity_summary: {
+          gpu_count: 4,
+          storage_root: "/mnt/shared-storage/naim/storage",
+        },
+      },
+      {
+        node_name: "storage1",
+        session_state: "connected",
+        derived_role: "storage",
+        capacity_summary: {
+          gpu_count: 0,
+          storage_root: "/mnt/array/naim/storage",
+        },
+      },
+    ];
+
+    expect(chooseDefaultPlaneNode(hosts, "execution")).toBe("hpc1");
+    expect(chooseDefaultPlaneNode(hosts, "storage")).toBe("storage1");
+
+    const form = buildNewPlaneFormStateWithNodes(hosts);
+    expect(form.executionNode).toBe("hpc1");
+    expect(form.materializationSourceNodeName).toBe("storage1");
   });
 
   it("does not emit legacy node-placement fields when topology is disabled", () => {


### PR DESCRIPTION
## Summary
- hydrate New plane defaults from fresh hostd/model-library node data when opening the editor
- treat session_state and derived_role from real controller APIs as node readiness/role signals
- preserve selected local storage/execution nodes when applying the lt-cypher-ai preset instead of forcing artifact node defaults
- add regression coverage for local hostd-node/local-hostd and distributed hpc1/storage1 defaults

## Browser validation
- opened production Web UI through SSH tunnel with Playwright
- reproduced current deployed issue: Apply lt-cypher-ai preset sets storage1/hpc1
- verified fixed source against real production API: hpc1/storage1 selected only when production API reports those roles
- verified fixed source against local single-node API shape: storage/execution stay hostd-node after Apply preset and generated JSON uses hostd-node

## Tests
- npm test -- skillsFactory.test.js
- npm run build