### PR TITLE
Add Voice Listener plane feature

### DIFF
--- a/common/include/naim/state/desired_state_v2_projector.h
+++ b/common/include/naim/state/desired_state_v2_projector.h
@@ -31,6 +31,7 @@ class DesiredStateV2Projector final {
   void ProjectSkills();
   void ProjectBrowsing();
   void ProjectKnowledge();
+  void ProjectVoiceListener();
   void ProjectResources();
 
   bool ShouldEmitTopology() const;
@@ -56,6 +57,7 @@ class DesiredStateV2Projector final {
   std::vector<const InstanceSpec*> app_instances_;
   const InstanceSpec* skills_instance_ = nullptr;
   const InstanceSpec* browsing_instance_ = nullptr;
+  const InstanceSpec* voice_module_instance_ = nullptr;
   std::vector<const InstanceSpec*> worker_instances_;
   const DiskSpec* shared_disk_ = nullptr;
 };

--- a/common/include/naim/state/desired_state_v2_projector_support.h
+++ b/common/include/naim/state/desired_state_v2_projector_support.h
@@ -18,12 +18,14 @@ class DesiredStateV2ProjectorSupport {
   static constexpr int kDefaultAppPrivateDiskSizeGb = 8;
   static constexpr int kDefaultSkillsPrivateDiskSizeGb = 1;
   static constexpr int kDefaultWebGatewayPrivateDiskSizeGb = 1;
+  static constexpr int kDefaultVoiceModulePrivateDiskSizeGb = 1;
 
   static constexpr std::string_view kDefaultInferImage = "naim/infer-runtime:dev";
   static constexpr std::string_view kDefaultWorkerImage = "naim/worker-runtime:dev";
   static constexpr std::string_view kDefaultSkillsImage = "naim/skills-runtime:dev";
   static constexpr std::string_view kDefaultWebGatewayImage =
       "naim/webgateway-runtime:dev";
+  static constexpr std::string_view kDefaultVoiceModuleImage = "naim/voice-module:dev";
 
   static constexpr std::string_view kDefaultInferCommand =
       "/runtime/bin/naim-inferctl container-boot";
@@ -33,6 +35,8 @@ class DesiredStateV2ProjectorSupport {
       "/runtime/bin/naim-skillsd";
   static constexpr std::string_view kDefaultWebGatewayCommand =
       "/runtime/bin/naim-webgatewayd";
+  static constexpr std::string_view kDefaultVoiceModuleCommand =
+      "/runtime/bin/naim-voice-moduled";
 
   static nlohmann::json ProjectServiceStart(
       const InstanceSpec& instance,

--- a/common/include/naim/state/desired_state_v2_renderer.h
+++ b/common/include/naim/state/desired_state_v2_renderer.h
@@ -31,6 +31,7 @@ class DesiredStateV2Renderer final {
   void RenderSkillsInstance();
   void RenderWebGatewayInstance();
   void RenderInteractionInstance();
+  void RenderVoiceModuleInstance();
 
   bool InferEnabled() const;
   int InferReplicaCount() const;
@@ -62,12 +63,14 @@ class DesiredStateV2Renderer final {
   std::string BuildSkillsInstanceName() const;
   std::string BuildWebGatewayInstanceName() const;
   std::string BuildInteractionInstanceName() const;
+  std::string BuildVoiceModuleInstanceName() const;
   int BuildInferApiPort(int infer_index) const;
   int BuildInferGatewayPort(int infer_index) const;
   int BuildInferLlamaPort(int infer_index) const;
   int BuildSkillsHostPort() const;
   int BuildWebGatewayHostPort() const;
   int BuildInteractionHostPort() const;
+  int BuildVoiceModuleHostPort() const;
   std::string BuildReplicaUpstreams(const std::vector<InstanceSpec>& infer_instances) const;
   std::string InferInstanceNameForWorker(int worker_index) const;
   std::string BuildPlaneSharedHostPath() const;

--- a/common/include/naim/state/models.h
+++ b/common/include/naim/state/models.h
@@ -15,6 +15,7 @@ enum class InstanceRole {
   Skills,
   Browsing,
   Interaction,
+  VoiceModule,
 };
 
 enum class DiskKind {
@@ -25,6 +26,7 @@ enum class DiskKind {
   SkillsPrivate,
   BrowsingPrivate,
   InteractionPrivate,
+  VoiceModulePrivate,
 };
 
 inline bool IsPrivateDiskKind(DiskKind kind) {
@@ -33,7 +35,8 @@ inline bool IsPrivateDiskKind(DiskKind kind) {
          kind == DiskKind::AppPrivate ||
          kind == DiskKind::SkillsPrivate ||
          kind == DiskKind::BrowsingPrivate ||
-         kind == DiskKind::InteractionPrivate;
+         kind == DiskKind::InteractionPrivate ||
+         kind == DiskKind::VoiceModulePrivate;
 }
 
 inline bool IsNodeLocalDiskKind(DiskKind kind) {
@@ -52,7 +55,8 @@ inline bool InstanceNeedsPrivateDisk(InstanceRole role) {
          role == InstanceRole::App ||
          role == InstanceRole::Skills ||
          role == InstanceRole::Browsing ||
-         role == InstanceRole::Interaction;
+         role == InstanceRole::Interaction ||
+         role == InstanceRole::VoiceModule;
 }
 
 struct PublishedPort {
@@ -345,6 +349,14 @@ struct ContextCompressionFeatureSpec {
   std::string memory_priority = "balanced";
 };
 
+struct VoiceListenerFeatureSpec {
+  bool enabled = false;
+  std::string wake_phrase = "Hey Jex";
+  std::string language = "auto";
+  AppModelMountSpec model;
+  std::optional<std::string> image;
+};
+
 using WebGatewayPolicySettings = BrowsingPolicySettings;
 using WebGatewaySettings = BrowsingSettings;
 
@@ -370,6 +382,7 @@ struct DesiredState {
   std::optional<KnowledgeSettings> knowledge;
   std::optional<TurboQuantFeatureSpec> turboquant;
   std::optional<ContextCompressionFeatureSpec> context_compression;
+  std::optional<VoiceListenerFeatureSpec> voice_listener;
   std::optional<ExternalAppHostConfig> app_host;
   InferenceRuntimeSettings inference;
   WorkerGroupSpec worker_group;

--- a/common/src/planning/planner.cpp
+++ b/common/src/planning/planner.cpp
@@ -274,9 +274,11 @@ ComposeService BuildComposeService(
                               "http://127.0.0.1:$${NAIM_INFERENCE_PORT:-8000}/health"
                             : (instance.role == InstanceRole::App
                                    ? "CMD-SHELL curl -fsS http://127.0.0.1:$${PORT:-8080}/health >/dev/null"
-                                   : (instance.role == InstanceRole::Skills
-                                          ? "CMD-SHELL test -f /tmp/naim-ready"
-                                          : "CMD-SHELL test -f /tmp/naim-ready"));
+                                   : (instance.role == InstanceRole::VoiceModule
+                                          ? "CMD-SHELL curl -fsS http://127.0.0.1:$${NAIM_VOICE_MODULE_PORT:-18140}/health >/dev/null"
+                                          : (instance.role == InstanceRole::Skills
+                                                 ? "CMD-SHELL test -f /tmp/naim-ready"
+                                                 : "CMD-SHELL test -f /tmp/naim-ready")));
   if (instance.role == InstanceRole::Infer) {
     const int infer_api_port = InferApiPort(state, instance);
     const int infer_gateway_port = InferGatewayPort(state, instance);
@@ -376,6 +378,8 @@ std::string ToString(InstanceRole role) {
       return "webgateway";
     case InstanceRole::Interaction:
       return "interaction";
+    case InstanceRole::VoiceModule:
+      return "voice-module";
   }
   return "unknown";
 }
@@ -396,6 +400,8 @@ std::string ToString(DiskKind kind) {
       return "webgateway-private";
     case DiskKind::InteractionPrivate:
       return "interaction-private";
+    case DiskKind::VoiceModulePrivate:
+      return "voice-module-private";
   }
   return "unknown";
 }

--- a/common/src/state/desired_state_v2_projector.cpp
+++ b/common/src/state/desired_state_v2_projector.cpp
@@ -54,6 +54,7 @@ nlohmann::json DesiredStateV2Projector::ProjectJson() {
   ProjectSkills();
   ProjectBrowsing();
   ProjectKnowledge();
+  ProjectVoiceListener();
   ProjectResources();
   return value_;
 }
@@ -64,6 +65,7 @@ void DesiredStateV2Projector::CollectInstancesAndDisks() {
   app_instances_ = FindInstances(InstanceRole::App);
   skills_instance_ = FindInstance(InstanceRole::Skills);
   browsing_instance_ = FindInstance(InstanceRole::Browsing);
+  voice_module_instance_ = FindInstance(InstanceRole::VoiceModule);
   worker_instances_ = FindWorkerInstances();
   shared_disk_ = FindSharedDisk();
 }
@@ -107,7 +109,8 @@ void DesiredStateV2Projector::ProjectPlacement() {
 }
 
 void DesiredStateV2Projector::ProjectFeatures() {
-  if (!state_.turboquant.has_value() && !state_.context_compression.has_value()) {
+  if (!state_.turboquant.has_value() && !state_.context_compression.has_value() &&
+      !state_.voice_listener.has_value()) {
     return;
   }
   nlohmann::json features = nlohmann::json::object();
@@ -130,6 +133,42 @@ void DesiredStateV2Projector::ProjectFeatures() {
         {"target", state_.context_compression->target},
         {"memory_priority", state_.context_compression->memory_priority},
     };
+  }
+  if (state_.voice_listener.has_value()) {
+    const auto& voice = *state_.voice_listener;
+    nlohmann::json source = {
+        {"type", "library"},
+        {"path", voice.model.source_path},
+    };
+    if (!voice.model.source_node_name.empty()) {
+      source["node"] = voice.model.source_node_name;
+    }
+    if (!voice.model.source_paths.empty() &&
+        !(voice.model.source_paths.size() == 1 &&
+          voice.model.source_paths.front() == voice.model.source_path)) {
+      source["paths"] = voice.model.source_paths;
+    }
+    nlohmann::json model = {
+        {"name", voice.model.name.empty() ? std::string("whisper") : voice.model.name},
+        {"source", std::move(source)},
+        {"mount_path", voice.model.mount_path},
+        {"env", voice.model.env_var.empty() ? std::string("WHISPER_MODEL_PATH")
+                                             : voice.model.env_var},
+        {"required", voice.model.required},
+    };
+    nlohmann::json voice_json = {
+        {"enabled", voice.enabled},
+        {"wake_phrase", voice.wake_phrase},
+        {"language", voice.language},
+        {"model", std::move(model)},
+    };
+    if (voice.image.has_value() && !voice.image->empty()) {
+      voice_json["image"] = *voice.image;
+    } else if (voice_module_instance_ != nullptr &&
+               voice_module_instance_->image != ProjectorSupport::kDefaultVoiceModuleImage) {
+      voice_json["image"] = voice_module_instance_->image;
+    }
+    features["voice_listener"] = std::move(voice_json);
   }
   value_["features"] = std::move(features);
 }
@@ -642,6 +681,39 @@ void DesiredStateV2Projector::ProjectBrowsing() {
     browsing["storage"] = storage;
   }
   value_["webgateway"] = std::move(browsing);
+}
+
+void DesiredStateV2Projector::ProjectVoiceListener() {
+  if (!state_.voice_listener.has_value() || voice_module_instance_ == nullptr) {
+    return;
+  }
+  if (!value_.contains("features") || !value_.at("features").is_object()) {
+    return;
+  }
+  auto& voice_json = value_["features"]["voice_listener"];
+  const auto start = ProjectorSupport::ProjectServiceStart(
+      *voice_module_instance_,
+      std::string(ProjectorSupport::kDefaultVoiceModuleCommand));
+  if (!start.is_null()) {
+    voice_json["start"] = start;
+  }
+  auto env = ProjectorSupport::ProjectCustomEnv(*voice_module_instance_, true);
+  env.erase("WHISPER_MODEL_PATH");
+  if (!env.empty()) {
+    voice_json["env"] = env;
+  }
+  const auto publish = ProjectorSupport::ProjectPublishedPorts(*voice_module_instance_);
+  if (!publish.empty()) {
+    voice_json["publish"] = publish;
+  }
+  if (voice_module_instance_->node_name != DefaultNodeName()) {
+    voice_json["node"] = voice_module_instance_->node_name;
+  }
+  const auto storage = ProjectorSupport::ProjectServiceStorage(
+      FindDiskByName(voice_module_instance_->private_disk_name));
+  if (!storage.is_null()) {
+    voice_json["storage"] = storage;
+  }
 }
 
 void DesiredStateV2Projector::ProjectResources() {

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -24,6 +24,7 @@ constexpr int kDefaultAppPrivateDiskSizeGb = 8;
 constexpr int kDefaultSkillsPrivateDiskSizeGb = 1;
 constexpr int kDefaultWebGatewayPrivateDiskSizeGb = 1;
 constexpr int kDefaultInteractionPrivateDiskSizeGb = 1;
+constexpr int kDefaultVoiceModulePrivateDiskSizeGb = 1;
 constexpr int kSkillsContainerPort = 18120;
 constexpr int kSkillsPublishedPortBase = 24000;
 constexpr int kSkillsPublishedPortSpan = 10000;
@@ -33,6 +34,9 @@ constexpr int kWebGatewayPublishedPortSpan = 10000;
 constexpr int kInteractionContainerPort = 18110;
 constexpr int kInteractionPublishedPortBase = 44000;
 constexpr int kInteractionPublishedPortSpan = 10000;
+constexpr int kVoiceModuleContainerPort = 18140;
+constexpr int kVoiceModulePublishedPortBase = 54000;
+constexpr int kVoiceModulePublishedPortSpan = 10000;
 constexpr std::string_view kTurboQuantDefaultCacheTypeK = "turbo4";
 constexpr std::string_view kTurboQuantDefaultCacheTypeV = "turbo4";
 
@@ -135,6 +139,7 @@ DesiredState DesiredStateV2Renderer::RenderState() {
   RenderSkillsInstance();
   RenderWebGatewayInstance();
   RenderInteractionInstance();
+  RenderVoiceModuleInstance();
   return state_;
 }
 
@@ -291,6 +296,43 @@ void DesiredStateV2Renderer::RenderFeatures() {
           "memory_priority",
           context_compression.memory_priority);
       state_.context_compression = std::move(context_compression);
+    }
+  }
+  if (features_json_.contains("voice_listener") &&
+      features_json_.at("voice_listener").is_object()) {
+    const auto& voice_json = features_json_.at("voice_listener");
+    if (voice_json.value("enabled", false)) {
+      VoiceListenerFeatureSpec voice_listener;
+      voice_listener.enabled = true;
+      voice_listener.wake_phrase = voice_json.value("wake_phrase", voice_listener.wake_phrase);
+      voice_listener.language = voice_json.value("language", voice_listener.language);
+      if (voice_json.contains("image") && voice_json.at("image").is_string()) {
+        voice_listener.image = voice_json.at("image").get<std::string>();
+      }
+      if (voice_json.contains("model") && voice_json.at("model").is_object()) {
+        const auto& model_json = voice_json.at("model");
+        const nlohmann::json source_json =
+            model_json.contains("source") && model_json.at("source").is_object()
+                ? model_json.at("source")
+                : nlohmann::json::object();
+        voice_listener.model.name = model_json.value("name", std::string("whisper"));
+        voice_listener.model.source_path = source_json.value("path", std::string{});
+        voice_listener.model.source_node_name = source_json.value("node", std::string{});
+        if (source_json.contains("paths") && source_json.at("paths").is_array()) {
+          voice_listener.model.source_paths =
+              source_json.at("paths").get<std::vector<std::string>>();
+        }
+        if (voice_listener.model.source_paths.empty() &&
+            !voice_listener.model.source_path.empty()) {
+          voice_listener.model.source_paths.push_back(voice_listener.model.source_path);
+        }
+        voice_listener.model.mount_path =
+            model_json.value("mount_path", std::string("/models/whisper/model.bin"));
+        voice_listener.model.env_var =
+            model_json.value("env", std::string("WHISPER_MODEL_PATH"));
+        voice_listener.model.required = model_json.value("required", true);
+      }
+      state_.voice_listener = std::move(voice_listener);
     }
   }
 }
@@ -801,6 +843,13 @@ void DesiredStateV2Renderer::RenderAppInstance() {
     if (!infer_names_.empty()) {
       app.depends_on.push_back(infer_names_.front());
     }
+    if (state_.voice_listener.has_value() && state_.voice_listener->enabled) {
+      app.depends_on.push_back(BuildVoiceModuleInstanceName());
+      app.environment["NAIM_VOICE_LISTENER_BASE"] =
+          "http://" + BuildVoiceModuleInstanceName() + ":" +
+          std::to_string(kVoiceModuleContainerPort) + "/v1";
+      app.environment["NAIM_VOICE_LISTENER_WAKE_PHRASE"] = state_.voice_listener->wake_phrase;
+    }
     if (app_entry.contains("env") && app_entry.at("env").is_object()) {
       app.environment = app_entry.at("env").get<std::map<std::string, std::string>>();
     }
@@ -1037,6 +1086,110 @@ void DesiredStateV2Renderer::RenderWebGatewayInstance() {
       ExtractPrivateMountPath(browsing_json_, "/naim/private", "storage");
   browsing_private_disk.size_gb = browsing.private_disk_size_gb;
   state_.disks.push_back(std::move(browsing_private_disk));
+}
+
+void DesiredStateV2Renderer::RenderVoiceModuleInstance() {
+  if (!state_.voice_listener.has_value() || !state_.voice_listener->enabled) {
+    return;
+  }
+
+  const auto& config = *state_.voice_listener;
+  InstanceSpec voice;
+  voice.name = BuildVoiceModuleInstanceName();
+  voice.role = InstanceRole::VoiceModule;
+  voice.plane_name = state_.plane_name;
+  voice.node_name = ResolveAppNodeName();
+  voice.image = config.image.has_value() && !config.image->empty()
+                    ? *config.image
+                    : std::string("naim/voice-module:dev");
+  const nlohmann::json voice_json =
+      features_json_.contains("voice_listener") &&
+              features_json_.at("voice_listener").is_object()
+          ? features_json_.at("voice_listener")
+          : nlohmann::json::object();
+  voice.command = BuildCommandFromStartSpec(
+      voice_json.value("start", nlohmann::json::object()),
+      "/runtime/bin/naim-voice-moduled");
+  voice.private_disk_name = voice.name + "-private";
+  voice.shared_disk_name =
+      InstanceNeedsSharedDiskMount(voice.role) ? state_.plane_shared_disk_name : "";
+  voice.private_disk_size_gb =
+      ExtractPrivateDiskSizeGb(voice_json, kDefaultVoiceModulePrivateDiskSizeGb, "storage");
+  voice.environment = {
+      {"NAIM_PLANE_NAME", state_.plane_name},
+      {"NAIM_INSTANCE_NAME", voice.name},
+      {"NAIM_INSTANCE_ROLE", "voice-module"},
+      {"NAIM_NODE_NAME", voice.node_name},
+      {"NAIM_PRIVATE_DISK_PATH", "/naim/private"},
+      {"NAIM_VOICE_MODULE_PORT", std::to_string(kVoiceModuleContainerPort)},
+      {"NAIM_VOICE_LISTENER_WAKE_PHRASE", config.wake_phrase},
+      {"VOICE_LISTENER_WAKE_PHRASE", config.wake_phrase},
+      {"VOICE_ASR_LANGUAGE", config.language},
+      {"HOST", "0.0.0.0"},
+      {"PORT", std::to_string(kVoiceModuleContainerPort)},
+      {"NAIM_CONTROLLER_URL", "http://controller.internal:18080"},
+      {"NAIM_CONTROL_ROOT", state_.control_root},
+  };
+  if (voice_json.contains("env") && voice_json.at("env").is_object()) {
+    const auto custom_env = voice_json.at("env").get<std::map<std::string, std::string>>();
+    for (const auto& [key, value] : custom_env) {
+      voice.environment[key] = value;
+    }
+  }
+  AppModelMountSpec model_mount = config.model;
+  if (model_mount.name.empty()) {
+    model_mount.name = "whisper";
+  }
+  if (model_mount.mount_path.empty()) {
+    model_mount.mount_path = "/models/whisper/model.bin";
+  }
+  if (model_mount.env_var.empty()) {
+    model_mount.env_var = "WHISPER_MODEL_PATH";
+  }
+  if (model_mount.source_paths.empty() && !model_mount.source_path.empty()) {
+    model_mount.source_paths.push_back(model_mount.source_path);
+  }
+  model_mount.host_path = BuildAppModelHostPath(
+      voice.name,
+      model_mount.name,
+      model_mount.mount_path,
+      model_mount.source_path);
+  voice.environment[model_mount.env_var] = model_mount.mount_path;
+  voice.app_model_mounts.push_back(std::move(model_mount));
+  voice.labels = {
+      {"naim.plane", state_.plane_name},
+      {"naim.role", "voice-module"},
+      {"naim.node", voice.node_name},
+  };
+  if (voice_json.contains("publish") && voice_json.at("publish").is_array()) {
+    for (const auto& port_json : voice_json.at("publish")) {
+      voice.published_ports.push_back(PublishedPort{
+          port_json.value("host_ip", std::string("127.0.0.1")),
+          port_json.value("host_port", 0),
+          port_json.value("container_port", 0),
+      });
+    }
+  }
+  if (voice.published_ports.empty()) {
+    voice.published_ports.push_back(PublishedPort{
+        "127.0.0.1",
+        BuildVoiceModuleHostPort(),
+        kVoiceModuleContainerPort,
+    });
+  }
+  state_.instances.push_back(voice);
+
+  DiskSpec voice_private_disk;
+  voice_private_disk.name = voice.private_disk_name;
+  voice_private_disk.kind = DiskKind::VoiceModulePrivate;
+  voice_private_disk.plane_name = state_.plane_name;
+  voice_private_disk.owner_name = voice.name;
+  voice_private_disk.node_name = voice.node_name;
+  voice_private_disk.host_path = BuildInstancePrivateHostPath(voice.name);
+  voice_private_disk.container_path =
+      ExtractPrivateMountPath(voice_json, "/naim/private", "storage");
+  voice_private_disk.size_gb = voice.private_disk_size_gb;
+  state_.disks.push_back(std::move(voice_private_disk));
 }
 
 void DesiredStateV2Renderer::RenderInteractionInstance() {
@@ -1359,6 +1512,10 @@ std::string DesiredStateV2Renderer::BuildInteractionInstanceName() const {
   return "interaction-" + state_.plane_name;
 }
 
+std::string DesiredStateV2Renderer::BuildVoiceModuleInstanceName() const {
+  return "voice-module-" + state_.plane_name;
+}
+
 std::string DesiredStateV2Renderer::BuildPlaneSharedHostPath() const {
   return "/var/lib/naim/disks/planes/" + state_.plane_name + "/shared";
 }
@@ -1472,6 +1629,13 @@ int DesiredStateV2Renderer::BuildInteractionHostPort() const {
       StablePortHash(state_.plane_name + ":" + BuildInteractionInstanceName()) %
       kInteractionPublishedPortSpan;
   return kInteractionPublishedPortBase + static_cast<int>(offset);
+}
+
+int DesiredStateV2Renderer::BuildVoiceModuleHostPort() const {
+  const uint32_t offset =
+      StablePortHash(state_.plane_name + ":" + BuildVoiceModuleInstanceName()) %
+      kVoiceModulePublishedPortSpan;
+  return kVoiceModulePublishedPortBase + static_cast<int>(offset);
 }
 
 std::string DesiredStateV2Renderer::DefaultInferRuntimeBackend() const {

--- a/common/src/state/desired_state_v2_validator.cpp
+++ b/common/src/state/desired_state_v2_validator.cpp
@@ -67,6 +67,48 @@ bool IsValidEnvName(const std::string& value) {
   return true;
 }
 
+void ValidateVoiceListenerModel(const nlohmann::json& model) {
+  if (!model.is_object()) {
+    throw std::runtime_error("desired-state v2 features.voice_listener.model must be an object");
+  }
+  if (!model.contains("source") || !model.at("source").is_object()) {
+    throw std::runtime_error("desired-state v2 features.voice_listener.model.source must be an object");
+  }
+  const auto& source = model.at("source");
+  if (source.value("type", std::string{}) != "library") {
+    throw std::runtime_error("desired-state v2 features.voice_listener.model.source.type must be library");
+  }
+  if (!IsAbsolutePath(source.value("path", std::string{}))) {
+    throw std::runtime_error("desired-state v2 features.voice_listener.model.source.path must be an absolute path");
+  }
+  if (source.contains("paths")) {
+    if (!source.at("paths").is_array()) {
+      throw std::runtime_error("desired-state v2 features.voice_listener.model.source.paths must be an array");
+    }
+    for (const auto& path : source.at("paths")) {
+      if (!path.is_string() || !IsAbsolutePath(path.get<std::string>())) {
+        throw std::runtime_error("desired-state v2 features.voice_listener.model.source.paths items must be absolute paths");
+      }
+    }
+  }
+  if (source.contains("node") && !source.at("node").is_string()) {
+    throw std::runtime_error("desired-state v2 features.voice_listener.model.source.node must be a string");
+  }
+  if (!IsAbsolutePath(model.value("mount_path", std::string{}))) {
+    throw std::runtime_error("desired-state v2 features.voice_listener.model.mount_path must be an absolute path");
+  }
+  if (model.contains("env") && !model.at("env").is_string()) {
+    throw std::runtime_error("desired-state v2 features.voice_listener.model.env must be a string");
+  }
+  const std::string env_name = model.value("env", std::string("WHISPER_MODEL_PATH"));
+  if (!env_name.empty() && !IsValidEnvName(env_name)) {
+    throw std::runtime_error("desired-state v2 features.voice_listener.model.env must be a valid environment variable name");
+  }
+  if (model.contains("required") && !model.at("required").is_boolean()) {
+    throw std::runtime_error("desired-state v2 features.voice_listener.model.required must be a boolean");
+  }
+}
+
 }  // namespace
 
 void DesiredStateV2Validator::ValidateOrThrow(const nlohmann::json& value) {
@@ -247,6 +289,39 @@ void DesiredStateV2Validator::ValidateFeatures() const {
   RequireObject("features");
   const auto& features = value_.at("features");
   const std::string plane_mode = value_.value("plane_mode", std::string("llm"));
+  if (features.contains("voice_listener")) {
+    if (!features.at("voice_listener").is_object()) {
+      throw std::runtime_error("desired-state v2 features.voice_listener must be an object");
+    }
+    const auto& voice_listener = features.at("voice_listener");
+    if (voice_listener.contains("enabled") && !voice_listener.at("enabled").is_boolean()) {
+      throw std::runtime_error("desired-state v2 features.voice_listener.enabled must be a boolean");
+    }
+    const bool enabled = voice_listener.value("enabled", false);
+    if (voice_listener.contains("wake_phrase") && !voice_listener.at("wake_phrase").is_string()) {
+      throw std::runtime_error("desired-state v2 features.voice_listener.wake_phrase must be a string");
+    }
+    if (voice_listener.contains("language") && !voice_listener.at("language").is_string()) {
+      throw std::runtime_error("desired-state v2 features.voice_listener.language must be a string");
+    }
+    if (voice_listener.contains("image") && !voice_listener.at("image").is_string()) {
+      throw std::runtime_error("desired-state v2 features.voice_listener.image must be a string");
+    }
+    if (enabled) {
+      if (plane_mode != "llm") {
+        throw std::runtime_error("desired-state v2 features.voice_listener requires plane_mode=llm");
+      }
+      if (voice_listener.value("wake_phrase", std::string("Hey Jex")).empty()) {
+        throw std::runtime_error("desired-state v2 features.voice_listener.wake_phrase must be non-empty");
+      }
+      if (!voice_listener.contains("model")) {
+        throw std::runtime_error("desired-state v2 features.voice_listener requires model when enabled");
+      }
+      ValidateVoiceListenerModel(voice_listener.at("model"));
+    } else if (voice_listener.contains("model")) {
+      ValidateVoiceListenerModel(voice_listener.at("model"));
+    }
+  }
   if (features.contains("turboquant")) {
     if (!features.at("turboquant").is_object()) {
       throw std::runtime_error("desired-state v2 features.turboquant must be an object");

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -1947,6 +1947,69 @@ int main() {
       std::cout << "ok: app-model-plane" << '\n';
     }
 
+    {
+      const json voice_listener_plane{
+          {"version", 2},
+          {"plane_name", "voice-listener-plane"},
+          {"plane_mode", "llm"},
+          {"model",
+           {
+               {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+               {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+               {"served_model_name", "qwen-voice-listener"},
+           }},
+          {"runtime",
+           {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+          {"infer", {{"replicas", 1}}},
+          {"app", {{"enabled", true}, {"image", "example/app:dev"}}},
+          {"features",
+           {{"voice_listener",
+             {{"enabled", true},
+              {"wake_phrase", "Hey Jex"},
+              {"language", "auto"},
+              {"model",
+               {{"name", "whisper"},
+                {"source",
+                 {{"type", "library"},
+                  {"path", "/mnt/shared-storage/models/whisper/ggml-base.bin"},
+                  {"node", "storage1"},
+                  {"paths", json::array({"/mnt/shared-storage/models/whisper/ggml-base.bin"})}}},
+                {"mount_path", "/models/whisper/ggml-base.bin"},
+                {"env", "WHISPER_MODEL_PATH"},
+                {"required", true}}}}}}}
+      };
+      const auto state = RenderValid(voice_listener_plane, "voice-listener-plane");
+      const auto voice = FindInstance(state, "voice-module-voice-listener-plane");
+      Expect(voice.role == naim::InstanceRole::VoiceModule,
+             "voice-listener-plane: voice module role mismatch");
+      Expect(voice.environment.at("NAIM_VOICE_LISTENER_WAKE_PHRASE") == "Hey Jex",
+             "voice-listener-plane: wake phrase env mismatch");
+      Expect(voice.app_model_mounts.size() == 1,
+             "voice-listener-plane: voice module should mount whisper model");
+      const auto app = FindInstance(state, "app-voice-listener-plane");
+      Expect(app.environment.at("NAIM_VOICE_LISTENER_BASE") ==
+                 "http://voice-module-voice-listener-plane:18140/v1",
+             "voice-listener-plane: primary app should receive voice feature base");
+      const auto projected = naim::DesiredStateV2Projector::Project(state);
+      Expect(projected.at("features").at("voice_listener").at("wake_phrase") == "Hey Jex",
+             "voice-listener-plane: projector should preserve wake phrase");
+      std::cout << "ok: voice-listener-plane" << '\n';
+    }
+
+    ExpectInvalid(
+        json{
+            {"version", 2},
+            {"plane_name", "bad-voice-listener"},
+            {"plane_mode", "llm"},
+            {"model",
+             {{"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+              {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+              {"served_model_name", "qwen"}}},
+            {"runtime", {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+            {"features", {{"voice_listener", {{"enabled", true}, {"wake_phrase", ""}}}}},
+        },
+        "bad-voice-listener");
+
     ExpectInvalid(
         json{
             {"version", 2},

--- a/common/src/state/state_json.cpp
+++ b/common/src/state/state_json.cpp
@@ -150,6 +150,40 @@ json ToJson(const ContextCompressionFeatureSpec& context_compression) {
   };
 }
 
+json ToJson(const VoiceListenerFeatureSpec& voice_listener) {
+  json source = {
+      {"type", "library"},
+      {"path", voice_listener.model.source_path},
+  };
+  if (!voice_listener.model.source_node_name.empty()) {
+    source["node"] = voice_listener.model.source_node_name;
+  }
+  if (!voice_listener.model.source_paths.empty() &&
+      !(voice_listener.model.source_paths.size() == 1 &&
+        voice_listener.model.source_paths.front() == voice_listener.model.source_path)) {
+    source["paths"] = voice_listener.model.source_paths;
+  }
+  json model = {
+      {"name", voice_listener.model.name.empty() ? std::string("whisper")
+                                                  : voice_listener.model.name},
+      {"source", std::move(source)},
+      {"mount_path", voice_listener.model.mount_path},
+      {"env", voice_listener.model.env_var.empty() ? std::string("WHISPER_MODEL_PATH")
+                                                    : voice_listener.model.env_var},
+      {"required", voice_listener.model.required},
+  };
+  json result = {
+      {"enabled", voice_listener.enabled},
+      {"wake_phrase", voice_listener.wake_phrase},
+      {"language", voice_listener.language},
+      {"model", std::move(model)},
+  };
+  if (voice_listener.image.has_value() && !voice_listener.image->empty()) {
+    result["image"] = *voice_listener.image;
+  }
+  return result;
+}
+
 json DesiredStateToJson(const DesiredState& state) {
   json result = {
       {"plane_name", state.plane_name},
@@ -222,13 +256,17 @@ json DesiredStateToJson(const DesiredState& state) {
   if (state.knowledge.has_value()) {
     result["knowledge"] = SettingsCodecs::ToJson(*state.knowledge);
   }
-  if (state.turboquant.has_value() || state.context_compression.has_value()) {
+  if (state.turboquant.has_value() || state.context_compression.has_value() ||
+      state.voice_listener.has_value()) {
     json features = json::object();
     if (state.turboquant.has_value()) {
       features["turboquant"] = ToJson(*state.turboquant);
     }
     if (state.context_compression.has_value()) {
       features["context_compression"] = ToJson(*state.context_compression);
+    }
+    if (state.voice_listener.has_value()) {
+      features["voice_listener"] = ToJson(*state.voice_listener);
     }
     result["features"] = std::move(features);
   }
@@ -326,6 +364,44 @@ DesiredState DesiredStateFromJson(const json& value) {
           "memory_priority",
           context_compression.memory_priority);
       state.context_compression = std::move(context_compression);
+    }
+    if (features.contains("voice_listener") &&
+        features.at("voice_listener").is_object()) {
+      VoiceListenerFeatureSpec voice_listener;
+      const auto& voice_listener_json = features.at("voice_listener");
+      voice_listener.enabled = voice_listener_json.value("enabled", voice_listener.enabled);
+      voice_listener.wake_phrase = voice_listener_json.value(
+          "wake_phrase",
+          voice_listener.wake_phrase);
+      voice_listener.language = voice_listener_json.value("language", voice_listener.language);
+      if (voice_listener_json.contains("image") &&
+          voice_listener_json.at("image").is_string()) {
+        voice_listener.image = voice_listener_json.at("image").get<std::string>();
+      }
+      if (voice_listener_json.contains("model") &&
+          voice_listener_json.at("model").is_object()) {
+        const auto& model_json = voice_listener_json.at("model");
+        const json source_json = model_json.contains("source") && model_json.at("source").is_object()
+                                     ? model_json.at("source")
+                                     : json::object();
+        voice_listener.model.name = model_json.value("name", std::string("whisper"));
+        voice_listener.model.source_path = source_json.value("path", std::string{});
+        voice_listener.model.source_node_name = source_json.value("node", std::string{});
+        if (source_json.contains("paths") && source_json.at("paths").is_array()) {
+          voice_listener.model.source_paths =
+              source_json.at("paths").get<std::vector<std::string>>();
+        }
+        if (voice_listener.model.source_paths.empty() &&
+            !voice_listener.model.source_path.empty()) {
+          voice_listener.model.source_paths.push_back(voice_listener.model.source_path);
+        }
+        voice_listener.model.mount_path =
+            model_json.value("mount_path", std::string("/models/whisper/model.bin"));
+        voice_listener.model.env_var =
+            model_json.value("env", std::string("WHISPER_MODEL_PATH"));
+        voice_listener.model.required = model_json.value("required", true);
+      }
+      state.voice_listener = std::move(voice_listener);
     }
   }
   if (value.contains("app_host") && value.at("app_host").is_object()) {

--- a/common/src/state/state_json_runtime_codecs.cpp
+++ b/common/src/state/state_json_runtime_codecs.cpp
@@ -35,6 +35,9 @@ DiskKind StateJsonRuntimeCodecs::ParseDiskKind(const std::string& value) {
   if (value == "interaction-private") {
     return DiskKind::InteractionPrivate;
   }
+  if (value == "voice-module-private") {
+    return DiskKind::VoiceModulePrivate;
+  }
   throw std::runtime_error("unknown disk kind '" + value + "'");
 }
 
@@ -60,6 +63,9 @@ InstanceRole StateJsonRuntimeCodecs::ParseInstanceRole(
   }
   if (value == "interaction") {
     return InstanceRole::Interaction;
+  }
+  if (value == "voice-module") {
+    return InstanceRole::VoiceModule;
   }
   throw std::runtime_error("unknown instance role '" + value + "'");
 }

--- a/runtime/voice/CMakeLists.txt
+++ b/runtime/voice/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.20)
+project(naim_voice_module LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(Threads REQUIRED)
+
+set(WHISPER_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(WHISPER_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+add_subdirectory(third_party/whisper.cpp)
+
+add_executable(naim-voice-moduled src/main.cpp)
+target_include_directories(naim-voice-moduled PRIVATE
+  ${CMAKE_SOURCE_DIR}/third_party/whisper.cpp/include
+  ${CMAKE_SOURCE_DIR}/third_party/whisper.cpp/ggml/include
+  ${CMAKE_SOURCE_DIR}/third_party/cpp-httplib
+)
+target_link_libraries(naim-voice-moduled PRIVATE whisper Threads::Threads)

--- a/runtime/voice/Dockerfile
+++ b/runtime/voice/Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:bookworm-slim AS build
+
+ARG WHISPER_CPP_REF=v1.8.1
+ARG CPP_HTTPLIB_REF=v0.26.0
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates cmake curl g++ git make pkg-config \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git clone --depth 1 --branch "${WHISPER_CPP_REF}" https://github.com/ggml-org/whisper.cpp.git third_party/whisper.cpp
+RUN mkdir -p third_party/cpp-httplib \
+  && curl -fsSL "https://raw.githubusercontent.com/yhirose/cpp-httplib/${CPP_HTTPLIB_REF}/httplib.h" \
+    -o third_party/cpp-httplib/httplib.h
+
+COPY CMakeLists.txt ./
+COPY src ./src
+
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
+  && cmake --build build -j
+
+FROM debian:bookworm-slim
+
+ENV HOST=0.0.0.0 \
+    PORT=18140 \
+    NAIM_VOICE_MODULE_TMP_DIR=/tmp/naim-voice-module \
+    VOICE_ASR_TMP_DIR=/tmp/naim-voice-module \
+    VOICE_ASR_FFMPEG_BIN=ffmpeg \
+    VOICE_ASR_LANGUAGE=auto \
+    VOICE_BODY_LIMIT_BYTES=16777216 \
+    VOICE_LISTENER_WAKE_PHRASE="Hey Jex"
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl ffmpeg libgomp1 \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /models /tmp/naim-voice-module /runtime/bin
+
+COPY --from=build /src/build/naim-voice-moduled /runtime/bin/naim-voice-moduled
+
+EXPOSE 18140
+
+CMD ["/runtime/bin/naim-voice-moduled"]

--- a/runtime/voice/src/main.cpp
+++ b/runtime/voice/src/main.cpp
@@ -1,0 +1,516 @@
+#include <whisper.h>
+
+#include <httplib.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+struct Config {
+  std::string host = "0.0.0.0";
+  int port = 8080;
+  std::string model_path;
+  std::string tmp_dir = "/tmp/naim-voice-module";
+  std::string wake_phrase = "Hey Jex";
+  std::string ffmpeg_bin = "ffmpeg";
+  std::string language = "auto";
+  int threads = std::max(1u, std::thread::hardware_concurrency());
+  int max_body_bytes = 16 * 1024 * 1024;
+  bool translate = false;
+};
+
+struct AudioPcm {
+  std::vector<float> samples;
+  int sample_rate = 16000;
+};
+
+std::atomic<uint64_t> g_request_seq{0};
+std::mutex g_whisper_mutex;
+
+std::string getenv_string(const char *name, const std::string &fallback = "") {
+  const char *value = std::getenv(name);
+  if (!value || !*value) {
+    return fallback;
+  }
+  return value;
+}
+
+int getenv_int(const char *name, int fallback) {
+  const std::string value = getenv_string(name);
+  if (value.empty()) {
+    return fallback;
+  }
+  try {
+    return std::stoi(value);
+  } catch (...) {
+    return fallback;
+  }
+}
+
+bool getenv_bool(const char *name, bool fallback) {
+  std::string value = getenv_string(name);
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  if (value == "1" || value == "true" || value == "yes" || value == "on") {
+    return true;
+  }
+  if (value == "0" || value == "false" || value == "no" || value == "off") {
+    return false;
+  }
+  return fallback;
+}
+
+Config load_config() {
+  Config config;
+  config.host = getenv_string("HOST", config.host);
+  config.port = getenv_int("PORT", getenv_int("NAIM_VOICE_MODULE_PORT", config.port));
+  config.model_path = getenv_string("WHISPER_MODEL_PATH");
+  config.tmp_dir = getenv_string("VOICE_ASR_TMP_DIR", getenv_string("NAIM_VOICE_MODULE_TMP_DIR", config.tmp_dir));
+  config.wake_phrase = getenv_string("VOICE_LISTENER_WAKE_PHRASE", getenv_string("NAIM_VOICE_LISTENER_WAKE_PHRASE", config.wake_phrase));
+  config.ffmpeg_bin = getenv_string("VOICE_ASR_FFMPEG_BIN", config.ffmpeg_bin);
+  config.language = getenv_string("VOICE_ASR_LANGUAGE", config.language);
+  config.threads = getenv_int("VOICE_ASR_THREADS", config.threads);
+  config.max_body_bytes = getenv_int("VOICE_BODY_LIMIT_BYTES", config.max_body_bytes);
+  config.translate = getenv_bool("VOICE_ASR_TRANSLATE", config.translate);
+  return config;
+}
+
+std::string json_escape(const std::string &input) {
+  std::ostringstream out;
+  for (char c : input) {
+    switch (c) {
+      case '\\': out << "\\\\"; break;
+      case '"': out << "\\\""; break;
+      case '\b': out << "\\b"; break;
+      case '\f': out << "\\f"; break;
+      case '\n': out << "\\n"; break;
+      case '\r': out << "\\r"; break;
+      case '\t': out << "\\t"; break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          out << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(c);
+        } else {
+          out << c;
+        }
+    }
+  }
+  return out.str();
+}
+
+std::string make_json_error(const std::string &message) {
+  return "{\"error\":\"" + json_escape(message) + "\"}";
+}
+
+std::string request_id() {
+  const auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::system_clock::now().time_since_epoch()
+  ).count();
+  return "asr_" + std::to_string(now) + "_" + std::to_string(++g_request_seq);
+}
+
+std::string shell_quote(const std::filesystem::path &path) {
+  std::string input = path.string();
+  std::string output = "'";
+  for (char c : input) {
+    if (c == '\'') {
+      output += "'\\''";
+    } else {
+      output += c;
+    }
+  }
+  output += "'";
+  return output;
+}
+
+std::optional<std::string> content_type_boundary(const std::string &content_type) {
+  const std::string marker = "boundary=";
+  const auto index = content_type.find(marker);
+  if (index == std::string::npos) {
+    return std::nullopt;
+  }
+  std::string boundary = content_type.substr(index + marker.size());
+  if (!boundary.empty() && boundary.front() == '"') {
+    const auto end = boundary.find('"', 1);
+    if (end != std::string::npos) {
+      boundary = boundary.substr(1, end - 1);
+    }
+  } else {
+    const auto end = boundary.find(';');
+    if (end != std::string::npos) {
+      boundary = boundary.substr(0, end);
+    }
+  }
+  return boundary.empty() ? std::nullopt : std::optional<std::string>(boundary);
+}
+
+std::string extract_multipart_audio(const std::string &body, const std::string &content_type) {
+  const auto boundary_opt = content_type_boundary(content_type);
+  if (!boundary_opt) {
+    return body;
+  }
+
+  const std::string delimiter = "--" + *boundary_opt;
+  size_t cursor = 0;
+  while (true) {
+    const auto begin = body.find(delimiter, cursor);
+    if (begin == std::string::npos) {
+      break;
+    }
+    const auto part_begin = begin + delimiter.size();
+    if (body.compare(part_begin, 2, "--") == 0) {
+      break;
+    }
+    const auto header_begin = body.compare(part_begin, 2, "\r\n") == 0 ? part_begin + 2 : part_begin;
+    const auto header_end = body.find("\r\n\r\n", header_begin);
+    if (header_end == std::string::npos) {
+      break;
+    }
+    const std::string headers = body.substr(header_begin, header_end - header_begin);
+    const auto data_begin = header_end + 4;
+    auto next = body.find(delimiter, data_begin);
+    if (next == std::string::npos) {
+      next = body.size();
+    }
+    auto data_end = next;
+    if (data_end >= 2 && body.compare(data_end - 2, 2, "\r\n") == 0) {
+      data_end -= 2;
+    }
+    const bool is_audio_field =
+      headers.find("name=\"file\"") != std::string::npos ||
+      headers.find("name=\"audio\"") != std::string::npos;
+    if (is_audio_field) {
+      return body.substr(data_begin, data_end - data_begin);
+    }
+    cursor = next;
+  }
+
+  throw std::runtime_error("multipart payload does not contain file or audio field");
+}
+
+std::string extract_request_audio(const httplib::Request &req) {
+  for (const auto *field_name : {"file", "audio"}) {
+    if (req.form.has_file(field_name)) {
+      return req.form.get_file(field_name).content;
+    }
+  }
+
+  const std::string content_type = req.get_header_value("Content-Type");
+  return extract_multipart_audio(req.body, content_type);
+}
+
+std::filesystem::path write_temp_file(const Config &config, const std::string &prefix, const std::string &data) {
+  std::filesystem::create_directories(config.tmp_dir);
+  const auto path = std::filesystem::path(config.tmp_dir) / (prefix + "-" + request_id());
+  std::ofstream out(path, std::ios::binary);
+  if (!out) {
+    throw std::runtime_error("failed to create temporary file");
+  }
+  out.write(data.data(), static_cast<std::streamsize>(data.size()));
+  return path;
+}
+
+class TempFile {
+ public:
+  explicit TempFile(std::filesystem::path path) : path_(std::move(path)) {}
+  ~TempFile() {
+    if (!path_.empty()) {
+      std::error_code ec;
+      std::filesystem::remove(path_, ec);
+    }
+  }
+  const std::filesystem::path &path() const { return path_; }
+
+ private:
+  std::filesystem::path path_;
+};
+
+AudioPcm read_wav_pcm16_mono_16k(const std::filesystem::path &path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    throw std::runtime_error("failed to open converted wav");
+  }
+  std::string bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  if (bytes.size() < 44 || bytes.compare(0, 4, "RIFF") != 0 || bytes.compare(8, 4, "WAVE") != 0) {
+    throw std::runtime_error("converted audio is not a WAV file");
+  }
+
+  size_t offset = 12;
+  uint16_t audio_format = 0;
+  uint16_t channels = 0;
+  uint32_t sample_rate = 0;
+  uint16_t bits_per_sample = 0;
+  size_t data_offset = 0;
+  uint32_t data_size = 0;
+
+  while (offset + 8 <= bytes.size()) {
+    const std::string chunk_id = bytes.substr(offset, 4);
+    const uint32_t chunk_size =
+      static_cast<unsigned char>(bytes[offset + 4]) |
+      (static_cast<unsigned char>(bytes[offset + 5]) << 8) |
+      (static_cast<unsigned char>(bytes[offset + 6]) << 16) |
+      (static_cast<unsigned char>(bytes[offset + 7]) << 24);
+    offset += 8;
+    if (offset + chunk_size > bytes.size()) {
+      break;
+    }
+    if (chunk_id == "fmt " && chunk_size >= 16) {
+      audio_format = static_cast<unsigned char>(bytes[offset]) |
+        (static_cast<unsigned char>(bytes[offset + 1]) << 8);
+      channels = static_cast<unsigned char>(bytes[offset + 2]) |
+        (static_cast<unsigned char>(bytes[offset + 3]) << 8);
+      sample_rate = static_cast<unsigned char>(bytes[offset + 4]) |
+        (static_cast<unsigned char>(bytes[offset + 5]) << 8) |
+        (static_cast<unsigned char>(bytes[offset + 6]) << 16) |
+        (static_cast<unsigned char>(bytes[offset + 7]) << 24);
+      bits_per_sample = static_cast<unsigned char>(bytes[offset + 14]) |
+        (static_cast<unsigned char>(bytes[offset + 15]) << 8);
+    } else if (chunk_id == "data") {
+      data_offset = offset;
+      data_size = chunk_size;
+    }
+    offset += chunk_size + (chunk_size % 2);
+  }
+
+  if (audio_format != 1 || channels != 1 || sample_rate != 16000 || bits_per_sample != 16 || data_offset == 0) {
+    throw std::runtime_error("converted WAV must be mono 16 kHz PCM16");
+  }
+
+  AudioPcm audio;
+  audio.samples.reserve(data_size / 2);
+  for (size_t i = data_offset; i + 1 < data_offset + data_size; i += 2) {
+    const int16_t sample = static_cast<int16_t>(
+      static_cast<unsigned char>(bytes[i]) |
+      (static_cast<unsigned char>(bytes[i + 1]) << 8)
+    );
+    audio.samples.push_back(static_cast<float>(sample) / 32768.0f);
+  }
+  return audio;
+}
+
+AudioPcm decode_audio_to_pcm(const Config &config, const std::string &audio_bytes) {
+  auto input_path = write_temp_file(config, "input", audio_bytes);
+  TempFile input_file(input_path);
+  auto output_path = std::filesystem::path(config.tmp_dir) / ("pcm-" + request_id() + ".wav");
+  TempFile output_file(output_path);
+
+  const std::string command =
+    config.ffmpeg_bin +
+    " -hide_banner -loglevel error -y -i " + shell_quote(input_file.path()) +
+    " -ar 16000 -ac 1 -c:a pcm_s16le " + shell_quote(output_file.path());
+
+  const int rc = std::system(command.c_str());
+  if (rc != 0) {
+    throw std::runtime_error("ffmpeg audio conversion failed");
+  }
+  return read_wav_pcm16_mono_16k(output_file.path());
+}
+
+std::string transcribe(whisper_context *ctx, const Config &config, const AudioPcm &audio) {
+  whisper_full_params params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+  params.n_threads = config.threads;
+  params.translate = config.translate;
+  params.print_progress = false;
+  params.print_realtime = false;
+  params.print_timestamps = false;
+  params.print_special = false;
+  params.no_context = true;
+  params.single_segment = false;
+  if (config.language != "auto") {
+    params.language = config.language.c_str();
+  }
+
+  std::lock_guard<std::mutex> lock(g_whisper_mutex);
+  const int rc = whisper_full(ctx, params, audio.samples.data(), static_cast<int>(audio.samples.size()));
+  if (rc != 0) {
+    throw std::runtime_error("whisper inference failed");
+  }
+
+  std::string text;
+  const int segments = whisper_full_n_segments(ctx);
+  for (int i = 0; i < segments; ++i) {
+    const char *segment = whisper_full_get_segment_text(ctx, i);
+    if (segment) {
+      text += segment;
+    }
+  }
+  while (!text.empty() && std::isspace(static_cast<unsigned char>(text.front()))) {
+    text.erase(text.begin());
+  }
+  while (!text.empty() && std::isspace(static_cast<unsigned char>(text.back()))) {
+    text.pop_back();
+  }
+  return text;
+}
+
+std::string lowercase_copy(const std::string &value) {
+  std::string out = value;
+  std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return out;
+}
+
+std::string trim_copy(std::string value) {
+  while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front()))) {
+    value.erase(value.begin());
+  }
+  while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back()))) {
+    value.pop_back();
+  }
+  return value;
+}
+
+std::string strip_configured_wake_phrase(
+  const std::string &transcript,
+  const std::string &wake_phrase,
+  bool *detected
+) {
+  if (detected) {
+    *detected = false;
+  }
+  const std::string trimmed = trim_copy(transcript);
+  const std::string lowered = lowercase_copy(trimmed);
+  const std::string lowered_wake = lowercase_copy(trim_copy(wake_phrase));
+  if (lowered_wake.empty() || lowered.rfind(lowered_wake, 0) != 0) {
+    return trimmed;
+  }
+  std::string rest = trimmed.substr(lowered_wake.size());
+  while (!rest.empty() && (std::isspace(static_cast<unsigned char>(rest.front())) ||
+                           rest.front() == ',' || rest.front() == '.' ||
+                           rest.front() == ':' || rest.front() == ';' ||
+                           rest.front() == '-')) {
+    rest.erase(rest.begin());
+  }
+  if (detected) {
+    *detected = true;
+  }
+  return trim_copy(rest);
+}
+
+std::string make_transcription_json(
+  const std::string &id,
+  const std::string &transcript,
+  const std::string &language,
+  int duration_ms,
+  size_t input_bytes,
+  bool wake_phrase_detected,
+  const std::string &wake_phrase
+) {
+  std::ostringstream out;
+  out << "{"
+      << "\"transcript\":\"" << json_escape(transcript) << "\","
+      << "\"text\":\"" << json_escape(transcript) << "\","
+      << "\"language\":\"" << json_escape(language) << "\","
+      << "\"asr_confidence\":0,"
+      << "\"segments\":[],"
+      << "\"wake_phrase_detected\":" << (wake_phrase_detected ? "true" : "false") << ","
+      << "\"wake_phrase\":\"" << json_escape(wake_phrase) << "\","
+      << "\"request_id\":\"" << json_escape(id) << "\","
+      << "\"duration_ms\":" << duration_ms << ","
+      << "\"input_bytes\":" << input_bytes
+      << "}";
+  return out.str();
+}
+
+}  // namespace
+
+int main() {
+  const Config config = load_config();
+  if (config.model_path.empty()) {
+    std::cerr << "WHISPER_MODEL_PATH is required\n";
+    return 2;
+  }
+
+  whisper_context_params cparams = whisper_context_default_params();
+  whisper_context *ctx = whisper_init_from_file_with_params(config.model_path.c_str(), cparams);
+  if (!ctx) {
+    std::cerr << "failed to load whisper model: " << config.model_path << "\n";
+    return 2;
+  }
+
+  httplib::Server server;
+  server.set_payload_max_length(static_cast<size_t>(config.max_body_bytes));
+
+  server.Get("/health", [&](const httplib::Request &, httplib::Response &res) {
+    res.set_content(
+      "{\"status\":\"ok\",\"engine\":\"whisper.cpp\",\"api_owner\":\"lt-cypher-ai\",\"model_path\":\"" +
+        json_escape(config.model_path) + "\"}",
+      "application/json"
+    );
+  });
+
+  const auto transcribe_handler = [&](const httplib::Request &req, httplib::Response &res) {
+    const auto started = std::chrono::steady_clock::now();
+    const std::string id = request_id();
+    try {
+      std::string audio_bytes = extract_request_audio(req);
+      if (audio_bytes.empty()) {
+        res.status = 400;
+        res.set_content(make_json_error("empty audio payload"), "application/json");
+        return;
+      }
+
+      AudioPcm audio = decode_audio_to_pcm(config, audio_bytes);
+      std::fill(audio_bytes.begin(), audio_bytes.end(), '\0');
+      const std::string raw_transcript = transcribe(ctx, config, audio);
+      bool wake_phrase_detected = false;
+      const std::string transcript =
+        strip_configured_wake_phrase(raw_transcript, config.wake_phrase, &wake_phrase_detected);
+      std::fill(audio.samples.begin(), audio.samples.end(), 0.0f);
+      const auto finished = std::chrono::steady_clock::now();
+      const int duration_ms = static_cast<int>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(finished - started).count()
+      );
+      res.set_content(
+        make_transcription_json(
+          id,
+          transcript,
+          config.language,
+          duration_ms,
+          req.body.size(),
+          wake_phrase_detected,
+          config.wake_phrase),
+        "application/json"
+      );
+    } catch (const std::exception &error) {
+      const auto finished = std::chrono::steady_clock::now();
+      const int duration_ms = static_cast<int>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(finished - started).count()
+      );
+      std::cerr << "{\"event\":\"voice_listener.error\",\"request_id\":\"" << id
+                << "\",\"duration_ms\":" << duration_ms
+                << ",\"error\":\"" << json_escape(error.what()) << "\"}\n";
+      res.status = 500;
+      res.set_content(make_json_error(error.what()), "application/json");
+    }
+  };
+
+  server.Post("/v1/transcribe", transcribe_handler);
+  server.Post("/api/asr/transcribe", transcribe_handler);
+
+  std::cout << "NAIM voice-module runtime listening on "
+            << config.host << ":" << config.port << "\n";
+  std::cout << "whisper.cpp model: " << config.model_path << "\n";
+  const bool ok = server.listen(config.host, config.port);
+  whisper_free(ctx);
+  return ok ? 0 : 1;
+}

--- a/ui/operator-react/src/planeV2Form.jsx
+++ b/ui/operator-react/src/planeV2Form.jsx
@@ -19,6 +19,9 @@ const TURBOQUANT_CACHE_TYPES = ["f16", "turbo3", "turbo4"];
 const CONTEXT_COMPRESSION_DEFAULT_MODE = "auto";
 const CONTEXT_COMPRESSION_DEFAULT_TARGET = "dialog_and_knowledge";
 const CONTEXT_COMPRESSION_DEFAULT_MEMORY_PRIORITY = "balanced";
+const VOICE_LISTENER_DEFAULT_WAKE_PHRASE = "Hey Jex";
+const VOICE_LISTENER_DEFAULT_LANGUAGE = "auto";
+const VOICE_LISTENER_DEFAULT_MOUNT_PATH = "/models/whisper/model.bin";
 const LT_CYPHER_PLANE_NAME = "lt-cypher-ai";
 const LT_CYPHER_HARBOR_IMAGE_PREFIX = "chainzano.com/localtrade/lt-cypher-ai:";
 const LT_CYPHER_DEFAULT_IMAGE = `${LT_CYPHER_HARBOR_IMAGE_PREFIX}<git-sha>`;
@@ -83,6 +86,10 @@ const FIELD_INFO = {
   contextCompressionMode: "Context Compression mode. V1 supports auto only.",
   contextCompressionTarget: "Prompt segments compressed by Context Compression. V1 supports dialog and knowledge together only.",
   contextCompressionMemoryPriority: "Budget policy used by Context Compression. V1 supports balanced only.",
+  voiceListenerEnabled: "Enable a plane-owned Voice Listener service backed by whisper.cpp ASR.",
+  voiceListenerModel: "Whisper model artifact used by the Voice Listener. Only whisper.cpp models are selectable here.",
+  voiceListenerWakePhrase: "Phrase that activates the listener before a transcript is submitted to chat.",
+  voiceListenerLanguage: "Language hint for whisper.cpp. Use auto unless a plane must listen in one fixed language.",
   browserSessionEnabled: "Allow approval-gated browser session APIs for this plane. Search and sanitized fetch stay enabled when Isolated Browsing is on.",
   turboquantEnabled: "Enable KV-cache quantization for llama.cpp + llama_rpc planes. This requires a compatible turboquant-capable llama.cpp build.",
   turboquantCacheTypeK: "KV cache type used for K cache pages. Defaults to turbo4 when TurboQuant is enabled.",
@@ -323,6 +330,20 @@ function inferModelQuantization(item) {
     }
   }
   return explicit;
+}
+
+function isWhisperModelLibraryItem(item) {
+  const format = inferModelFormat(item);
+  if (format === "whisper.cpp" || format === "whisper") {
+    return true;
+  }
+  const text = normalizeSearchText([item?.name, item?.model_id, item?.path, ...modelLibraryPaths(item)].join(" "));
+  return text.includes("whisper") || /(^|\/)ggml-[^/]+\.bin$/.test(text);
+}
+
+function whisperModelMountPath(item) {
+  const name = String(item?.name || item?.path?.split("/").pop() || "model.bin").trim() || "model.bin";
+  return `/models/whisper/${name}`;
 }
 
 function findLtCypherModelItem(items) {
@@ -726,6 +747,14 @@ export function buildNewPlaneFormState() {
     contextCompressionMode: CONTEXT_COMPRESSION_DEFAULT_MODE,
     contextCompressionTarget: CONTEXT_COMPRESSION_DEFAULT_TARGET,
     contextCompressionMemoryPriority: CONTEXT_COMPRESSION_DEFAULT_MEMORY_PRIORITY,
+    voiceListenerEnabled: false,
+    voiceListenerWakePhrase: VOICE_LISTENER_DEFAULT_WAKE_PHRASE,
+    voiceListenerLanguage: VOICE_LISTENER_DEFAULT_LANGUAGE,
+    voiceListenerModelPath: "",
+    voiceListenerModelRef: "",
+    voiceListenerModelNodeName: "",
+    voiceListenerModelPaths: [],
+    voiceListenerModelMountPath: VOICE_LISTENER_DEFAULT_MOUNT_PATH,
     planeMode: "llm",
     protectedPlane: false,
     factorySkillIds: [],
@@ -862,6 +891,9 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
   const appHost = value?.placement?.app_host || {};
   const turboquant = value?.features?.turboquant || {};
   const contextCompression = value?.features?.context_compression || {};
+  const voiceListener = value?.features?.voice_listener || {};
+  const voiceListenerModel = voiceListener?.model || {};
+  const voiceListenerModelSource = voiceListenerModel?.source || {};
   const planeName = value?.plane_name || defaults.planeName;
   const servedModelName = value?.model?.served_model_name || deriveServedModelName(planeName);
   const serverName = network.server_name || deriveServerName(planeName);
@@ -896,6 +928,19 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
     contextCompressionMemoryPriority:
       contextCompression?.memory_priority ||
       CONTEXT_COMPRESSION_DEFAULT_MEMORY_PRIORITY,
+    voiceListenerEnabled: Boolean(voiceListener?.enabled),
+    voiceListenerWakePhrase:
+      voiceListener?.wake_phrase || VOICE_LISTENER_DEFAULT_WAKE_PHRASE,
+    voiceListenerLanguage:
+      voiceListener?.language || VOICE_LISTENER_DEFAULT_LANGUAGE,
+    voiceListenerModelPath: voiceListenerModelSource?.path || "",
+    voiceListenerModelRef: voiceListenerModelSource?.ref || voiceListenerModel?.name || "",
+    voiceListenerModelNodeName: voiceListenerModelSource?.node || "",
+    voiceListenerModelPaths: Array.isArray(voiceListenerModelSource?.paths)
+      ? voiceListenerModelSource.paths
+      : [],
+    voiceListenerModelMountPath:
+      voiceListenerModel?.mount_path || VOICE_LISTENER_DEFAULT_MOUNT_PATH,
     planeMode: value?.plane_mode || defaults.planeMode,
     protectedPlane: Boolean(value?.protected),
     factorySkillIds: Array.isArray(value?.skills?.factory_skill_ids)
@@ -1245,6 +1290,41 @@ export function buildDesiredStateV2FromForm(form) {
         memory_priority: CONTEXT_COMPRESSION_DEFAULT_MEMORY_PRIORITY,
       };
     }
+    if (form.voiceListenerEnabled) {
+      const source = {
+        type: "library",
+        path: String(form.voiceListenerModelPath || "").trim(),
+      };
+      if (String(form.voiceListenerModelNodeName || "").trim()) {
+        source.node = String(form.voiceListenerModelNodeName || "").trim();
+      }
+      const sourcePaths = (Array.isArray(form.voiceListenerModelPaths)
+        ? form.voiceListenerModelPaths
+        : [])
+        .map((path) => String(path || "").trim())
+        .filter(Boolean);
+      if (sourcePaths.length > 0) {
+        source.paths = sourcePaths;
+      }
+      features.voice_listener = {
+        enabled: true,
+        wake_phrase:
+          String(form.voiceListenerWakePhrase || "").trim() ||
+          VOICE_LISTENER_DEFAULT_WAKE_PHRASE,
+        language:
+          String(form.voiceListenerLanguage || "").trim() ||
+          VOICE_LISTENER_DEFAULT_LANGUAGE,
+        model: {
+          name: String(form.voiceListenerModelRef || "").trim() || "whisper",
+          source,
+          mount_path:
+            String(form.voiceListenerModelMountPath || "").trim() ||
+            VOICE_LISTENER_DEFAULT_MOUNT_PATH,
+          env: "WHISPER_MODEL_PATH",
+          required: true,
+        },
+      };
+    }
     if (Object.keys(features).length > 0) {
       desiredState.features = features;
     }
@@ -1460,6 +1540,14 @@ export function validatePlaneV2Form(form) {
     }
   }
   if (form?.planeMode === "llm") {
+    if (form?.voiceListenerEnabled) {
+      if (!String(form?.voiceListenerWakePhrase || "").trim()) {
+        errors.push("Voice Listener Wake Phrase is required.");
+      }
+      if (!String(form?.voiceListenerModelPath || "").trim()) {
+        errors.push("Voice Listener requires a Whisper model.");
+      }
+    }
     if (Number(form?.inferReplicas || 0) <= 0) {
       errors.push("Infer replicas must be a positive integer for llm planes.");
     }
@@ -2165,6 +2253,7 @@ export function PlaneV2FormBuilder({
           skillsEnabled: nextPlaneMode === "llm" ? current.skillsEnabled : false,
           browsingEnabled: nextPlaneMode === "llm" ? current.browsingEnabled : false,
           knowledgeEnabled: nextPlaneMode === "llm" ? current.knowledgeEnabled : false,
+          voiceListenerEnabled: nextPlaneMode === "llm" ? current.voiceListenerEnabled : false,
           browserSessionEnabled:
             nextPlaneMode === "llm" ? current.browserSessionEnabled : false,
         });
@@ -2287,6 +2376,17 @@ export function PlaneV2FormBuilder({
           : fallbackName.replace(/\s+/g, "-").toLowerCase(),
       };
     });
+  }
+
+  function selectVoiceListenerModel(item) {
+    updatePlaneDialogForm(setDialog, (current) => ({
+      ...current,
+      voiceListenerModelPath: item?.path || "",
+      voiceListenerModelRef: item?.model_id || item?.name || item?.path || "whisper",
+      voiceListenerModelNodeName: item?.node_name || "",
+      voiceListenerModelPaths: Array.isArray(item?.paths) ? item.paths : [],
+      voiceListenerModelMountPath: whisperModelMountPath(item),
+    }));
   }
 
   function updateTopologyNodes(update) {
@@ -2424,6 +2524,8 @@ export function PlaneV2FormBuilder({
   );
   const factoryGroupTree = buildSkillsFactoryGroupTree(skillsFactoryItems, skillsFactoryGroups);
   const factoryTreePaths = collectSkillsFactoryTreePaths(factoryGroupTree);
+  const whisperModelLibraryItems = (Array.isArray(modelLibraryItems) ? modelLibraryItems : [])
+    .filter(isWhisperModelLibraryItem);
   const expandedFactoryGroupPathSet = new Set(expandedFactoryGroupPaths);
 
   function renderFactoryGroupNode(node) {
@@ -2637,6 +2739,14 @@ export function PlaneV2FormBuilder({
           disabled={form.planeMode !== "llm"}
           disabledLabel="LLM only"
           onToggle={toggleFeature("turboquantEnabled")}
+        />
+        <FeatureToggle
+          title="Voice Listener"
+          info={FIELD_INFO.voiceListenerEnabled}
+          active={form.planeMode === "llm" && form.voiceListenerEnabled}
+          disabled={form.planeMode !== "llm"}
+          disabledLabel="LLM only"
+          onToggle={toggleFeature("voiceListenerEnabled")}
         />
         <FeatureToggle
           title="App"

--- a/ui/operator-react/src/skillsFactory.test.js
+++ b/ui/operator-react/src/skillsFactory.test.js
@@ -265,6 +265,44 @@ describe("planeV2Form SkillsFactory mapping", () => {
     expect(reparsed.contextCompressionMemoryPriority).toBe("balanced");
   });
 
+  it("round-trips voice listener capability through desired state v2", () => {
+    const form = buildNewPlaneFormState();
+    form.planeName = "voice-plane";
+    form.modelPath = "/models/qwen";
+    form.voiceListenerEnabled = true;
+    form.voiceListenerWakePhrase = "Hey Jex";
+    form.voiceListenerLanguage = "auto";
+    form.voiceListenerModelPath = "/models/whisper/ggml-large-v3-turbo-q5_0.bin";
+    form.voiceListenerModelRef = "ggml-large-v3-turbo-q5_0.bin";
+    form.voiceListenerModelNodeName = "storage1";
+    form.voiceListenerModelPaths = ["/models/whisper/ggml-large-v3-turbo-q5_0.bin"];
+    form.voiceListenerModelMountPath = "/models/whisper/ggml-large-v3-turbo-q5_0.bin";
+
+    const desiredState = buildDesiredStateV2FromForm(form);
+    expect(desiredState.features.voice_listener).toEqual({
+      enabled: true,
+      wake_phrase: "Hey Jex",
+      language: "auto",
+      model: {
+        name: "ggml-large-v3-turbo-q5_0.bin",
+        source: {
+          type: "library",
+          path: "/models/whisper/ggml-large-v3-turbo-q5_0.bin",
+          node: "storage1",
+          paths: ["/models/whisper/ggml-large-v3-turbo-q5_0.bin"],
+        },
+        mount_path: "/models/whisper/ggml-large-v3-turbo-q5_0.bin",
+        env: "WHISPER_MODEL_PATH",
+        required: true,
+      },
+    });
+
+    const reparsed = buildPlaneFormStateFromDesiredStateV2(desiredState);
+    expect(reparsed.voiceListenerEnabled).toBe(true);
+    expect(reparsed.voiceListenerWakePhrase).toBe("Hey Jex");
+    expect(reparsed.voiceListenerModelPath).toBe("/models/whisper/ggml-large-v3-turbo-q5_0.bin");
+  });
+
   it("preserves interaction runtime image through desired state v2 round-trip", () => {
     const desiredState = {
       ...buildDesiredStateV2FromForm(buildNewPlaneFormState()),


### PR DESCRIPTION
## Summary
- add NAIM desired-state support for features.voice_listener and voice-module runtime role
- add a standalone whisper.cpp-backed runtime/voice container
- add operator UI fields for enabling Voice Listener, Wake Phrase, language hint, and Whisper-only model selection

## Tests
- npm test (ui/operator-react): 46 passed
- cmake --build build/voice-listener-check --target naim-state-v2-tests naim-state-v2-projector-tests -j 24
- ./build/voice-listener-check/naim-state-v2-tests
- ./build/voice-listener-check/naim-state-v2-projector-tests

Note: local full CUDA configure on WSL hangs after FindCUDAToolkit while entering llama.cpp/ggml-cuda configure; isolated reproduction is being tracked separately from this state/UI/runtime feature work.