### PR TITLE
Retry skills factory health check

### DIFF
--- a/scripts/ci/main-bootstrap-controller-update.sh
+++ b/scripts/ci/main-bootstrap-controller-update.sh
@@ -179,6 +179,30 @@ wait_for_http() {
   return 1
 }
 
+wait_for_container_http_contains() {
+  local container="$1"
+  local port="$2"
+  local expected="$3"
+  local attempts="${4:-45}"
+  for _ in $(seq 1 "${attempts}"); do
+    if docker exec \
+        -e NAIM_HEALTH_PORT="${port}" \
+        -e NAIM_HEALTH_EXPECTED="${expected}" \
+        "${container}" \
+        bash -lc '
+          exec 3<>"/dev/tcp/127.0.0.1/${NAIM_HEALTH_PORT}"
+          printf "GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3
+          response="$(cat <&3)"
+          grep -F "${NAIM_HEALTH_EXPECTED}" <<<"${response}" >/dev/null
+        ' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timed out waiting for ${container} health on port ${port}" >&2
+  return 1
+}
+
 docker compose -f "${compose_path}" pull naim-controller >/dev/null
 docker compose -f "${compose_path}" up -d --remove-orphans naim-controller >/dev/null
 wait_for_http "http://127.0.0.1:${controller_port}/health" 90
@@ -186,11 +210,11 @@ wait_for_http "http://127.0.0.1:${controller_port}/health" 90
 docker compose -f "${compose_path}" pull naim-skills-factory naim-web-ui >/dev/null
 docker compose -f "${compose_path}" up -d --remove-orphans naim-skills-factory naim-web-ui >/dev/null
 wait_for_http "http://127.0.0.1:${web_ui_port}/health" 90
-docker exec naim-skills-factory bash -lc \
-  'exec 3<>/dev/tcp/127.0.0.1/18082
-   printf "GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3
-   response="$(cat <&3)"
-   grep -F "\"service\":\"naim-skills-factory\"" <<<"${response}" >/dev/null'
+wait_for_container_http_contains \
+  naim-skills-factory \
+  18082 \
+  '"service":"naim-skills-factory"' \
+  90
 
 rollout_json="$(
   docker run --rm \


### PR DESCRIPTION
## Summary
- replace the single-shot `naim-skills-factory` `/health` probe in the main bootstrap release script with a retry loop
- keep the same in-container `/dev/tcp` check to avoid adding container dependencies

## Root cause
The post-merge production workflow for PR #186 failed after the controller and skills-factory containers restarted. The script probed `127.0.0.1:18082` inside `naim-skills-factory` immediately after `docker compose up -d`, and the service was not listening yet. The release rollback restored the previous tag successfully, but the workflow ended failed.

## Validation
- `bash -n scripts/ci/main-bootstrap-controller-update.sh`
- `git diff --check`