### PR TITLE
Use compatible runtime base for voice module

### DIFF
--- a/runtime/voice/Dockerfile
+++ b/runtime/voice/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 
 ENV HOST=0.0.0.0 \
     PORT=18140 \


### PR DESCRIPTION
## Summary
- switch the voice-module runtime image from Debian bookworm to Ubuntu 24.04
- keep the runtime base ABI-compatible with the hpc1 Ubuntu 24 build host

## Verification
- git diff --check
- cmake --build build/voice-llama-external-no-cuda --target naim-voice-module-runtime-all -j 8