### PR TITLE
Implement GPU ASR sharing

### DIFF
--- a/common/include/naim/state/desired_state_v2_renderer.h
+++ b/common/include/naim/state/desired_state_v2_renderer.h
@@ -46,6 +46,8 @@ class DesiredStateV2Renderer final {
   std::string ResolveAppNodeName(const nlohmann::json& app_json) const;
   std::string ResolveWorkerNodeName(int worker_index) const;
   std::optional<std::string> ResolveWorkerGpuDevice(int worker_index) const;
+  const nlohmann::json& VoiceModuleResources() const;
+  bool VoiceModuleGpuEnabled() const;
   std::optional<std::string> ResolveLegacyServiceNodeName(
       const nlohmann::json& service_json,
       const char* service_name) const;
@@ -110,6 +112,7 @@ class DesiredStateV2Renderer final {
   nlohmann::json worker_json_;
   nlohmann::json resources_json_;
   nlohmann::json worker_resources_json_;
+  nlohmann::json voice_module_resources_json_;
   nlohmann::json app_json_;
   std::vector<nlohmann::json> apps_json_;
   nlohmann::json skills_json_;

--- a/common/include/naim/state/desired_state_v2_validator.h
+++ b/common/include/naim/state/desired_state_v2_validator.h
@@ -24,6 +24,7 @@ class DesiredStateV2Validator final {
   void ValidateInfer() const;
   void ValidateWorker() const;
   void ValidateWorkerResources() const;
+  void ValidateVoiceModuleResources() const;
   void ValidateApp() const;
   void ValidateSingleAppSpec(
       const nlohmann::json& app,

--- a/common/src/state/desired_state_v2_projector.cpp
+++ b/common/src/state/desired_state_v2_projector.cpp
@@ -1,6 +1,7 @@
 #include "naim/state/desired_state_v2_projector.h"
 
 #include <algorithm>
+#include <cmath>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -17,6 +18,8 @@ namespace {
 using ProjectorSupport = DesiredStateV2ProjectorSupport;
 
 constexpr int kDefaultSharedDiskSizeGb = ProjectorSupport::kDefaultSharedDiskSizeGb;
+constexpr double kDefaultVoiceModuleGpuFraction = 0.2;
+constexpr int kDefaultVoiceModuleGpuPriority = 50;
 constexpr std::string_view kDefaultInferImage = ProjectorSupport::kDefaultInferImage;
 constexpr std::string_view kDefaultSkillsImage = ProjectorSupport::kDefaultSkillsImage;
 constexpr std::string_view kDefaultWebGatewayImage =
@@ -727,6 +730,29 @@ void DesiredStateV2Projector::ProjectResources() {
     };
     if (worker->memory_cap_mb.has_value()) {
       resources["worker"]["memory_cap_mb"] = *worker->memory_cap_mb;
+    }
+  }
+  if (voice_module_instance_ != nullptr && voice_module_instance_->gpu_device.has_value()) {
+    resources["voice_module"] = {
+        {"gpu_enabled", true},
+        {"share_mode", ToString(voice_module_instance_->share_mode)},
+        {"gpu_fraction", voice_module_instance_->gpu_fraction},
+    };
+    if (voice_module_instance_->priority != kDefaultVoiceModuleGpuPriority) {
+      resources["voice_module"]["priority"] = voice_module_instance_->priority;
+    }
+    if (voice_module_instance_->preemptible) {
+      resources["voice_module"]["preemptible"] = true;
+    }
+    if (voice_module_instance_->memory_cap_mb.has_value()) {
+      resources["voice_module"]["memory_cap_mb"] = *voice_module_instance_->memory_cap_mb;
+    }
+    if (std::abs(voice_module_instance_->gpu_fraction - kDefaultVoiceModuleGpuFraction) < 1e-9 &&
+        voice_module_instance_->share_mode == GpuShareMode::Shared &&
+        voice_module_instance_->priority == kDefaultVoiceModuleGpuPriority &&
+        !voice_module_instance_->preemptible &&
+        !voice_module_instance_->memory_cap_mb.has_value()) {
+      resources["voice_module"] = {{"gpu_enabled", true}};
     }
   }
   if (shared_disk_ != nullptr) {

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -3,9 +3,12 @@
 #include <algorithm>
 #include <cstdint>
 #include <filesystem>
+#include <map>
+#include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include "naim/runtime/infer_runtime_config.h"
@@ -37,6 +40,8 @@ constexpr int kInteractionPublishedPortSpan = 10000;
 constexpr int kVoiceModuleContainerPort = 18140;
 constexpr int kVoiceModulePublishedPortBase = 54000;
 constexpr int kVoiceModulePublishedPortSpan = 10000;
+constexpr double kDefaultVoiceModuleGpuFraction = 0.2;
+constexpr int kDefaultVoiceModuleGpuPriority = 50;
 constexpr std::string_view kTurboQuantDefaultCacheTypeK = "turbo4";
 constexpr std::string_view kTurboQuantDefaultCacheTypeV = "turbo4";
 
@@ -58,6 +63,47 @@ std::string PlacementExecutionNodeName(const nlohmann::json& placement) {
     return execution_node;
   }
   return placement.value("primary_node", std::string{});
+}
+
+struct VoiceGpuHost {
+  std::string node_name;
+  std::string gpu_device;
+  double allocated_fraction = 0.0;
+  int allocated_memory_cap_mb = 0;
+  std::string first_worker_name;
+};
+
+std::optional<VoiceGpuHost> SelectVoiceGpuHost(const DesiredState& state) {
+  std::map<std::pair<std::string, std::string>, VoiceGpuHost> hosts;
+  for (const auto& instance : state.instances) {
+    if (instance.role != InstanceRole::Worker || !instance.gpu_device.has_value() ||
+        instance.gpu_device->empty()) {
+      continue;
+    }
+    auto& host = hosts[{instance.node_name, *instance.gpu_device}];
+    if (host.node_name.empty()) {
+      host.node_name = instance.node_name;
+      host.gpu_device = *instance.gpu_device;
+      host.first_worker_name = instance.name;
+    }
+    host.allocated_fraction += instance.gpu_fraction;
+    host.allocated_memory_cap_mb += instance.memory_cap_mb.value_or(0);
+  }
+
+  std::optional<VoiceGpuHost> best;
+  for (const auto& [_, host] : hosts) {
+    if (!best.has_value() ||
+        host.allocated_fraction < best->allocated_fraction ||
+        (host.allocated_fraction == best->allocated_fraction &&
+         host.allocated_memory_cap_mb < best->allocated_memory_cap_mb) ||
+        (host.allocated_fraction == best->allocated_fraction &&
+         host.allocated_memory_cap_mb == best->allocated_memory_cap_mb &&
+         std::tie(host.node_name, host.gpu_device, host.first_worker_name) <
+             std::tie(best->node_name, best->gpu_device, best->first_worker_name))) {
+      best = host;
+    }
+  }
+  return best;
 }
 
 }  // namespace
@@ -83,6 +129,14 @@ DesiredStateV2Renderer::DesiredStateV2Renderer(const nlohmann::json& value)
           resources_json_.contains("worker") && resources_json_.at("worker").is_object()
               ? resources_json_.at("worker")
               : nlohmann::json::object()),
+      voice_module_resources_json_(
+          resources_json_.contains("voice_module") &&
+                  resources_json_.at("voice_module").is_object()
+              ? resources_json_.at("voice_module")
+              : (resources_json_.contains("voice_listener") &&
+                         resources_json_.at("voice_listener").is_object()
+                     ? resources_json_.at("voice_listener")
+                     : nlohmann::json::object())),
       app_json_(nlohmann::json::object()),
       skills_json_(
           value.contains("skills") && value.at("skills").is_object() ? value.at("skills")
@@ -1095,11 +1149,17 @@ void DesiredStateV2Renderer::RenderVoiceModuleInstance() {
   }
 
   const auto& config = *state_.voice_listener;
+  const bool gpu_enabled = VoiceModuleGpuEnabled();
+  const auto voice_gpu_host = gpu_enabled ? SelectVoiceGpuHost(state_) : std::nullopt;
+  if (gpu_enabled && !voice_gpu_host.has_value()) {
+    throw std::runtime_error(
+        "desired-state v2 resources.voice_module requires at least one worker with gpu_device");
+  }
   InstanceSpec voice;
   voice.name = BuildVoiceModuleInstanceName();
   voice.role = InstanceRole::VoiceModule;
   voice.plane_name = state_.plane_name;
-  voice.node_name = ResolveAppNodeName();
+  voice.node_name = voice_gpu_host.has_value() ? voice_gpu_host->node_name : ResolveAppNodeName();
   voice.image = config.image.has_value() && !config.image->empty()
                     ? *config.image
                     : std::string("naim/voice-module:dev");
@@ -1116,6 +1176,21 @@ void DesiredStateV2Renderer::RenderVoiceModuleInstance() {
       InstanceNeedsSharedDiskMount(voice.role) ? state_.plane_shared_disk_name : "";
   voice.private_disk_size_gb =
       ExtractPrivateDiskSizeGb(voice_json, kDefaultVoiceModulePrivateDiskSizeGb, "storage");
+  if (voice_gpu_host.has_value()) {
+    const auto& resources = VoiceModuleResources();
+    voice.gpu_device = voice_gpu_host->gpu_device;
+    voice.placement_mode = PlacementMode::Manual;
+    voice.share_mode =
+        ParseGpuShareMode(resources.value("share_mode", std::string("shared")));
+    voice.gpu_fraction =
+        resources.value("gpu_fraction", kDefaultVoiceModuleGpuFraction);
+    voice.priority = resources.value("priority", kDefaultVoiceModuleGpuPriority);
+    voice.preemptible =
+        resources.value("preemptible", voice.share_mode == GpuShareMode::BestEffort);
+    voice.memory_cap_mb = resources.contains("memory_cap_mb")
+                              ? std::optional<int>(resources.at("memory_cap_mb").get<int>())
+                              : std::nullopt;
+  }
   voice.environment = {
       {"NAIM_PLANE_NAME", state_.plane_name},
       {"NAIM_INSTANCE_NAME", voice.name},
@@ -1271,6 +1346,26 @@ int DesiredStateV2Renderer::WorkerCount() const {
 
 int DesiredStateV2Renderer::ExpectedWorkers() const {
   return std::max(1, WorkerCount());
+}
+
+const nlohmann::json& DesiredStateV2Renderer::VoiceModuleResources() const {
+  return voice_module_resources_json_;
+}
+
+bool DesiredStateV2Renderer::VoiceModuleGpuEnabled() const {
+  const auto& resources = VoiceModuleResources();
+  if (resources.empty()) {
+    return false;
+  }
+  if (resources.contains("gpu_enabled")) {
+    return resources.value("gpu_enabled", false);
+  }
+  if (resources.contains("enabled")) {
+    return resources.value("enabled", false);
+  }
+  return resources.contains("share_mode") || resources.contains("gpu_fraction") ||
+      resources.contains("memory_cap_mb") || resources.contains("priority") ||
+      resources.contains("preemptible");
 }
 
 bool DesiredStateV2Renderer::HasExternalAppHost() const {

--- a/common/src/state/desired_state_v2_validator.cpp
+++ b/common/src/state/desired_state_v2_validator.cpp
@@ -1,5 +1,6 @@
 #include "naim/state/desired_state_v2_validator.h"
 
+#include <cmath>
 #include <map>
 #include <optional>
 #include <set>
@@ -67,6 +68,70 @@ bool IsValidEnvName(const std::string& value) {
   return true;
 }
 
+void ValidateGpuResourceBlock(
+    const nlohmann::json& resources,
+    const std::string& field_name,
+    bool allow_enabled_flags) {
+  if (!resources.is_object()) {
+    throw std::runtime_error("desired-state v2 " + field_name + " must be an object");
+  }
+  if (allow_enabled_flags) {
+    if (resources.contains("enabled") && !resources.at("enabled").is_boolean()) {
+      throw std::runtime_error("desired-state v2 " + field_name + ".enabled must be a boolean");
+    }
+    if (resources.contains("gpu_enabled") && !resources.at("gpu_enabled").is_boolean()) {
+      throw std::runtime_error(
+          "desired-state v2 " + field_name + ".gpu_enabled must be a boolean");
+    }
+  }
+  if (resources.contains("share_mode")) {
+    if (!resources.at("share_mode").is_string()) {
+      throw std::runtime_error("desired-state v2 " + field_name + ".share_mode must be a string");
+    }
+    const std::string share_mode = resources.at("share_mode").get<std::string>();
+    if (share_mode != "exclusive" && share_mode != "shared" && share_mode != "best-effort") {
+      throw std::runtime_error(
+          "desired-state v2 " + field_name +
+          ".share_mode must be exclusive, shared, or best-effort");
+    }
+  }
+  if (resources.contains("gpu_fraction")) {
+    if (!resources.at("gpu_fraction").is_number()) {
+      throw std::runtime_error(
+          "desired-state v2 " + field_name + ".gpu_fraction must be a number");
+    }
+    const double gpu_fraction = resources.at("gpu_fraction").get<double>();
+    if (gpu_fraction <= 0.0 || gpu_fraction > 1.0) {
+      throw std::runtime_error(
+          "desired-state v2 " + field_name + ".gpu_fraction must be in (0, 1]");
+    }
+  }
+  const std::string share_mode = resources.value("share_mode", std::string{});
+  if (share_mode == "exclusive" && resources.contains("gpu_fraction")) {
+    const double gpu_fraction = resources.at("gpu_fraction").get<double>();
+    if (std::abs(gpu_fraction - 1.0) > 1e-9) {
+      throw std::runtime_error(
+          "desired-state v2 " + field_name +
+          ".gpu_fraction must be 1.0 when share_mode=exclusive");
+    }
+  }
+  if (resources.contains("memory_cap_mb") &&
+      (!resources.at("memory_cap_mb").is_number_integer() ||
+       resources.at("memory_cap_mb").get<int>() <= 0)) {
+    throw std::runtime_error(
+        "desired-state v2 " + field_name + ".memory_cap_mb must be a positive integer");
+  }
+  if (resources.contains("priority") &&
+      (!resources.at("priority").is_number_integer() || resources.at("priority").get<int>() < 0)) {
+    throw std::runtime_error(
+        "desired-state v2 " + field_name + ".priority must be a non-negative integer");
+  }
+  if (resources.contains("preemptible") && !resources.at("preemptible").is_boolean()) {
+    throw std::runtime_error(
+        "desired-state v2 " + field_name + ".preemptible must be a boolean");
+  }
+}
+
 void ValidateVoiceListenerModel(const nlohmann::json& model) {
   if (!model.is_object()) {
     throw std::runtime_error("desired-state v2 features.voice_listener.model must be an object");
@@ -127,6 +192,7 @@ void DesiredStateV2Validator::Validate() {
   ValidateLegacyPlacementCompatibility();
   ValidateInfer();
   ValidateWorker();
+  ValidateVoiceModuleResources();
   ValidateApp();
   ValidateSkills();
   ValidateBrowsing();
@@ -671,21 +737,32 @@ void DesiredStateV2Validator::ValidateWorker() const {
 }
 
 void DesiredStateV2Validator::ValidateWorkerResources() const {
-  if (!value_.contains("resources") || !value_.at("resources").is_object()) {
+  if (!value_.contains("resources")) {
     return;
+  }
+  if (!value_.at("resources").is_object()) {
+    throw std::runtime_error("desired-state v2 resources must be an object");
   }
   const auto& resources = value_.at("resources");
-  if (!resources.contains("worker") || !resources.at("worker").is_object()) {
+  if (!resources.contains("worker")) {
     return;
   }
-  const auto& worker_resources = resources.at("worker");
-  const std::string share_mode = worker_resources.value("share_mode", std::string{});
-  if (share_mode == "exclusive" && worker_resources.contains("gpu_fraction")) {
-    const double gpu_fraction = worker_resources.at("gpu_fraction").get<double>();
-    if (std::abs(gpu_fraction - 1.0) > 1e-9) {
-      throw std::runtime_error(
-          "desired-state v2 resources.worker.gpu_fraction must be 1.0 when share_mode=exclusive");
-    }
+  ValidateGpuResourceBlock(resources.at("worker"), "resources.worker", false);
+}
+
+void DesiredStateV2Validator::ValidateVoiceModuleResources() const {
+  if (!value_.contains("resources")) {
+    return;
+  }
+  if (!value_.at("resources").is_object()) {
+    throw std::runtime_error("desired-state v2 resources must be an object");
+  }
+  const auto& resources = value_.at("resources");
+  if (resources.contains("voice_module")) {
+    ValidateGpuResourceBlock(resources.at("voice_module"), "resources.voice_module", true);
+  }
+  if (resources.contains("voice_listener")) {
+    ValidateGpuResourceBlock(resources.at("voice_listener"), "resources.voice_listener", true);
   }
 }
 

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -2001,6 +2001,102 @@ int main() {
       std::cout << "ok: voice-listener-plane" << '\n';
     }
 
+    {
+      const json gpu_voice_listener_plane{
+          {"version", 2},
+          {"plane_name", "gpu-voice-listener-plane"},
+          {"plane_mode", "llm"},
+          {"model",
+           {
+               {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+               {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+               {"served_model_name", "qwen-gpu-voice-listener"},
+           }},
+          {"runtime",
+           {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 2}}},
+          {"topology",
+           {{"nodes",
+             json::array(
+                 {{{"name", "local-hostd"},
+                   {"execution_mode", "mixed"},
+                   {"gpu_memory_mb", {{"0", 24576}, {"1", 24576}}}}})}}},
+          {"infer", {{"replicas", 1}}},
+          {"worker",
+           {{"assignments",
+             json::array(
+                 {{{"node", "local-hostd"}, {"gpu_device", "0"}},
+                  {{"node", "local-hostd"}, {"gpu_device", "1"}}})}}},
+          {"app", {{"enabled", true}, {"image", "example/app:dev"}}},
+          {"features",
+           {{"voice_listener",
+             {{"enabled", true},
+              {"wake_phrase", "Hey Jex"},
+              {"model",
+               {{"name", "whisper"},
+                {"source",
+                 {{"type", "library"},
+                  {"path", "/mnt/shared-storage/models/whisper/ggml-base.bin"}}},
+                {"mount_path", "/models/whisper/ggml-base.bin"},
+                {"env", "WHISPER_MODEL_PATH"},
+                {"required", true}}}}}}},
+          {"resources",
+           {{"worker",
+             {{"share_mode", "shared"}, {"gpu_fraction", 0.7}, {"memory_cap_mb", 16384}}},
+            {"voice_module",
+             {{"gpu_enabled", true},
+              {"share_mode", "shared"},
+              {"gpu_fraction", 0.2},
+              {"memory_cap_mb", 4096}}}}},
+      };
+      const auto state = RenderValid(gpu_voice_listener_plane, "gpu-voice-listener-plane");
+      const auto voice = FindInstance(state, "voice-module-gpu-voice-listener-plane");
+      Expect(voice.node_name == "local-hostd",
+             "gpu-voice-listener-plane: voice module should colocate with a GPU worker");
+      Expect(voice.gpu_device == std::optional<std::string>("0"),
+             "gpu-voice-listener-plane: voice module should choose a worker GPU deterministically");
+      Expect(voice.share_mode == naim::GpuShareMode::Shared,
+             "gpu-voice-listener-plane: voice module should use shared GPU mode");
+      Expect(voice.gpu_fraction == 0.2,
+             "gpu-voice-listener-plane: voice module gpu_fraction mismatch");
+      Expect(voice.memory_cap_mb == std::optional<int>(4096),
+             "gpu-voice-listener-plane: voice module memory cap mismatch");
+      const auto compose_plans = naim::BuildNodeComposePlans(state);
+      const auto& service = *std::find_if(
+          compose_plans.front().services.begin(),
+          compose_plans.front().services.end(),
+          [](const naim::ComposeService& candidate) {
+            return candidate.name == "voice-module-gpu-voice-listener-plane";
+          });
+      Expect(service.use_nvidia_runtime,
+             "gpu-voice-listener-plane: compose should enable nvidia runtime for voice");
+      Expect(service.gpu_device == std::optional<std::string>("0"),
+             "gpu-voice-listener-plane: compose voice gpu_device mismatch");
+      Expect(service.environment.at("NVIDIA_VISIBLE_DEVICES") == "0",
+             "gpu-voice-listener-plane: compose should expose selected voice GPU");
+      const auto projected = naim::DesiredStateV2Projector::Project(state);
+      Expect(projected.at("resources").at("voice_module").at("gpu_enabled") == true,
+             "gpu-voice-listener-plane: projector should preserve voice GPU enablement");
+      Expect(projected.at("resources").at("voice_module").at("gpu_fraction") == 0.2,
+             "gpu-voice-listener-plane: projector should preserve voice GPU fraction");
+      std::cout << "ok: gpu-voice-listener-plane" << '\n';
+    }
+
+    ExpectInvalid(
+        json{
+            {"version", 2},
+            {"plane_name", "bad-voice-gpu-fraction"},
+            {"plane_mode", "llm"},
+            {"model",
+             {{"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+              {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+              {"served_model_name", "qwen"}}},
+            {"runtime", {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+            {"infer", {{"replicas", 1}}},
+            {"resources",
+             {{"voice_module", {{"gpu_enabled", true}, {"share_mode", "exclusive"}, {"gpu_fraction", 0.25}}}}},
+        },
+        "bad-voice-gpu-fraction");
+
     ExpectInvalid(
         json{
             {"version", 2},


### PR DESCRIPTION
## Summary
- add `resources.voice_module` GPU controls for GPU-enabled ASR
- colocate the voice module on an existing worker GPU and soft-share by fraction/memory cap
- preserve voice GPU settings through desired-state projection and add validator coverage

## Validation
- hpc1 sandbox `/tmp/naim-node-gpu-asr-20260429-213927`
- CUDA configure with `/usr/local/cuda-13.1` and Blackwell `120a-real`
- `cmake --build build/gpu-asr-sandbox2 --target naim-state-v2-tests naim-state-v2-projector-tests`
- `./build/gpu-asr-sandbox2/naim-state-v2-tests`
- `./build/gpu-asr-sandbox2/naim-state-v2-projector-tests`
- `git diff --check`