### PR TITLE
Mount plane shared state for all runtime roles

### DIFF
--- a/common/include/naim/state/models.h
+++ b/common/include/naim/state/models.h
@@ -47,7 +47,10 @@ inline bool InstanceNeedsSharedDiskMount(InstanceRole role) {
   return role == InstanceRole::Infer ||
          role == InstanceRole::Worker ||
          role == InstanceRole::App ||
-         role == InstanceRole::Interaction;
+         role == InstanceRole::Skills ||
+         role == InstanceRole::Browsing ||
+         role == InstanceRole::Interaction ||
+         role == InstanceRole::VoiceModule;
 }
 
 inline bool InstanceNeedsPrivateDisk(InstanceRole role) {

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -1261,11 +1261,11 @@ int main() {
       Expect(service_it->healthcheck == "CMD-SHELL test -f /tmp/naim-ready",
              "llm-with-skills: compose healthcheck should use readiness file");
       Expect(
-          std::none_of(
+          std::any_of(
               service_it->volumes.begin(),
               service_it->volumes.end(),
               [](const naim::ComposeVolume& volume) { return volume.target == "/naim/shared"; }),
-          "llm-with-skills: skills service should not mount shared disk by default");
+          "llm-with-skills: skills service should mount shared disk by default");
       std::cout << "ok: llm-with-skills" << '\n';
     }
 
@@ -1378,11 +1378,11 @@ int main() {
               "seccomp=unconfined") != service_it->security_opts.end(),
           "llm-with-browsing: compose service should relax seccomp for CEF");
       Expect(
-          std::none_of(
+          std::any_of(
               service_it->volumes.begin(),
               service_it->volumes.end(),
               [](const naim::ComposeVolume& volume) { return volume.target == "/naim/shared"; }),
-          "llm-with-browsing: browsing service should not mount shared disk by default");
+          "llm-with-browsing: browsing service should mount shared disk by default");
       std::cout << "ok: llm-with-browsing" << '\n';
     }
 
@@ -1985,6 +1985,8 @@ int main() {
       const auto voice = FindInstance(state, "voice-module-voice-listener-plane");
       Expect(voice.role == naim::InstanceRole::VoiceModule,
              "voice-listener-plane: voice module role mismatch");
+      Expect(voice.shared_disk_name == state.plane_shared_disk_name,
+             "voice-listener-plane: voice module should mount plane shared disk");
       Expect(voice.environment.at("NAIM_VOICE_LISTENER_WAKE_PHRASE") == "Hey Jex",
              "voice-listener-plane: wake phrase env mismatch");
       Expect(voice.app_model_mounts.size() == 1,


### PR DESCRIPTION
## Summary
- mount the plane shared disk for every NAIM-managed runtime role by default
- make skills, webgateway, and voice-module receive the same local desired-state snapshot path as infer, worker, app, and interaction runtime
- update desired-state renderer tests to assert the new plane-local state default

## Tests
- cmake --build build/macos/arm64 --target naim-state-v2-tests naim-state-v2-projector-tests naim-compose-renderer-tests -j 8
- build/macos/arm64/naim-state-v2-tests
- build/macos/arm64/naim-state-v2-projector-tests
- build/macos/arm64/naim-compose-renderer-tests