### PR TITLE
Improve New plane validation timing

### DIFF
--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -1203,7 +1203,8 @@ export function PlaneEditorDialog({
 
   const readOnly = dialog.mode === "view";
   const showFormBuilder = !readOnly && Boolean(dialog.form);
-  const formValidation = showFormBuilder
+  const showValidation = Boolean(dialog.showValidation);
+  const formValidation = showFormBuilder && showValidation
     ? validatePlaneV2Form(dialog.form || buildNewPlaneFormState())
     : { errors: [], warnings: [] };
   const desiredStateLabel = showFormBuilder
@@ -1280,6 +1281,7 @@ export function PlaneEditorDialog({
               peerLinks={peerLinks || null}
               skillsFactoryItems={skillsFactoryItems || []}
               skillsFactoryGroups={skillsFactoryGroups || []}
+              showValidation={showValidation}
               onResetLtCypherDeployment={onResetLtCypherDeployment}
             />
           ) : null}
@@ -2055,6 +2057,7 @@ function App() {
     text: "",
     form: null,
     originalSkillsEnabled: false,
+    showValidation: false,
     busy: false,
     error: "",
   });
@@ -3153,6 +3156,7 @@ function App() {
           text: JSON.stringify(buildDesiredStateV2FromForm(form), null, 2),
           form,
           originalSkillsEnabled: false,
+          showValidation: false,
           busy: false,
           error: "",
         });
@@ -3172,6 +3176,7 @@ function App() {
           ? buildPlaneFormStateFromDesiredStateV2(payload.desired_state_v2)
           : null,
         originalSkillsEnabled: Boolean(payload?.desired_state_v2?.skills?.enabled),
+        showValidation: false,
         busy: false,
         error: "",
       });
@@ -3181,7 +3186,7 @@ function App() {
   }
 
   async function savePlaneDialog() {
-    setPlaneDialog((current) => ({ ...current, busy: true, error: "" }));
+    setPlaneDialog((current) => ({ ...current, busy: true, error: "", showValidation: true }));
     try {
       if (planeDialog.form) {
         const validation = validatePlaneV2Form(planeDialog.form);
@@ -3252,6 +3257,7 @@ function App() {
         text: "",
         form: null,
         originalSkillsEnabled: false,
+        showValidation: false,
         busy: false,
         error: "",
       });
@@ -7929,6 +7935,7 @@ function App() {
             text: "",
             form: null,
             originalSkillsEnabled: false,
+            showValidation: false,
             busy: false,
             error: "",
           })

--- a/ui/operator-react/src/planeV2Form.jsx
+++ b/ui/operator-react/src/planeV2Form.jsx
@@ -1598,6 +1598,7 @@ export function updatePlaneDialogForm(setDialog, update) {
       ...current,
       form: nextForm,
       text: JSON.stringify(buildDesiredStateV2FromForm(nextForm), null, 2),
+      error: "",
     };
   });
 }
@@ -2014,10 +2015,12 @@ export function PlaneV2FormBuilder({
   skillsFactoryGroups = [],
   hostdHosts = [],
   peerLinks = null,
+  showValidation = false,
   onResetLtCypherDeployment,
 }) {
   const form = dialog.form || buildNewPlaneFormState();
-  const validation = validatePlaneV2Form(form);
+  const rawValidation = validatePlaneV2Form(form);
+  const validation = showValidation ? rawValidation : { errors: [], warnings: [] };
   const [ltCypherPreflight, setLtCypherPreflight] = useState(null);
   const [factorySkillFilter, setFactorySkillFilter] = useState("");
   const [knowledgeSelectorOpen, setKnowledgeSelectorOpen] = useState(false);

--- a/ui/operator-react/src/skillsFactory.test.js
+++ b/ui/operator-react/src/skillsFactory.test.js
@@ -9,6 +9,7 @@ import {
   buildNewPlaneFormStateWithNodes,
   buildPlaneFormStateFromDesiredStateV2,
   chooseDefaultPlaneNode,
+  updatePlaneDialogForm,
   validatePlaneV2Form,
 } from "./planeV2Form.jsx";
 import { PlaneEditorDialog } from "./App.jsx";
@@ -142,6 +143,25 @@ describe("planeV2Form SkillsFactory mapping", () => {
 
     const reparsed = buildPlaneFormStateFromDesiredStateV2(desiredState);
     expect(reparsed.factorySkillIds).toEqual(["skill-alpha", "skill-beta"]);
+  });
+
+  it("clears stale plane dialog errors when the form changes", () => {
+    let dialog = {
+      form: buildNewPlaneFormState(),
+      text: "",
+      error: "Model Library selection is required when model source type is library.",
+    };
+    const setDialog = (updater) => {
+      dialog = typeof updater === "function" ? updater(dialog) : updater;
+    };
+
+    updatePlaneDialogForm(setDialog, (current) => ({
+      ...current,
+      planeName: "updated-plane",
+    }));
+
+    expect(dialog.error).toBe("");
+    expect(dialog.text).toContain('"plane_name": "updated-plane"');
   });
 
   it("warns when factory selections exist while Skills is disabled", () => {


### PR DESCRIPTION
## Summary
- hide New plane validation errors until the user attempts to save
- keep form validation active after a failed save, but clear stale dialog errors on form changes
- add a regression test for stale error clearing

## Validation
- npm test -- skillsFactory.test.js
- npm run build
- Playwright against local Vite UI with production API proxy: New plane opens with storage1/hpc1, zero validation errors, zero layout overflow; lt-cypher-ai preset applies storage1/hpc1 and model path without errors