### PR TITLE
Add local interaction runtime fast path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -930,6 +930,34 @@ target_link_libraries(
 naim_enable_strict_warnings(naim-interaction-utf8-payload-sanitizer-tests)
 
 add_executable(
+  naim-interaction-runtime-server-tests
+  controller/src/app/controller_language_support.cpp
+  controller/src/http/controller_http_server_support.cpp
+  controller/src/http/controller_http_transport.cpp
+  controller/src/infra/controller_network_manager.cpp
+  controller/src/interaction/interaction_completion_policy_support.cpp
+  controller/src/interaction/interaction_context_compression_service.cpp
+  controller/src/interaction/interaction_conversation_payload_builder.cpp
+  controller/src/interaction/interaction_model_identity_builder.cpp
+  controller/src/interaction/interaction_payload_builder.cpp
+  controller/src/interaction/interaction_request_contract_support.cpp
+  controller/src/interaction/interaction_request_heuristics.cpp
+  controller/src/interaction/interaction_runtime_request_codec.cpp
+  controller/src/interaction/interaction_text_post_processor.cpp
+  controller/src/interaction/interaction_utf8_payload_sanitizer.cpp
+  runtime/interaction/src/interaction_runtime_server.cpp
+  runtime/interaction/src/interaction_runtime_server_tests.cpp
+)
+target_include_directories(
+  naim-interaction-runtime-server-tests PRIVATE common/include controller/include runtime/interaction/include)
+target_link_libraries(
+  naim-interaction-runtime-server-tests PRIVATE naim-common Threads::Threads)
+if(WIN32)
+  target_link_libraries(naim-interaction-runtime-server-tests PRIVATE ws2_32)
+endif()
+naim_enable_strict_warnings(naim-interaction-runtime-server-tests)
+
+add_executable(
   naim-knowledge-vault-service-tests
   controller/src/http/controller_http_server_support.cpp
   controller/src/http/controller_http_transport.cpp

--- a/runtime/interaction/include/interaction/interaction_runtime_server.h
+++ b/runtime/interaction/include/interaction/interaction_runtime_server.h
@@ -42,6 +42,8 @@ class InteractionRuntimeServer final {
     naim::controller::ResolvedInteractionPolicy resolved_policy;
     bool force_stream = false;
     bool structured_output_json = false;
+    bool local_raw_execution = false;
+    int skills_resolve_ms = 0;
   };
 
   void AcceptLoop();
@@ -52,6 +54,7 @@ class InteractionRuntimeServer final {
   HttpResponse ExecuteNonStream(const HttpRequest& request);
   void ExecuteStream(naim::platform::SocketHandle client_fd, const HttpRequest& request);
   bool ShouldProxyRawRequestThroughController(const HttpRequest& request) const;
+  bool HasLocalPlaneStateSnapshot() const;
   HttpResponse ProxyRawRequestThroughController(
       const HttpRequest& request,
       const std::string& controller_path) const;
@@ -63,6 +66,11 @@ class InteractionRuntimeServer final {
   std::optional<RuntimeExecution> TryBuildWrappedRuntimeExecution(
       const std::string& body) const;
   RuntimeExecution BuildDirectRuntimeExecution(const HttpRequest& request) const;
+  int ResolveExplicitSkillsForDirectExecution(
+      const naim::controller::PlaneInteractionResolution& resolution,
+      naim::controller::InteractionRequestContext* request_context) const;
+  std::optional<naim::controller::ControllerEndpointTarget> ResolvePlaneNetworkSkillsTarget(
+      const naim::DesiredState& desired_state) const;
   nlohmann::json LoadPlaneStatePayload() const;
   nlohmann::json LoadPlaneStatePayloadFromSnapshot() const;
   HttpResponse BuildJsonResponse(int status_code, const nlohmann::json& payload) const;

--- a/runtime/interaction/src/interaction_runtime_server.cpp
+++ b/runtime/interaction/src/interaction_runtime_server.cpp
@@ -1,6 +1,8 @@
 #include "interaction/interaction_runtime_server.h"
 
+#include <algorithm>
 #include <array>
+#include <chrono>
 #include <cctype>
 #include <csignal>
 #include <fstream>
@@ -23,6 +25,12 @@ namespace naim::interaction_runtime {
 namespace {
 
 std::atomic<bool>* g_stop_requested = nullptr;
+constexpr const char* kSkillsSystemInstructionPayloadKey =
+    "_naim_skills_system_instruction";
+constexpr const char* kAppliedSkillsPayloadKey = "_naim_applied_skills";
+constexpr const char* kAutoAppliedSkillsPayloadKey = "_naim_auto_applied_skills";
+constexpr const char* kSkillsSessionIdPayloadKey = "_naim_skills_session_id";
+constexpr const char* kSkillResolutionModePayloadKey = "_naim_skill_resolution_mode";
 
 void SignalHandler(int) {
   if (g_stop_requested != nullptr) {
@@ -68,6 +76,54 @@ std::optional<std::string> FindRequestHeader(
   return it->second;
 }
 
+bool HasExplicitSkillIds(const nlohmann::json& payload) {
+  return payload.contains("skill_ids") && payload.at("skill_ids").is_array() &&
+         !payload.at("skill_ids").empty();
+}
+
+int ParsePositiveIntOr(const std::string& value, int fallback) {
+  try {
+    const int parsed = std::stoi(value);
+    return parsed > 0 ? parsed : fallback;
+  } catch (const std::exception&) {
+    return fallback;
+  }
+}
+
+std::string BuildSkillsSystemInstruction(const nlohmann::json& skills) {
+  std::string instruction = "Skills currently applied for this request:";
+  for (const auto& skill : skills) {
+    if (!skill.is_object()) {
+      continue;
+    }
+    const std::string name = skill.value("name", std::string{});
+    const std::string description = skill.value("description", std::string{});
+    const std::string content = skill.value("content", std::string{});
+    if (content.empty()) {
+      continue;
+    }
+    instruction += "\n\nSkill: " + name;
+    if (!description.empty()) {
+      instruction += "\nDescription: " + description;
+    }
+    instruction += "\n\nInstructions:\n" + content;
+  }
+  return instruction;
+}
+
+void SetNoResolvedSkills(naim::controller::InteractionRequestContext* context) {
+  if (context == nullptr) {
+    return;
+  }
+  context->payload[kAppliedSkillsPayloadKey] = nlohmann::json::array();
+  context->payload[kAutoAppliedSkillsPayloadKey] = nlohmann::json::array();
+  context->payload[kSkillResolutionModePayloadKey] = "none";
+}
+
+std::vector<std::pair<std::string, std::string>> JsonHeaders() {
+  return {{"Accept", "application/json"}, {"Content-Type", "application/json"}};
+}
+
 std::map<std::string, std::string> BuildCompressionHeaders(
     const naim::controller::InteractionRequestContext& request_context) {
   std::map<std::string, std::string> headers;
@@ -94,6 +150,27 @@ std::map<std::string, std::string> BuildCompressionHeaders(
   headers["x-naim-context-compression-ratio"] =
       std::to_string(compression.value("compression_ratio", 1.0));
   return headers;
+}
+
+void AddRuntimeTelemetryHeaders(
+    HttpResponse* response,
+    bool local_raw_execution,
+    int skills_resolve_ms,
+    int context_compression_ms,
+    int prompt_build_ms,
+    int local_runtime_ms) {
+  if (response == nullptr) {
+    return;
+  }
+  response->headers["x-naim-local-raw-execution"] =
+      local_raw_execution ? "true" : "false";
+  response->headers["x-naim-skills-resolve-ms"] =
+      std::to_string(skills_resolve_ms);
+  response->headers["x-naim-context-compression-ms"] =
+      std::to_string(context_compression_ms);
+  response->headers["x-naim-prompt-build-ms"] = std::to_string(prompt_build_ms);
+  response->headers["x-naim-runtime-local-execution-ms"] =
+      std::to_string(local_runtime_ms);
 }
 
 HttpResponse SanitizeJsonChatResponse(HttpResponse response) {
@@ -280,16 +357,21 @@ HttpResponse InteractionRuntimeServer::ExecuteNonStream(const HttpRequest& reque
         request,
         "/api/v1/planes/" + config_.plane_name + "/interaction/chat/completions");
   }
+  const auto local_started_at = std::chrono::steady_clock::now();
   auto execution = BuildRuntimeExecution(request);
+  const auto compression_started_at = std::chrono::steady_clock::now();
   naim::controller::InteractionContextCompressionService().Apply(
       execution.resolution,
       &execution.request_context);
+  const auto compression_finished_at = std::chrono::steady_clock::now();
+  const auto prompt_started_at = std::chrono::steady_clock::now();
   const std::string upstream_body = naim::controller::BuildInteractionUpstreamBodyPayload(
       execution.resolution,
       execution.request_context.payload,
       execution.force_stream,
       execution.resolved_policy,
       execution.structured_output_json);
+  const auto prompt_finished_at = std::chrono::steady_clock::now();
   HttpResponse response = SendControllerHttpRequest(
       UpstreamTarget(),
       "POST",
@@ -299,6 +381,19 @@ HttpResponse InteractionRuntimeServer::ExecuteNonStream(const HttpRequest& reque
   for (const auto& [name, value] : BuildCompressionHeaders(execution.request_context)) {
     response.headers[name] = value;
   }
+  AddRuntimeTelemetryHeaders(
+      &response,
+      execution.local_raw_execution,
+      execution.skills_resolve_ms,
+      static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                           compression_finished_at - compression_started_at)
+                           .count()),
+      static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                           prompt_finished_at - prompt_started_at)
+                           .count()),
+      static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                           prompt_finished_at - local_started_at)
+                           .count()));
   return SanitizeJsonChatResponse(std::move(response));
 }
 
@@ -312,24 +407,49 @@ void InteractionRuntimeServer::ExecuteStream(
         "/api/v1/planes/" + config_.plane_name + "/interaction/chat/completions/stream");
     return;
   }
+  const auto local_started_at = std::chrono::steady_clock::now();
   auto execution = BuildRuntimeExecution(request);
   execution.force_stream = true;
+  const auto compression_started_at = std::chrono::steady_clock::now();
   naim::controller::InteractionContextCompressionService().Apply(
       execution.resolution,
       &execution.request_context);
+  const auto compression_finished_at = std::chrono::steady_clock::now();
+  const auto prompt_started_at = std::chrono::steady_clock::now();
   const std::string upstream_body = naim::controller::BuildInteractionUpstreamBodyPayload(
       execution.resolution,
       execution.request_context.payload,
       true,
       execution.resolved_policy,
       execution.structured_output_json);
+  const auto prompt_finished_at = std::chrono::steady_clock::now();
   auto upstream = OpenInteractionStreamRequest(
       UpstreamTarget(),
       "interaction-runtime",
       upstream_body);
+  auto response_headers = BuildCompressionHeaders(execution.request_context);
+  response_headers["x-naim-local-raw-execution"] =
+      execution.local_raw_execution ? "true" : "false";
+  response_headers["x-naim-skills-resolve-ms"] =
+      std::to_string(execution.skills_resolve_ms);
+  response_headers["x-naim-context-compression-ms"] =
+      std::to_string(static_cast<int>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              compression_finished_at - compression_started_at)
+              .count()));
+  response_headers["x-naim-prompt-build-ms"] =
+      std::to_string(static_cast<int>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              prompt_finished_at - prompt_started_at)
+              .count()));
+  response_headers["x-naim-runtime-local-execution-ms"] =
+      std::to_string(static_cast<int>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              prompt_finished_at - local_started_at)
+              .count()));
   if (!naim::controller::ControllerNetworkManager::SendSseHeaders(
           client_fd,
-          BuildCompressionHeaders(execution.request_context))) {
+          response_headers)) {
     upstream.close();
     naim::controller::ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
     return;
@@ -358,12 +478,26 @@ bool InteractionRuntimeServer::ShouldProxyRawRequestThroughController(
   if (TryBuildWrappedRuntimeExecution(request.body).has_value()) {
     return false;
   }
+  if (HasLocalPlaneStateSnapshot()) {
+    return false;
+  }
   return !config_.controller_url.empty();
+}
+
+bool InteractionRuntimeServer::HasLocalPlaneStateSnapshot() const {
+  try {
+    const auto snapshot = LoadPlaneStatePayloadFromSnapshot();
+    return snapshot.is_object() && snapshot.contains("desired_state") &&
+           snapshot.at("desired_state").is_object();
+  } catch (const std::exception&) {
+    return false;
+  }
 }
 
 HttpResponse InteractionRuntimeServer::ProxyRawRequestThroughController(
     const HttpRequest& request,
     const std::string& controller_path) const {
+  const auto started_at = std::chrono::steady_clock::now();
   std::vector<std::pair<std::string, std::string>> headers{
       {"Accept", "application/json"},
       {"Content-Type", "application/json"},
@@ -376,12 +510,19 @@ HttpResponse InteractionRuntimeServer::ProxyRawRequestThroughController(
       request_id.has_value()) {
     headers.emplace_back("X-Naim-Request-Id", *request_id);
   }
-  return SendControllerHttpRequest(
+  HttpResponse response = SendControllerHttpRequest(
       ParseControllerEndpointTarget(config_.controller_url),
       "POST",
       controller_path,
       request.body,
       headers);
+  response.headers["x-naim-local-raw-execution"] = "false";
+  response.headers["x-naim-controller-proxy-fallback-ms"] =
+      std::to_string(static_cast<int>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::steady_clock::now() - started_at)
+              .count()));
+  return response;
 }
 
 void InteractionRuntimeServer::ProxyRawStreamThroughController(
@@ -492,7 +633,122 @@ InteractionRuntimeServer::BuildDirectRuntimeExecution(const HttpRequest& request
       request.path == "/v1/chat/completions/stream" || payload.value("stream", false);
   execution.structured_output_json =
       execution.request_context.structured_output_json;
+  execution.local_raw_execution = true;
+  execution.skills_resolve_ms = ResolveExplicitSkillsForDirectExecution(
+      execution.resolution,
+      &execution.request_context);
   return execution;
+}
+
+int InteractionRuntimeServer::ResolveExplicitSkillsForDirectExecution(
+    const naim::controller::PlaneInteractionResolution& resolution,
+    naim::controller::InteractionRequestContext* request_context) const {
+  const auto started_at = std::chrono::steady_clock::now();
+  if (request_context == nullptr) {
+    throw std::invalid_argument("interaction request context is required");
+  }
+  if (!HasExplicitSkillIds(request_context->payload)) {
+    SetNoResolvedSkills(request_context);
+    return 0;
+  }
+  if (!resolution.desired_state.skills.has_value() ||
+      !resolution.desired_state.skills->enabled) {
+    throw std::runtime_error("skills are not enabled for this plane");
+  }
+  const auto target = ResolvePlaneNetworkSkillsTarget(resolution.desired_state);
+  if (!target.has_value()) {
+    throw std::runtime_error("skills service is not ready for this plane");
+  }
+
+  nlohmann::json resolve_payload = nlohmann::json::object();
+  resolve_payload["skill_ids"] = request_context->payload.at("skill_ids");
+  if (request_context->payload.contains("session_id") &&
+      request_context->payload.at("session_id").is_string()) {
+    resolve_payload["session_id"] = request_context->payload.at("session_id");
+  }
+
+  const HttpResponse response = SendControllerHttpRequest(
+      *target,
+      "POST",
+      "/v1/skills/resolve",
+      resolve_payload.dump(),
+      JsonHeaders());
+  if (response.status_code != 200) {
+    throw std::runtime_error(
+        "skills service returned status " + std::to_string(response.status_code));
+  }
+  const nlohmann::json response_payload =
+      response.body.empty() ? nlohmann::json::object() : nlohmann::json::parse(response.body);
+  const nlohmann::json resolved_skills =
+      response_payload.value("skills", nlohmann::json::array());
+  if (!resolved_skills.is_array()) {
+    throw std::runtime_error("skills service returned malformed resolve payload");
+  }
+
+  nlohmann::json applied_skills = nlohmann::json::array();
+  for (const auto& skill : resolved_skills) {
+    if (!skill.is_object()) {
+      continue;
+    }
+    applied_skills.push_back(
+        nlohmann::json{{"id", skill.value("id", std::string{})},
+                       {"name", skill.value("name", std::string{})},
+                       {"source", skill.value("source", std::string{})}});
+  }
+  if (!resolved_skills.empty()) {
+    request_context->payload[kSkillsSystemInstructionPayloadKey] =
+        BuildSkillsSystemInstruction(resolved_skills);
+  }
+  request_context->payload[kAppliedSkillsPayloadKey] = applied_skills;
+  request_context->payload[kAutoAppliedSkillsPayloadKey] = nlohmann::json::array();
+  request_context->payload[kSkillResolutionModePayloadKey] = "explicit";
+  if (response_payload.contains("skills_session_id") &&
+      !response_payload.at("skills_session_id").is_null()) {
+    request_context->payload[kSkillsSessionIdPayloadKey] =
+        response_payload.at("skills_session_id");
+  } else if (request_context->payload.contains("session_id") &&
+             request_context->payload.at("session_id").is_string()) {
+    request_context->payload[kSkillsSessionIdPayloadKey] =
+        request_context->payload.at("session_id");
+  }
+
+  return static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::steady_clock::now() - started_at)
+                              .count());
+}
+
+std::optional<naim::controller::ControllerEndpointTarget>
+InteractionRuntimeServer::ResolvePlaneNetworkSkillsTarget(
+    const naim::DesiredState& desired_state) const {
+  const auto it = std::find_if(
+      desired_state.instances.begin(),
+      desired_state.instances.end(),
+      [](const naim::InstanceSpec& instance) {
+        return instance.role == naim::InstanceRole::Skills;
+      });
+  if (it == desired_state.instances.end() || it->name.empty()) {
+    return std::nullopt;
+  }
+
+  int port = 18120;
+  if (const auto env_it = it->environment.find("NAIM_SKILLS_PORT");
+      env_it != it->environment.end()) {
+    port = ParsePositiveIntOr(env_it->second, port);
+  }
+  for (const auto& published : it->published_ports) {
+    if (published.container_port > 0) {
+      port = published.container_port;
+      break;
+    }
+  }
+  naim::controller::ControllerEndpointTarget target;
+  target.host = it->name;
+  target.port = port;
+  target.raw = "http://" + target.host + ":" + std::to_string(target.port);
+  target.node_name = it->node_name;
+  target.route_mode = "plane-network";
+  target.route_via_hostd_proxy = false;
+  return target;
 }
 
 nlohmann::json InteractionRuntimeServer::LoadPlaneStatePayload() const {

--- a/runtime/interaction/src/interaction_runtime_server_tests.cpp
+++ b/runtime/interaction/src/interaction_runtime_server_tests.cpp
@@ -1,0 +1,172 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <unistd.h>
+
+#include <nlohmann/json.hpp>
+
+#include "http/controller_http_transport.h"
+#include "interaction/interaction_types.h"
+#include "naim/core/platform_compat.h"
+
+#define private public
+#include "interaction/interaction_runtime_server.h"
+#undef private
+
+#include "interaction/interaction_completion_policy_support.h"
+#include "interaction/interaction_runtime_request_codec.h"
+#include "naim/state/state_json.h"
+
+namespace {
+
+void Expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+class TempDir final {
+ public:
+  TempDir() {
+    path_ = std::filesystem::temp_directory_path() /
+            ("naim-interaction-runtime-tests-" + std::to_string(getpid()) + "-" +
+             std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::filesystem::create_directories(path_);
+  }
+
+  ~TempDir() {
+    std::error_code error;
+    std::filesystem::remove_all(path_, error);
+  }
+
+  const std::filesystem::path& path() const {
+    return path_;
+  }
+
+ private:
+  std::filesystem::path path_;
+};
+
+naim::DesiredState BuildDesiredState() {
+  naim::DesiredState state;
+  state.plane_name = "test-plane";
+  state.control_root = "/naim/shared/control/test-plane";
+  state.plane_mode = naim::PlaneMode::Llm;
+  state.interaction = naim::InteractionSettings{};
+  state.interaction->system_prompt = "You are a test assistant.";
+  state.skills = naim::SkillsSettings{};
+  state.skills->enabled = true;
+
+  naim::InstanceSpec skills;
+  skills.name = "skills-test-plane";
+  skills.role = naim::InstanceRole::Skills;
+  skills.plane_name = state.plane_name;
+  skills.node_name = "hpc1";
+  skills.environment["NAIM_SKILLS_PORT"] = "18120";
+  skills.published_ports.push_back(naim::PublishedPort{"127.0.0.1", 26182, 18120});
+  state.instances.push_back(skills);
+  return state;
+}
+
+void WriteSnapshot(const std::filesystem::path& root, const naim::DesiredState& state) {
+  std::filesystem::create_directories(root);
+  std::ofstream output(root / "desired-state.v2.json", std::ios::binary | std::ios::trunc);
+  output << naim::SerializeDesiredStateJson(state);
+}
+
+naim::interaction_runtime::InteractionRuntimeServer BuildServer(
+    const std::filesystem::path& control_root) {
+  naim::interaction_runtime::InteractionRuntimeConfig config;
+  config.plane_name = "test-plane";
+  config.control_root = control_root.string();
+  config.controller_url = "http://controller.internal:18080";
+  config.upstream_base = "http://infer-test-plane:18084/v1";
+  return naim::interaction_runtime::InteractionRuntimeServer(std::move(config));
+}
+
+HttpRequest RawChatRequest(const std::string& body) {
+  HttpRequest request;
+  request.method = "POST";
+  request.path = "/v1/chat/completions";
+  request.body = body;
+  return request;
+}
+
+void TestRawRequestUsesLocalSnapshot() {
+  TempDir temp;
+  WriteSnapshot(temp.path(), BuildDesiredState());
+  auto server = BuildServer(temp.path());
+  const HttpRequest request = RawChatRequest(
+      R"({"messages":[{"role":"user","content":"Answer OK"}],"auto_skills":true})");
+
+  Expect(!server.ShouldProxyRawRequestThroughController(request),
+         "raw request with local snapshot should not proxy through controller");
+  const auto execution = server.BuildDirectRuntimeExecution(request);
+  Expect(execution.local_raw_execution, "direct execution should mark local raw path");
+  Expect(execution.skills_resolve_ms == 0,
+         "default auto_skills without skill_ids should not resolve skills");
+  Expect(
+      execution.request_context.payload.value(
+          "_naim_skill_resolution_mode", std::string{}) == "none",
+      "default auto_skills should be marked as no resolved skills");
+}
+
+void TestRawRequestFallsBackWithoutSnapshot() {
+  TempDir temp;
+  auto server = BuildServer(temp.path());
+  const HttpRequest request = RawChatRequest(
+      R"({"messages":[{"role":"user","content":"Answer OK"}]})");
+  Expect(server.ShouldProxyRawRequestThroughController(request),
+         "raw request without local snapshot should fall back to controller");
+}
+
+void TestWrappedRequestNeverUsesRawProxy() {
+  auto state = BuildDesiredState();
+  naim::controller::InteractionRuntimeExecutionRequest wrapped;
+  wrapped.desired_state = state;
+  wrapped.status_payload = nlohmann::json{{"plane_name", state.plane_name}};
+  wrapped.payload = nlohmann::json{
+      {"messages",
+       nlohmann::json::array(
+           {nlohmann::json{{"role", "user"}, {"content", "Answer OK"}}})}};
+  wrapped.resolved_policy =
+      naim::controller::InteractionCompletionPolicySupport{}.ResolvePolicy(
+          state,
+          wrapped.payload);
+
+  TempDir temp;
+  auto server = BuildServer(temp.path());
+  const HttpRequest request = RawChatRequest(
+      naim::controller::InteractionRuntimeRequestCodec{}.Serialize(wrapped));
+  Expect(!server.ShouldProxyRawRequestThroughController(request),
+         "wrapped runtime request should never use raw controller proxy");
+}
+
+void TestPlaneNetworkSkillsTargetUsesContainerPort() {
+  TempDir temp;
+  auto server = BuildServer(temp.path());
+  const auto target = server.ResolvePlaneNetworkSkillsTarget(BuildDesiredState());
+  Expect(target.has_value(), "skills plane-network target should resolve");
+  Expect(target->host == "skills-test-plane", "skills target should use instance DNS name");
+  Expect(target->port == 18120, "skills target should use container port");
+  Expect(!target->route_via_hostd_proxy, "plane-network skills target should not use hostd proxy");
+}
+
+}  // namespace
+
+int main() {
+  try {
+    TestRawRequestUsesLocalSnapshot();
+    TestRawRequestFallsBackWithoutSnapshot();
+    TestWrappedRequestNeverUsesRawProxy();
+    TestPlaneNetworkSkillsTargetUsesContainerPort();
+    std::cout << "ok: interaction-runtime-server-fast-path-tests\n";
+    return 0;
+  } catch (const std::exception& error) {
+    std::cerr << "interaction_runtime_server_tests failed: " << error.what() << '\n';
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary
- route raw interaction-runtime chat requests through the local desired-state snapshot when available instead of bouncing through controller hostd proxy
- skip contextual skills proxy on local raw requests unless explicit skill_ids are provided
- add runtime telemetry headers and focused fast-path tests

## Tests
- cmake --build build/macos/arm64 --target naim-interaction-runtime-server-tests -j 8
- build/macos/arm64/naim-interaction-runtime-server-tests
- cmake --build build/macos/arm64 --target naim-interactiond -j 8
- git diff --check