### PR TITLE
Add voice module image to NAIM releases

### DIFF
--- a/scripts/build-runtime-images.sh
+++ b/scripts/build-runtime-images.sh
@@ -101,6 +101,7 @@ interaction_tag="${7:-naim/interaction-runtime:dev}"
 controller_tag="${8:-naim/controller:dev}"
 hostd_tag="${9:-naim/hostd:dev}"
 knowledge_tag="${10:-naim/knowledge-runtime:dev}"
+voice_module_tag="${11:-naim/voice-module:dev}"
 
 build_dir="$("${script_dir}/print-build-dir.sh")"
 turboquant_build_dir="${NAIM_TURBOQUANT_BUILD_DIR:-${repo_root}/build-turboquant/linux/x64}"
@@ -248,6 +249,12 @@ echo "building ${interaction_tag}"
   -t "${interaction_tag}" \
   "${image_context}"
 
+echo "building ${voice_module_tag}"
+"${docker_cmd[@]}" build \
+  -f "${image_context}/runtime/voice/Dockerfile" \
+  -t "${voice_module_tag}" \
+  "${image_context}/runtime/voice"
+
 if [[ "${skip_web_ui}" != "yes" ]]; then
   echo "building ${web_ui_tag}"
   build_web_ui_image
@@ -264,6 +271,7 @@ echo "  skills=${skills_tag}"
 echo "  knowledge=${knowledge_tag}"
 echo "  webgateway=${webgateway_tag}"
 echo "  interaction=${interaction_tag}"
+echo "  voice_module=${voice_module_tag}"
 if [[ "${skip_web_ui}" != "yes" ]]; then
   echo "  web_ui=${web_ui_tag}"
 fi

--- a/scripts/ci/fetch-main-release-report.sh
+++ b/scripts/ci/fetch-main-release-report.sh
@@ -77,6 +77,7 @@ manifest_hostd = None
 manifest_controller = None
 manifest_web_ui = None
 manifest_knowledge = None
+manifest_voice_module = None
 try:
     with open(manifest_path, "r", encoding="utf-8") as handle:
         manifest = json.load(handle)
@@ -88,6 +89,7 @@ try:
     manifest_hostd = (manifest.get("images") or {}).get("hostd")
     manifest_web_ui = (manifest.get("images") or {}).get("web-ui")
     manifest_knowledge = (manifest.get("images") or {}).get("knowledge-runtime")
+    manifest_voice_module = (manifest.get("images") or {}).get("voice-module")
 except FileNotFoundError:
     pass
 
@@ -151,6 +153,8 @@ if manifest_web_ui:
     lines.append(f"- web ui image: `{manifest_web_ui}`")
 if manifest_knowledge:
     lines.append(f"- knowledge runtime image: `{manifest_knowledge}`")
+if manifest_voice_module:
+    lines.append(f"- voice module image: `{manifest_voice_module}`")
 lines.append("")
 lines.append("### Main")
 if docker_lines:

--- a/scripts/ci/main-bootstrap-controller-update.sh
+++ b/scripts/ci/main-bootstrap-controller-update.sh
@@ -353,6 +353,7 @@ managed_images = {
     ("browsing", "image"): images.get("webgateway-runtime", ""),
 }
 interaction_image = images.get("interaction-runtime", "")
+voice_module_image = images.get("voice-module", "")
 
 def is_managed_image(value: object) -> bool:
     if not isinstance(value, str):
@@ -400,6 +401,15 @@ for row in rows:
             if current != interaction_image:
                 interaction["image"] = interaction_image
                 changed = True
+    features = payload.get("features")
+    if isinstance(features, dict) and voice_module_image:
+        voice_listener = features.get("voice_listener")
+        if isinstance(voice_listener, dict) and voice_listener.get("enabled") is True:
+            current = voice_listener.get("image")
+            if current is None or is_managed_image(current):
+                if current != voice_module_image:
+                    voice_listener["image"] = voice_module_image
+                    changed = True
     if not changed:
         continue
     state_path = output_dir / f"{row['name']}.desired-state.v2.json"

--- a/scripts/release/build-and-push-images.sh
+++ b/scripts/release/build-and-push-images.sh
@@ -133,6 +133,7 @@ skills_ref="$(image_ref skills-runtime)"
 knowledge_ref="$(image_ref knowledge-runtime)"
 webgateway_ref="$(image_ref webgateway-runtime)"
 interaction_ref="$(image_ref interaction-runtime)"
+voice_module_ref="$(image_ref voice-module)"
 controller_ref="$(image_ref controller)"
 hostd_ref="$(image_ref hostd)"
 
@@ -147,6 +148,7 @@ build_args=(
   "${controller_ref}"
   "${hostd_ref}"
   "${knowledge_ref}"
+  "${voice_module_ref}"
 )
 
 if [[ "${skip_web_ui}" == "yes" ]]; then
@@ -165,6 +167,7 @@ declare -a image_names=(
   knowledge-runtime
   webgateway-runtime
   interaction-runtime
+  voice-module
 )
 if [[ "${skip_web_ui}" != "yes" ]]; then
   image_names+=(web-ui)


### PR DESCRIPTION
## Summary
- build and push the new voice-module runtime image in release builds
- include voice-module in release manifests and reports
- refresh enabled features.voice_listener.image to the immutable release image during managed rollout

## Tests
- bash -n scripts/build-runtime-images.sh scripts/release/build-and-push-images.sh scripts/ci/main-bootstrap-controller-update.sh scripts/ci/fetch-main-release-report.sh