### PR TITLE
Build voice module runtime on host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ option(NAIM_ENABLE_LLAMA_RUNTIME
        ON)
 option(NAIM_ENABLE_CUDA "Build llama.cpp runtime with CUDA backend" ON)
 option(NAIM_ENABLE_CEF_BROWSING "Enable CEF-backed browsing runtime support" OFF)
+option(NAIM_ENABLE_VOICE_MODULE
+       "Configure whisper.cpp-backed Voice Listener runtime target"
+       ON)
 set(NAIM_CEF_ROOT "" CACHE PATH "Path to an unpacked CEF binary distribution")
 set(NAIM_CEF_DOWNLOAD_URL "" CACHE STRING "Optional URL to a CEF binary distribution archive")
 
@@ -65,6 +68,49 @@ project(
 )
 
 find_package(Threads REQUIRED)
+
+if(NAIM_ENABLE_VOICE_MODULE AND NOT WIN32)
+  include(FetchContent)
+
+  if(DEFINED BUILD_SHARED_LIBS)
+    set(_naim_voice_saved_build_shared_libs "${BUILD_SHARED_LIBS}")
+    set(_naim_voice_restore_build_shared_libs ON)
+  else()
+    set(_naim_voice_restore_build_shared_libs OFF)
+  endif()
+
+  set(NAIM_WHISPER_CPP_GIT_TAG "v1.8.1" CACHE STRING
+      "Pinned whisper.cpp release used for the NAIM voice-module runtime")
+  set(NAIM_CPP_HTTPLIB_GIT_TAG "v0.26.0" CACHE STRING
+      "Pinned cpp-httplib release used for the NAIM voice-module runtime")
+
+  set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static whisper.cpp for the NAIM voice-module runtime" FORCE)
+  set(WHISPER_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+  set(WHISPER_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+  set(WHISPER_BUILD_SERVER OFF CACHE BOOL "" FORCE)
+
+  FetchContent_Declare(
+    whisper_cpp
+    GIT_REPOSITORY https://github.com/ggml-org/whisper.cpp.git
+    GIT_TAG ${NAIM_WHISPER_CPP_GIT_TAG}
+    GIT_SHALLOW TRUE
+  )
+  FetchContent_Declare(
+    cpp_httplib
+    GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+    GIT_TAG ${NAIM_CPP_HTTPLIB_GIT_TAG}
+    GIT_SHALLOW TRUE
+  )
+  FetchContent_MakeAvailable(whisper_cpp cpp_httplib)
+
+  if(_naim_voice_restore_build_shared_libs)
+    set(BUILD_SHARED_LIBS "${_naim_voice_saved_build_shared_libs}" CACHE BOOL "" FORCE)
+  else()
+    unset(BUILD_SHARED_LIBS CACHE)
+  endif()
+  unset(_naim_voice_saved_build_shared_libs)
+  unset(_naim_voice_restore_build_shared_libs)
+endif()
 
 function(naim_enable_strict_warnings target_name)
   if(MSVC)
@@ -1616,6 +1662,27 @@ if(NOT WIN32)
     target_link_libraries(naim-knowledged PRIVATE ws2_32)
   endif()
   naim_enable_strict_warnings(naim-knowledged)
+
+  if(NAIM_ENABLE_VOICE_MODULE)
+    add_executable(
+      naim-voice-moduled
+      runtime/voice/src/main.cpp
+    )
+    target_include_directories(
+      naim-voice-moduled
+      PRIVATE
+        "${whisper_cpp_SOURCE_DIR}/include"
+        "${whisper_cpp_SOURCE_DIR}/ggml/include"
+        "${cpp_httplib_SOURCE_DIR}"
+    )
+    target_link_libraries(
+      naim-voice-moduled
+      PRIVATE
+        whisper
+        Threads::Threads
+    )
+    naim_enable_strict_warnings(naim-voice-moduled)
+  endif()
 
   add_executable(
     naim-inferctl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1681,64 +1681,44 @@ if(NOT WIN32)
   naim_enable_strict_warnings(naim-workerd)
 
   if(NAIM_ENABLE_VOICE_MODULE)
-    include(FetchContent)
-
-    if(DEFINED BUILD_SHARED_LIBS)
-      set(_naim_voice_saved_build_shared_libs "${BUILD_SHARED_LIBS}")
-      set(_naim_voice_restore_build_shared_libs ON)
-    else()
-      set(_naim_voice_restore_build_shared_libs OFF)
-    endif()
-
     set(NAIM_WHISPER_CPP_GIT_TAG "v1.8.1" CACHE STRING
         "Pinned whisper.cpp release used for the NAIM voice-module runtime")
     set(NAIM_CPP_HTTPLIB_GIT_TAG "v0.26.0" CACHE STRING
         "Pinned cpp-httplib release used for the NAIM voice-module runtime")
+    include(ExternalProject)
 
-    set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static whisper.cpp for the NAIM voice-module runtime" FORCE)
-    set(WHISPER_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-    set(WHISPER_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-    set(WHISPER_BUILD_SERVER OFF CACHE BOOL "" FORCE)
-
-    FetchContent_Declare(
-      whisper_cpp
-      GIT_REPOSITORY https://github.com/ggml-org/whisper.cpp.git
-      GIT_TAG ${NAIM_WHISPER_CPP_GIT_TAG}
-      GIT_SHALLOW TRUE
+    set(_naim_voice_module_build_dir "${CMAKE_BINARY_DIR}/runtime/voice-module-build")
+    set(_naim_voice_module_output "${CMAKE_BINARY_DIR}/naim-voice-moduled")
+    set(_naim_voice_module_cmake_args
+        "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+        "-DNAIM_WHISPER_CPP_GIT_TAG=${NAIM_WHISPER_CPP_GIT_TAG}"
+        "-DNAIM_CPP_HTTPLIB_GIT_TAG=${NAIM_CPP_HTTPLIB_GIT_TAG}"
     )
-    FetchContent_Declare(
-      cpp_httplib
-      GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-      GIT_TAG ${NAIM_CPP_HTTPLIB_GIT_TAG}
-      GIT_SHALLOW TRUE
-    )
-    FetchContent_MakeAvailable(whisper_cpp cpp_httplib)
-
-    if(_naim_voice_restore_build_shared_libs)
-      set(BUILD_SHARED_LIBS "${_naim_voice_saved_build_shared_libs}" CACHE BOOL "" FORCE)
-    else()
-      unset(BUILD_SHARED_LIBS CACHE)
+    if(CMAKE_C_COMPILER)
+      list(APPEND _naim_voice_module_cmake_args "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}")
     endif()
-    unset(_naim_voice_saved_build_shared_libs)
-    unset(_naim_voice_restore_build_shared_libs)
+    if(CMAKE_CXX_COMPILER)
+      list(APPEND _naim_voice_module_cmake_args "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
+    endif()
 
-    add_executable(
-      naim-voice-moduled
-      runtime/voice/src/main.cpp
+    ExternalProject_Add(
+      naim-voice-module-runtime
+      SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/runtime/voice"
+      BINARY_DIR "${_naim_voice_module_build_dir}"
+      CMAKE_ARGS ${_naim_voice_module_cmake_args}
+      BUILD_COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target naim-voice-moduled
+      INSTALL_COMMAND
+        "${CMAKE_COMMAND}" -E copy_if_different
+        "<BINARY_DIR>/naim-voice-moduled"
+        "${_naim_voice_module_output}"
+      BUILD_BYPRODUCTS "${_naim_voice_module_output}"
     )
-    target_include_directories(
-      naim-voice-moduled
-      PRIVATE
-        "${whisper_cpp_SOURCE_DIR}/include"
-        "${whisper_cpp_SOURCE_DIR}/ggml/include"
-        "${cpp_httplib_SOURCE_DIR}"
+
+    add_custom_target(
+      naim-voice-module-runtime-all
+      ALL
+      DEPENDS naim-voice-module-runtime
     )
-    target_link_libraries(
-      naim-voice-moduled
-      PRIVATE
-        whisper
-        Threads::Threads
-    )
-    naim_enable_strict_warnings(naim-voice-moduled)
+    unset(_naim_voice_module_cmake_args)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,49 +69,6 @@ project(
 
 find_package(Threads REQUIRED)
 
-if(NAIM_ENABLE_VOICE_MODULE AND NOT WIN32)
-  include(FetchContent)
-
-  if(DEFINED BUILD_SHARED_LIBS)
-    set(_naim_voice_saved_build_shared_libs "${BUILD_SHARED_LIBS}")
-    set(_naim_voice_restore_build_shared_libs ON)
-  else()
-    set(_naim_voice_restore_build_shared_libs OFF)
-  endif()
-
-  set(NAIM_WHISPER_CPP_GIT_TAG "v1.8.1" CACHE STRING
-      "Pinned whisper.cpp release used for the NAIM voice-module runtime")
-  set(NAIM_CPP_HTTPLIB_GIT_TAG "v0.26.0" CACHE STRING
-      "Pinned cpp-httplib release used for the NAIM voice-module runtime")
-
-  set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static whisper.cpp for the NAIM voice-module runtime" FORCE)
-  set(WHISPER_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-  set(WHISPER_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-  set(WHISPER_BUILD_SERVER OFF CACHE BOOL "" FORCE)
-
-  FetchContent_Declare(
-    whisper_cpp
-    GIT_REPOSITORY https://github.com/ggml-org/whisper.cpp.git
-    GIT_TAG ${NAIM_WHISPER_CPP_GIT_TAG}
-    GIT_SHALLOW TRUE
-  )
-  FetchContent_Declare(
-    cpp_httplib
-    GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-    GIT_TAG ${NAIM_CPP_HTTPLIB_GIT_TAG}
-    GIT_SHALLOW TRUE
-  )
-  FetchContent_MakeAvailable(whisper_cpp cpp_httplib)
-
-  if(_naim_voice_restore_build_shared_libs)
-    set(BUILD_SHARED_LIBS "${_naim_voice_saved_build_shared_libs}" CACHE BOOL "" FORCE)
-  else()
-    unset(BUILD_SHARED_LIBS CACHE)
-  endif()
-  unset(_naim_voice_saved_build_shared_libs)
-  unset(_naim_voice_restore_build_shared_libs)
-endif()
-
 function(naim_enable_strict_warnings target_name)
   if(MSVC)
     target_compile_options(${target_name} PRIVATE /W4)
@@ -1663,27 +1620,6 @@ if(NOT WIN32)
   endif()
   naim_enable_strict_warnings(naim-knowledged)
 
-  if(NAIM_ENABLE_VOICE_MODULE)
-    add_executable(
-      naim-voice-moduled
-      runtime/voice/src/main.cpp
-    )
-    target_include_directories(
-      naim-voice-moduled
-      PRIVATE
-        "${whisper_cpp_SOURCE_DIR}/include"
-        "${whisper_cpp_SOURCE_DIR}/ggml/include"
-        "${cpp_httplib_SOURCE_DIR}"
-    )
-    target_link_libraries(
-      naim-voice-moduled
-      PRIVATE
-        whisper
-        Threads::Threads
-    )
-    naim_enable_strict_warnings(naim-voice-moduled)
-  endif()
-
   add_executable(
     naim-inferctl
     runtime/infer/src/app/infer_command_line.cpp
@@ -1743,4 +1679,66 @@ if(NOT WIN32)
       # llama
   )
   naim_enable_strict_warnings(naim-workerd)
+
+  if(NAIM_ENABLE_VOICE_MODULE)
+    include(FetchContent)
+
+    if(DEFINED BUILD_SHARED_LIBS)
+      set(_naim_voice_saved_build_shared_libs "${BUILD_SHARED_LIBS}")
+      set(_naim_voice_restore_build_shared_libs ON)
+    else()
+      set(_naim_voice_restore_build_shared_libs OFF)
+    endif()
+
+    set(NAIM_WHISPER_CPP_GIT_TAG "v1.8.1" CACHE STRING
+        "Pinned whisper.cpp release used for the NAIM voice-module runtime")
+    set(NAIM_CPP_HTTPLIB_GIT_TAG "v0.26.0" CACHE STRING
+        "Pinned cpp-httplib release used for the NAIM voice-module runtime")
+
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static whisper.cpp for the NAIM voice-module runtime" FORCE)
+    set(WHISPER_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(WHISPER_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(WHISPER_BUILD_SERVER OFF CACHE BOOL "" FORCE)
+
+    FetchContent_Declare(
+      whisper_cpp
+      GIT_REPOSITORY https://github.com/ggml-org/whisper.cpp.git
+      GIT_TAG ${NAIM_WHISPER_CPP_GIT_TAG}
+      GIT_SHALLOW TRUE
+    )
+    FetchContent_Declare(
+      cpp_httplib
+      GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+      GIT_TAG ${NAIM_CPP_HTTPLIB_GIT_TAG}
+      GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(whisper_cpp cpp_httplib)
+
+    if(_naim_voice_restore_build_shared_libs)
+      set(BUILD_SHARED_LIBS "${_naim_voice_saved_build_shared_libs}" CACHE BOOL "" FORCE)
+    else()
+      unset(BUILD_SHARED_LIBS CACHE)
+    endif()
+    unset(_naim_voice_saved_build_shared_libs)
+    unset(_naim_voice_restore_build_shared_libs)
+
+    add_executable(
+      naim-voice-moduled
+      runtime/voice/src/main.cpp
+    )
+    target_include_directories(
+      naim-voice-moduled
+      PRIVATE
+        "${whisper_cpp_SOURCE_DIR}/include"
+        "${whisper_cpp_SOURCE_DIR}/ggml/include"
+        "${cpp_httplib_SOURCE_DIR}"
+    )
+    target_link_libraries(
+      naim-voice-moduled
+      PRIVATE
+        whisper
+        Threads::Threads
+    )
+    naim_enable_strict_warnings(naim-voice-moduled)
+  endif()
 endif()

--- a/runtime/voice/CMakeLists.txt
+++ b/runtime/voice/CMakeLists.txt
@@ -1,20 +1,61 @@
-cmake_minimum_required(VERSION 3.20)
-project(naim_voice_module LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.22)
 
-set(CMAKE_CXX_STANDARD 17)
+project(
+  naim-voice-module-runtime
+  LANGUAGES C CXX
+)
+
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(Threads REQUIRED)
+include(FetchContent)
 
+set(NAIM_WHISPER_CPP_GIT_TAG "v1.8.1" CACHE STRING
+    "Pinned whisper.cpp release used for the NAIM voice-module runtime")
+set(NAIM_CPP_HTTPLIB_GIT_TAG "v0.26.0" CACHE STRING
+    "Pinned cpp-httplib release used for the NAIM voice-module runtime")
+
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static whisper.cpp for the NAIM voice-module runtime" FORCE)
+set(GGML_CUDA OFF CACHE BOOL "Build whisper.cpp without CUDA for the NAIM voice-module runtime" FORCE)
 set(WHISPER_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(WHISPER_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-add_subdirectory(third_party/whisper.cpp)
+set(WHISPER_BUILD_SERVER OFF CACHE BOOL "" FORCE)
 
-add_executable(naim-voice-moduled src/main.cpp)
-target_include_directories(naim-voice-moduled PRIVATE
-  ${CMAKE_SOURCE_DIR}/third_party/whisper.cpp/include
-  ${CMAKE_SOURCE_DIR}/third_party/whisper.cpp/ggml/include
-  ${CMAKE_SOURCE_DIR}/third_party/cpp-httplib
+FetchContent_Declare(
+  whisper_cpp
+  GIT_REPOSITORY https://github.com/ggml-org/whisper.cpp.git
+  GIT_TAG ${NAIM_WHISPER_CPP_GIT_TAG}
+  GIT_SHALLOW TRUE
 )
-target_link_libraries(naim-voice-moduled PRIVATE whisper Threads::Threads)
+FetchContent_Declare(
+  cpp_httplib
+  GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+  GIT_TAG ${NAIM_CPP_HTTPLIB_GIT_TAG}
+  GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(whisper_cpp cpp_httplib)
+
+add_executable(
+  naim-voice-moduled
+  src/main.cpp
+)
+target_include_directories(
+  naim-voice-moduled
+  PRIVATE
+    "${whisper_cpp_SOURCE_DIR}/include"
+    "${whisper_cpp_SOURCE_DIR}/ggml/include"
+    "${cpp_httplib_SOURCE_DIR}"
+)
+target_link_libraries(
+  naim-voice-moduled
+  PRIVATE
+    whisper
+    Threads::Threads
+)
+if(MSVC)
+  target_compile_options(naim-voice-moduled PRIVATE /W4)
+else()
+  target_compile_options(naim-voice-moduled PRIVATE -Wall -Wextra -Wpedantic)
+endif()

--- a/runtime/voice/Dockerfile
+++ b/runtime/voice/Dockerfile
@@ -1,24 +1,3 @@
-FROM debian:bookworm-slim AS build
-
-ARG WHISPER_CPP_REF=v1.8.1
-ARG CPP_HTTPLIB_REF=v0.26.0
-
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates cmake curl g++ git make pkg-config \
-  && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /src
-RUN git clone --depth 1 --branch "${WHISPER_CPP_REF}" https://github.com/ggml-org/whisper.cpp.git third_party/whisper.cpp
-RUN mkdir -p third_party/cpp-httplib \
-  && curl -fsSL "https://raw.githubusercontent.com/yhirose/cpp-httplib/${CPP_HTTPLIB_REF}/httplib.h" \
-    -o third_party/cpp-httplib/httplib.h
-
-COPY CMakeLists.txt ./
-COPY src ./src
-
-RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
-  && cmake --build build -j
-
 FROM debian:bookworm-slim
 
 ENV HOST=0.0.0.0 \
@@ -35,7 +14,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && mkdir -p /models /tmp/naim-voice-module /runtime/bin
 
-COPY --from=build /src/build/naim-voice-moduled /runtime/bin/naim-voice-moduled
+COPY build/linux/x64/naim-voice-moduled /runtime/bin/naim-voice-moduled
 
 EXPOSE 18140
 

--- a/runtime/voice/src/main.cpp
+++ b/runtime/voice/src/main.cpp
@@ -452,7 +452,7 @@ int main() {
 
   server.Get("/health", [&](const httplib::Request &, httplib::Response &res) {
     res.set_content(
-      "{\"status\":\"ok\",\"engine\":\"whisper.cpp\",\"api_owner\":\"lt-cypher-ai\",\"model_path\":\"" +
+      "{\"status\":\"ok\",\"engine\":\"whisper.cpp\",\"api_owner\":\"naim\",\"model_path\":\"" +
         json_escape(config.model_path) + "\"}",
       "application/json"
     );

--- a/scripts/build-runtime-images.sh
+++ b/scripts/build-runtime-images.sh
@@ -119,6 +119,7 @@ cp -R "${repo_root}/runtime" "${image_context}/runtime"
 for binary in naim-controller naim-hostd naim-node naim-inferctl naim-workerd naim-skillsd naim-knowledged naim-webgatewayd naim-interactiond; do
   cp "${build_dir}/${binary}" "${image_context}/build/linux/x64/${binary}"
 done
+cp "${build_dir}/naim-voice-moduled" "${image_context}/build/linux/x64/naim-voice-moduled"
 cp "${build_dir}/bin/llama-server" "${image_context}/build/linux/x64/bin/llama-server"
 cp "${build_dir}/bin/rpc-server" "${image_context}/build/linux/x64/bin/rpc-server"
 copy_turboquant_binary() {
@@ -253,7 +254,7 @@ echo "building ${voice_module_tag}"
 "${docker_cmd[@]}" build \
   -f "${image_context}/runtime/voice/Dockerfile" \
   -t "${voice_module_tag}" \
-  "${image_context}/runtime/voice"
+  "${image_context}"
 
 if [[ "${skip_web_ui}" != "yes" ]]; then
   echo "building ${web_ui_tag}"


### PR DESCRIPTION
## Summary
- build naim-voice-moduled as a host CMake target using pinned whisper.cpp/cpp-httplib FetchContent
- make the voice-module Dockerfile copy the already-built binary instead of cloning GitHub during Docker build
- copy naim-voice-moduled into runtime image contexts
- mark the voice module health API owner as NAIM

## Tests
- cmake -S . -B build/voice-host-static-check -G Ninja -DCMAKE_BUILD_TYPE=Debug -DNAIM_ENABLE_CUDA=OFF -DNAIM_ENABLE_LLAMA_RUNTIME=OFF
- cmake --build build/voice-host-static-check --target naim-voice-moduled -j 8
- bash -n scripts/build-runtime-images.sh scripts/release/build-and-push-images.sh scripts/ci/main-bootstrap-controller-update.sh scripts/ci/fetch-main-release-report.sh