### PR TITLE
Repair hpc1 shared git permissions before fetch

### DIFF
--- a/.github/workflows/naim-production-release.yml
+++ b/.github/workflows/naim-production-release.yml
@@ -56,6 +56,27 @@ jobs:
             "cd ${repo_q} && NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_RELEASE_BRANCH='${NAIM_RELEASE_BRANCH}' bash -s" <<'REMOTE'
           set -euo pipefail
 
+          ensure_shared_git_permissions() {
+            local git_dir
+            local group_name
+
+            git_dir="$(git rev-parse --git-dir)"
+            group_name="$(id -gn)"
+
+            git config core.sharedRepository group >/dev/null 2>&1 || true
+            git config core.filemode false >/dev/null 2>&1 || true
+
+            if sudo -n true >/dev/null 2>&1; then
+              sudo chgrp -R "${group_name}" "${git_dir}" || true
+              sudo chmod -R g+rwX "${git_dir}" || true
+              sudo find "${git_dir}" -type d -exec chmod g+s {} + || true
+            else
+              chgrp -R "${group_name}" "${git_dir}" 2>/dev/null || true
+              chmod -R g+rwX "${git_dir}" 2>/dev/null || true
+              find "${git_dir}" -type d -exec chmod g+s {} + 2>/dev/null || true
+            fi
+          }
+
           retry_git_fetch() {
             local remote="$1"
             local branch="$2"
@@ -79,6 +100,7 @@ jobs:
           }
 
           git config http.version HTTP/1.1 >/dev/null 2>&1 || true
+          ensure_shared_git_permissions
           retry_git_fetch origin "${NAIM_RELEASE_BRANCH}"
 
           if git show-ref --verify --quiet "refs/heads/${NAIM_RELEASE_BRANCH}"; then

--- a/scripts/ci/hpc1-pull-main.sh
+++ b/scripts/ci/hpc1-pull-main.sh
@@ -4,6 +4,27 @@ set -euo pipefail
 : "${NAIM_RELEASE_SHA:?NAIM_RELEASE_SHA is required}"
 : "${NAIM_RELEASE_BRANCH:=main}"
 
+naim_ci_ensure_shared_git_permissions() {
+  local git_dir
+  local group_name
+
+  git_dir="$(git rev-parse --git-dir)"
+  group_name="$(id -gn)"
+
+  git config core.sharedRepository group >/dev/null 2>&1 || true
+  git config core.filemode false >/dev/null 2>&1 || true
+
+  if sudo -n true >/dev/null 2>&1; then
+    sudo chgrp -R "${group_name}" "${git_dir}" || true
+    sudo chmod -R g+rwX "${git_dir}" || true
+    sudo find "${git_dir}" -type d -exec chmod g+s {} + || true
+  else
+    chgrp -R "${group_name}" "${git_dir}" 2>/dev/null || true
+    chmod -R g+rwX "${git_dir}" 2>/dev/null || true
+    find "${git_dir}" -type d -exec chmod g+s {} + 2>/dev/null || true
+  fi
+}
+
 naim_ci_retry_git_fetch() {
   local remote="$1"
   local branch="$2"
@@ -27,6 +48,7 @@ naim_ci_retry_git_fetch() {
 }
 
 git config http.version HTTP/1.1 >/dev/null 2>&1 || true
+naim_ci_ensure_shared_git_permissions
 naim_ci_retry_git_fetch origin "${NAIM_RELEASE_BRANCH}"
 
 # This checkout is dedicated to CI builds, so local tracked changes are disposable.


### PR DESCRIPTION
## Summary
- configure the hpc1 release checkout as a group-shared git repository before fetching
- repair .git group ownership, group write bits, and setgid directory bits before each production pull
- mirror the same repair logic in scripts/ci/hpc1-pull-main.sh

## Root cause
The shared hpc1 checkout is touched by both baal and naim-deploy. Some .git/objects/XX directories were created without group write, so CI running as naim-deploy could not add objects even though baal could fetch manually.

## Validation
- fixed the live hpc1 checkout: core.sharedRepository=group, core.filemode=false, all .git/objects directories group-writable
- deliberately removed g+w from .git/objects/55, then ran the repair+git fetch path as naim-deploy; fetch succeeded and permissions were restored
- bash -n scripts/ci/hpc1-pull-main.sh
- git diff --check