### PR TITLE
Preserve Voice Listener app environment

### DIFF
--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -851,7 +851,8 @@ void DesiredStateV2Renderer::RenderAppInstance() {
       app.environment["NAIM_VOICE_LISTENER_WAKE_PHRASE"] = state_.voice_listener->wake_phrase;
     }
     if (app_entry.contains("env") && app_entry.at("env").is_object()) {
-      app.environment = app_entry.at("env").get<std::map<std::string, std::string>>();
+      const auto app_env = app_entry.at("env").get<std::map<std::string, std::string>>();
+      app.environment.insert(app_env.begin(), app_env.end());
     }
     app.environment["NAIM_APP_NAME"] = app_name;
     app.environment["NAIM_APP_PRIMARY"] = primary ? "true" : "false";

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -1961,7 +1961,10 @@ int main() {
           {"runtime",
            {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
           {"infer", {{"replicas", 1}}},
-          {"app", {{"enabled", true}, {"image", "example/app:dev"}}},
+          {"app",
+           {{"enabled", true},
+            {"image", "example/app:dev"},
+            {"env", {{"APP_MODE", "voice-test"}}}}},
           {"features",
            {{"voice_listener",
              {{"enabled", true},
@@ -1990,6 +1993,8 @@ int main() {
       Expect(app.environment.at("NAIM_VOICE_LISTENER_BASE") ==
                  "http://voice-module-voice-listener-plane:18140/v1",
              "voice-listener-plane: primary app should receive voice feature base");
+      Expect(app.environment.at("APP_MODE") == "voice-test",
+             "voice-listener-plane: primary app should preserve explicit app env");
       const auto projected = naim::DesiredStateV2Projector::Project(state);
       Expect(projected.at("features").at("voice_listener").at("wake_phrase") == "Hey Jex",
              "voice-listener-plane: projector should preserve wake phrase");


### PR DESCRIPTION
## Summary
- merge explicit app env into generated feature env instead of replacing it
- add regression coverage for Voice Listener plus app env

## Tests
- cmake -S . -B build/codex-voice-env-check -DNAIM_ENABLE_CUDA=OFF -DNAIM_ENABLE_VOICE_MODULE=OFF
- cmake --build build/codex-voice-env-check --target naim-state-v2-tests -- -j2
- ./build/codex-voice-env-check/naim-state-v2-tests