### PR TITLE
Avoid unconditional skills runtime probe in interaction resolution

### DIFF
--- a/controller/src/interaction/interaction_service.cpp
+++ b/controller/src/interaction/interaction_service.cpp
@@ -1947,9 +1947,11 @@ PlaneInteractionResolution InteractionPlaneResolver::Resolve(
   const PlaneSkillsService skills_service;
   const bool skills_enabled = skills_service.IsEnabled(*desired_state);
   const auto skills_target = skills_service.ResolveTarget(*desired_state);
+  // Do not probe the skills runtime while resolving the interaction target.
+  // Request-time skill resolution performs the runtime health check only when
+  // auto skills or explicit skill ids are actually requested.
   const bool skills_ready =
-      skills_enabled && running_plane && skills_target.has_value() &&
-      skills_service.ProbeTargetOk(db_path, *desired_state, "/health");
+      skills_enabled && running_plane && skills_target.has_value();
   const auto skills_instance = std::find_if(
       desired_state->instances.begin(),
       desired_state->instances.end(),


### PR DESCRIPTION
## Summary
- stop probing plane skills runtime during generic interaction target resolution
- keep skills runtime health checks inside request-time skill resolution only when auto skills or explicit skill ids are requested
- aligns interaction hot path with plane-owned SkillsFactory trigger rule

## Checks
- hpc1: cmake --build /tmp/naim-node-skills-hourly-build --target naim-controller naim-plane-skills-tests naim-interaction-stream-http-request-preparation-service-tests -j 24
- hpc1: /tmp/naim-node-skills-hourly-build/naim-plane-skills-tests
- hpc1: /tmp/naim-node-skills-hourly-build/naim-interaction-stream-http-request-preparation-service-tests