### PR TITLE
Enable CUDA voice ASR runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1693,12 +1693,26 @@ if(NOT WIN32)
         "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
         "-DNAIM_WHISPER_CPP_GIT_TAG=${NAIM_WHISPER_CPP_GIT_TAG}"
         "-DNAIM_CPP_HTTPLIB_GIT_TAG=${NAIM_CPP_HTTPLIB_GIT_TAG}"
+        "-DNAIM_ENABLE_CUDA=${NAIM_ENABLE_CUDA}"
+        "-DNAIM_CUDA_NATIVE=${NAIM_CUDA_NATIVE}"
+        "-DNAIM_CUDA_ARCHITECTURES=${NAIM_CUDA_ARCHITECTURES}"
+        "-DNAIM_CUDA_NVCC_JOBS=${NAIM_CUDA_NVCC_JOBS}"
     )
     if(CMAKE_C_COMPILER)
       list(APPEND _naim_voice_module_cmake_args "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}")
     endif()
     if(CMAKE_CXX_COMPILER)
       list(APPEND _naim_voice_module_cmake_args "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
+    endif()
+    if(CUDAToolkit_ROOT)
+      list(APPEND _naim_voice_module_cmake_args "-DCUDAToolkit_ROOT=${CUDAToolkit_ROOT}")
+    endif()
+    if(CMAKE_CUDA_COMPILER)
+      list(APPEND _naim_voice_module_cmake_args "-DCMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER}")
+    endif()
+    if(CMAKE_CUDA_COMPILER_LAUNCHER)
+      list(APPEND _naim_voice_module_cmake_args
+           "-DCMAKE_CUDA_COMPILER_LAUNCHER=${CMAKE_CUDA_COMPILER_LAUNCHER}")
     endif()
 
     ExternalProject_Add(

--- a/runtime/voice/CMakeLists.txt
+++ b/runtime/voice/CMakeLists.txt
@@ -16,9 +16,31 @@ set(NAIM_WHISPER_CPP_GIT_TAG "v1.8.1" CACHE STRING
     "Pinned whisper.cpp release used for the NAIM voice-module runtime")
 set(NAIM_CPP_HTTPLIB_GIT_TAG "v0.26.0" CACHE STRING
     "Pinned cpp-httplib release used for the NAIM voice-module runtime")
+option(NAIM_ENABLE_CUDA "Build whisper.cpp with CUDA backend for the NAIM voice-module runtime" OFF)
+option(NAIM_CUDA_NATIVE "Prefer native CUDA architectures for ggml-cuda builds" OFF)
+set(NAIM_CUDA_ARCHITECTURES "" CACHE STRING
+    "Explicit CUDA architectures for ggml-cuda builds; empty lets whisper.cpp choose defaults")
+set(NAIM_CUDA_NVCC_JOBS "1" CACHE STRING
+    "Maximum number of concurrent nvcc compile jobs for ggml-cuda when using Ninja")
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static whisper.cpp for the NAIM voice-module runtime" FORCE)
-set(GGML_CUDA OFF CACHE BOOL "Build whisper.cpp without CUDA for the NAIM voice-module runtime" FORCE)
+if(NAIM_ENABLE_CUDA)
+  if(NAIM_CUDA_ARCHITECTURES)
+    set(NAIM_CUDA_NATIVE OFF CACHE BOOL "" FORCE)
+    set(CMAKE_CUDA_ARCHITECTURES
+        "${NAIM_CUDA_ARCHITECTURES}"
+        CACHE STRING "Explicit CUDA architectures for voice-module ggml-cuda builds" FORCE)
+  endif()
+  set(GGML_NATIVE ${NAIM_CUDA_NATIVE} CACHE BOOL "" FORCE)
+  set(GGML_CUDA ON CACHE BOOL "Build whisper.cpp with CUDA for the NAIM voice-module runtime" FORCE)
+  message(STATUS "Naim voice-module CUDA runtime: enabled")
+  message(STATUS "Naim voice-module CUDA native architectures: ${NAIM_CUDA_NATIVE}")
+  message(STATUS "Naim voice-module CUDA explicit architectures: ${NAIM_CUDA_ARCHITECTURES}")
+else()
+  set(GGML_NATIVE OFF CACHE BOOL "" FORCE)
+  set(GGML_CUDA OFF CACHE BOOL "Build whisper.cpp without CUDA for the NAIM voice-module runtime" FORCE)
+  message(STATUS "Naim voice-module CUDA runtime: disabled")
+endif()
 set(WHISPER_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(WHISPER_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(WHISPER_BUILD_SERVER OFF CACHE BOOL "" FORCE)
@@ -36,6 +58,18 @@ FetchContent_Declare(
   GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(whisper_cpp cpp_httplib)
+
+if(NAIM_ENABLE_CUDA AND TARGET ggml-cuda AND CMAKE_GENERATOR STREQUAL "Ninja")
+  if(NAIM_CUDA_NVCC_JOBS MATCHES "^[1-9][0-9]*$")
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS "naim_voice_cuda_pool=${NAIM_CUDA_NVCC_JOBS}")
+    set_property(TARGET ggml-cuda PROPERTY JOB_POOL_COMPILE naim_voice_cuda_pool)
+    message(STATUS "Using voice-module ggml-cuda compile pool size: ${NAIM_CUDA_NVCC_JOBS}")
+  else()
+    message(WARNING
+      "NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' is not a positive integer; "
+      "voice-module ggml-cuda will use the default global compile pool")
+  endif()
+endif()
 
 add_executable(
   naim-voice-moduled

--- a/runtime/voice/Dockerfile
+++ b/runtime/voice/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:24.04
+ARG BASE_IMAGE=nvidia/cuda:13.0.1-runtime-ubuntu24.04
+FROM ${BASE_IMAGE}
 
 ENV HOST=0.0.0.0 \
     PORT=18140 \


### PR DESCRIPTION
## Summary

- enable CUDA-backed whisper.cpp builds for the NAIM voice-module runtime
- pass top-level CUDA build settings into the voice-module ExternalProject
- build the voice-module image from the CUDA runtime base image so CUDA/cuBLAS runtime libraries are available

## Root Cause

`runtime/voice/CMakeLists.txt` forced `GGML_CUDA OFF`, so the voice-module binary could see a GPU allocation but whisper.cpp had no active CUDA backend and logged `whisper_backend_init_gpu: no GPU found`.

## Validation

- `git diff --check HEAD~1..HEAD`
- hpc1 sandbox CUDA configure/build of `runtime/voice`
- hpc1 sandbox CPU configure/build of `runtime/voice` with `NAIM_ENABLE_CUDA=OFF`
- hpc1 sandbox image run with production-like GPU/AppArmor settings:
  - `whisper_backend_init_gpu: using CUDA0 backend`
  - ASR benchmark on `/tmp/naim-voice-jfk.wav`: 5/5 HTTP 200, median backend latency 90 ms
