### PR TITLE
Route WebGateway through hostd runtime proxy

### DIFF
--- a/controller/include/browsing/plane_browsing_service.h
+++ b/controller/include/browsing/plane_browsing_service.h
@@ -18,8 +18,22 @@ class PlaneBrowsingService final {
       const DesiredState& desired_state) const;
 
   nlohmann::json BuildStatusPayload(
+      const std::string& db_path,
       const DesiredState& desired_state,
       const std::optional<std::string>& plane_state) const;
+
+  nlohmann::json BuildStatusPayload(
+      const DesiredState& desired_state,
+      const std::optional<std::string>& plane_state) const;
+
+  std::optional<HttpResponse> ProxyPlaneBrowsingRequest(
+      const std::string& db_path,
+      const DesiredState& desired_state,
+      const std::string& method,
+      const std::string& path_suffix,
+      const std::string& body,
+      std::string* error_code,
+      std::string* error_message) const;
 
   std::optional<HttpResponse> ProxyPlaneBrowsingRequest(
       const DesiredState& desired_state,

--- a/controller/src/browsing/interaction_browsing_service.cpp
+++ b/controller/src/browsing/interaction_browsing_service.cpp
@@ -209,6 +209,7 @@ InteractionBrowsingService::ResolveInteractionBrowsing(
   std::string error_code;
   std::string error_message;
   const auto response = service.ProxyPlaneBrowsingRequest(
+      resolution.db_path,
       resolution.desired_state,
       "POST",
       "/resolve",
@@ -277,6 +278,7 @@ void InteractionBrowsingService::ReviewInteractionResponse(
   std::string error_code;
   std::string error_message;
   const auto review_response = PlaneBrowsingService().ProxyPlaneBrowsingRequest(
+      resolution.db_path,
       resolution.desired_state,
       "POST",
       "/review-response",

--- a/controller/src/browsing/plane_browsing_service.cpp
+++ b/controller/src/browsing/plane_browsing_service.cpp
@@ -1,10 +1,14 @@
 #include "browsing/plane_browsing_service.h"
 
 #include <algorithm>
+#include <chrono>
+#include <thread>
 
 namespace naim::controller {
 
 namespace {
+
+using nlohmann::json;
 
 std::vector<std::pair<std::string, std::string>> DefaultJsonHeaders() {
   return {{"Content-Type", "application/json"}};
@@ -15,6 +19,15 @@ std::string NormalizeControllerTargetHost(const PublishedPort& port) {
     return "127.0.0.1";
   }
   return port.host_ip;
+}
+
+bool IsControllerLocalNode(const std::string& node_name) {
+  return node_name.empty() || node_name == "local-hostd" ||
+         node_name == "controller-local";
+}
+
+bool IsLoopbackTargetHost(const std::string& host) {
+  return host == "127.0.0.1" || host == "localhost" || host == "::1";
 }
 
 const InstanceSpec* FindBrowsingInstance(const DesiredState& desired_state) {
@@ -38,9 +51,161 @@ std::string NormalizeWebGatewayPathSuffix(const std::string& path_suffix) {
   return "/v1/webgateway/" + path_suffix;
 }
 
-bool ProbeWebGatewayTargetOk(const ControllerEndpointTarget& target) {
+json BuildHeaderArray(
+    const std::vector<std::pair<std::string, std::string>>& headers) {
+  json result = json::array();
+  for (const auto& [key, value] : headers) {
+    result.push_back(json::array({key, value}));
+  }
+  return result;
+}
+
+HttpResponse BuildProxyErrorResponse(
+    int status_code,
+    const std::string& code,
+    const std::string& message) {
+  HttpResponse response;
+  response.status_code = status_code;
+  response.content_type = "application/json";
+  response.headers["Content-Type"] = response.content_type;
+  response.body =
+      json{{"status", "error"}, {"code", code}, {"message", message}}.dump();
+  return response;
+}
+
+HttpResponse ParseProxyResponsePayload(const json& progress) {
+  if (!progress.is_object() || !progress.contains("response") ||
+      !progress.at("response").is_object()) {
+    return BuildProxyErrorResponse(
+        502,
+        "webgateway_runtime_proxy_response_missing",
+        "hostd webgateway runtime proxy did not return an upstream response");
+  }
+  const auto& response_payload = progress.at("response");
+  HttpResponse response;
+  response.status_code = response_payload.value("status_code", 502);
+  response.content_type =
+      response_payload.value("content_type", std::string("application/json"));
+  response.body = response_payload.value("body", std::string{});
+  if (response_payload.contains("headers") &&
+      response_payload.at("headers").is_object()) {
+    for (const auto& [key, value] : response_payload.at("headers").items()) {
+      if (value.is_string()) {
+        response.headers[key] = value.get<std::string>();
+      }
+    }
+  }
+  if (!response.content_type.empty()) {
+    response.headers["Content-Type"] = response.content_type;
+  }
+  return response;
+}
+
+HttpResponse SendPlaneWebGatewayRequest(
+    const std::string& db_path,
+    const std::string& plane_name,
+    const ControllerEndpointTarget& target,
+    const std::string& method,
+    const std::string& path,
+    const std::string& body = "",
+    const std::vector<std::pair<std::string, std::string>>& headers = {}) {
+  if (!target.route_via_hostd_proxy) {
+    return SendControllerHttpRequest(target, method, path, body, headers);
+  }
+  if (db_path.empty() || target.node_name.empty()) {
+    return BuildProxyErrorResponse(
+        502,
+        "webgateway_runtime_proxy_route_missing",
+        "webgateway runtime target requires hostd proxy routing but has no node binding");
+  }
+  if (!IsLoopbackTargetHost(target.host)) {
+    return BuildProxyErrorResponse(
+        502,
+        "webgateway_runtime_proxy_target_rejected",
+        "hostd webgateway runtime proxy only accepts node-local loopback targets");
+  }
+
+  ControllerStore store(db_path);
+  store.Initialize();
+  const std::string request_id =
+      "webgateway-" + plane_name + "-" +
+      std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+  const std::string proxy_plane_name =
+      "runtime-http-proxy:webgateway:" + plane_name + ":" + request_id;
+
+  HostAssignment assignment;
+  assignment.node_name = target.node_name;
+  assignment.plane_name = proxy_plane_name;
+  assignment.desired_generation = 0;
+  assignment.max_attempts = 1;
+  assignment.assignment_type = "runtime-http-proxy";
+  assignment.desired_state_json =
+      json{
+          {"target_host", target.host},
+          {"target_port", target.port},
+          {"method", method},
+          {"path", path},
+          {"body", body},
+          {"headers", BuildHeaderArray(headers)},
+          {"request_id", request_id},
+          {"policy", "webgateway"},
+      }
+          .dump();
+  assignment.artifacts_root = "";
+  assignment.status = HostAssignmentStatus::Pending;
+  assignment.status_message = "proxy webgateway runtime HTTP request";
+  store.EnqueueHostAssignments(
+      {assignment}, "superseded webgateway runtime proxy request");
+
+  const auto assignments = store.LoadHostAssignments(
+      target.node_name,
+      std::nullopt,
+      proxy_plane_name);
+  if (assignments.empty()) {
+    return BuildProxyErrorResponse(
+        500,
+        "webgateway_runtime_proxy_queue_failed",
+        "failed to queue hostd webgateway runtime proxy assignment");
+  }
+  const int assignment_id = assignments.back().id;
+  const auto started_at = std::chrono::steady_clock::now();
+  while (std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now() - started_at)
+             .count() < 30000) {
+    const auto current = store.LoadHostAssignment(assignment_id);
+    if (!current.has_value()) {
+      return BuildProxyErrorResponse(
+          500,
+          "webgateway_runtime_proxy_assignment_missing",
+          "hostd webgateway runtime proxy assignment disappeared");
+    }
+    if (current->status == HostAssignmentStatus::Applied) {
+      const auto progress = json::parse(current->progress_json, nullptr, false);
+      return ParseProxyResponsePayload(progress);
+    }
+    if (current->status == HostAssignmentStatus::Failed) {
+      return BuildProxyErrorResponse(
+          502,
+          "webgateway_runtime_proxy_failed",
+          current->status_message.empty()
+              ? "hostd webgateway runtime proxy request failed"
+              : current->status_message);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  return BuildProxyErrorResponse(
+      504,
+      "webgateway_runtime_proxy_timeout",
+      "timed out waiting for hostd webgateway runtime proxy response");
+}
+
+bool ProbeWebGatewayTargetOk(
+    const std::string& db_path,
+    const std::string& plane_name,
+    const ControllerEndpointTarget& target) {
   try {
-    const auto response = SendControllerHttpRequest(target, "GET", "/health");
+    const auto response =
+        SendPlaneWebGatewayRequest(db_path, plane_name, target, "GET", "/health");
     return response.status_code >= 200 && response.status_code < 300;
   } catch (...) {
     return false;
@@ -70,10 +235,16 @@ std::optional<ControllerEndpointTarget> PlaneBrowsingService::ResolveTarget(
   target.host = NormalizeControllerTargetHost(*published);
   target.port = published->host_port;
   target.raw = "http://" + target.host + ":" + std::to_string(target.port);
+  target.node_name = browsing->node_name;
+  if (!IsControllerLocalNode(target.node_name) && IsLoopbackTargetHost(target.host)) {
+    target.route_via_hostd_proxy = true;
+    target.route_mode = "hostd-runtime-proxy";
+  }
   return target;
 }
 
 nlohmann::json PlaneBrowsingService::BuildStatusPayload(
+    const std::string& db_path,
     const DesiredState& desired_state,
     const std::optional<std::string>& plane_state) const {
   const bool enabled = IsEnabled(desired_state);
@@ -81,7 +252,8 @@ nlohmann::json PlaneBrowsingService::BuildStatusPayload(
   const auto target = ResolveTarget(desired_state);
   const bool running_plane = plane_state.has_value() && *plane_state == "running";
   const bool ready =
-      enabled && running_plane && target.has_value() && ProbeWebGatewayTargetOk(*target);
+      enabled && running_plane && target.has_value() &&
+      ProbeWebGatewayTargetOk(db_path, desired_state.plane_name, *target);
 
   std::string reason = "ready";
   if (!enabled) {
@@ -104,6 +276,12 @@ nlohmann::json PlaneBrowsingService::BuildStatusPayload(
       {"webgateway_container_name",
        browsing_instance != nullptr ? nlohmann::json(browsing_instance->name) : nlohmann::json(nullptr)},
       {"webgateway_target", target.has_value() ? nlohmann::json(target->raw) : nlohmann::json(nullptr)},
+      {"webgateway_node_name",
+       target.has_value() && !target->node_name.empty()
+           ? nlohmann::json(target->node_name)
+           : nlohmann::json(nullptr)},
+      {"webgateway_route_mode",
+       target.has_value() ? nlohmann::json(target->route_mode) : nlohmann::json(nullptr)},
       {"browser_session_enabled",
        desired_state.browsing.has_value() && desired_state.browsing->policy.has_value()
            ? nlohmann::json(desired_state.browsing->policy->browser_session_enabled)
@@ -120,7 +298,12 @@ nlohmann::json PlaneBrowsingService::BuildStatusPayload(
 
   if (ready) {
     try {
-      const auto response = SendControllerHttpRequest(*target, "GET", "/v1/webgateway/status");
+      const auto response = SendPlaneWebGatewayRequest(
+          db_path,
+          desired_state.plane_name,
+          *target,
+          "GET",
+          "/v1/webgateway/status");
       if (!response.body.empty()) {
         const auto runtime_status = nlohmann::json::parse(response.body, nullptr, false);
         if (runtime_status.is_object()) {
@@ -135,7 +318,14 @@ nlohmann::json PlaneBrowsingService::BuildStatusPayload(
   return payload;
 }
 
+nlohmann::json PlaneBrowsingService::BuildStatusPayload(
+    const DesiredState& desired_state,
+    const std::optional<std::string>& plane_state) const {
+  return BuildStatusPayload("", desired_state, plane_state);
+}
+
 std::optional<HttpResponse> PlaneBrowsingService::ProxyPlaneBrowsingRequest(
+    const std::string& db_path,
     const DesiredState& desired_state,
     const std::string& method,
     const std::string& path_suffix,
@@ -163,7 +353,9 @@ std::optional<HttpResponse> PlaneBrowsingService::ProxyPlaneBrowsingRequest(
   }
 
   try {
-    return SendControllerHttpRequest(
+    return SendPlaneWebGatewayRequest(
+        db_path,
+        desired_state.plane_name,
         *target,
         method,
         NormalizeWebGatewayPathSuffix(path_suffix),
@@ -178,6 +370,17 @@ std::optional<HttpResponse> PlaneBrowsingService::ProxyPlaneBrowsingRequest(
     }
     return std::nullopt;
   }
+}
+
+std::optional<HttpResponse> PlaneBrowsingService::ProxyPlaneBrowsingRequest(
+    const DesiredState& desired_state,
+    const std::string& method,
+    const std::string& path_suffix,
+    const std::string& body,
+    std::string* error_code,
+    std::string* error_message) const {
+  return ProxyPlaneBrowsingRequest(
+      "", desired_state, method, path_suffix, body, error_code, error_message);
 }
 
 }  // namespace naim::controller

--- a/controller/src/interaction/interaction_service.cpp
+++ b/controller/src/interaction/interaction_service.cpp
@@ -2059,8 +2059,7 @@ PlaneInteractionResolution InteractionPlaneResolver::Resolve(
   const bool browsing_enabled = browsing_service.IsEnabled(*desired_state);
   const auto browsing_target = browsing_service.ResolveTarget(*desired_state);
   const bool browsing_ready =
-      browsing_enabled && running_plane && browsing_target.has_value() &&
-      probe_controller_target_ok_(browsing_target, "/health");
+      browsing_enabled && running_plane && browsing_target.has_value();
   const auto browsing_instance = std::find_if(
       desired_state->instances.begin(),
       desired_state->instances.end(),

--- a/controller/src/plane/dashboard_service.cpp
+++ b/controller/src/plane/dashboard_service.cpp
@@ -821,6 +821,7 @@ nlohmann::json DashboardService::BuildPayload(
       *view.desired_state,
       store.LoadPlaneSkillBindings(view.desired_state->plane_name, std::nullopt));
   payload["webgateway"] = PlaneBrowsingService().BuildStatusPayload(
+      db_path,
       *view.desired_state,
       selected_plane_state);
 

--- a/controller/src/plane/plane_http_service.cpp
+++ b/controller/src/plane/plane_http_service.cpp
@@ -340,13 +340,14 @@ HttpResponse PlaneHttpService::HandlePlanePath(
           }
           return support_.build_json_response(
               200,
-              browsing_service.BuildStatusPayload(*desired_state, plane_state),
+              browsing_service.BuildStatusPayload(db_path, *desired_state, plane_state),
               {});
         }
 
         std::string error_code;
         std::string error_message;
         const auto proxied = browsing_service.ProxyPlaneBrowsingRequest(
+            db_path,
             *desired_state,
             request.method,
             path_suffix,

--- a/controller/src/skills/plane_skills_service_tests.cpp
+++ b/controller/src/skills/plane_skills_service_tests.cpp
@@ -1437,7 +1437,8 @@ naim::DesiredState BuildDesiredStateWithSkillsPort(
 
 naim::DesiredState BuildDesiredStateWithBrowsingPort(
     const std::string& host_ip,
-    const int host_port) {
+    const int host_port,
+    const std::string& node_name = "local-hostd") {
   naim::DesiredState desired_state;
   desired_state.plane_name = "maglev";
   desired_state.plane_mode = naim::PlaneMode::Llm;
@@ -1453,7 +1454,7 @@ naim::DesiredState BuildDesiredStateWithBrowsingPort(
   naim::InstanceSpec browsing;
   browsing.name = "webgateway-maglev";
   browsing.plane_name = "maglev";
-  browsing.node_name = "local-hostd";
+  browsing.node_name = node_name;
   browsing.role = naim::InstanceRole::Browsing;
   naim::PublishedPort published_port;
   published_port.host_ip = host_ip;
@@ -1569,6 +1570,9 @@ int main() {
       Expect(
           target->raw == "http://127.0.0.1:28130",
           "browsing target raw URL should use normalized published endpoint");
+      Expect(
+          !target->route_via_hostd_proxy,
+          "local browsing target should use direct runtime routing");
       std::cout << "ok: browsing-published-host-ip-target" << '\n';
     }
 
@@ -1581,6 +1585,23 @@ int main() {
           target->host == "127.0.0.1",
           "browsing target host should normalize wildcard host_ip to loopback");
       std::cout << "ok: browsing-wildcard-host-ip-normalization" << '\n';
+    }
+
+    {
+      naim::controller::PlaneBrowsingService browsing_service;
+      const auto target = browsing_service.ResolveTarget(
+          BuildDesiredStateWithBrowsingPort("127.0.0.1", 28130, "hpc1"));
+      Expect(target.has_value(), "remote browsing target should resolve");
+      Expect(
+          target->node_name == "hpc1",
+          "remote browsing target should preserve node binding");
+      Expect(
+          target->route_via_hostd_proxy,
+          "remote loopback browsing target should use hostd runtime proxy");
+      Expect(
+          target->route_mode == "hostd-runtime-proxy",
+          "remote loopback browsing target should expose hostd proxy route mode");
+      std::cout << "ok: remote-loopback-browsing-target-hostd-proxy" << '\n';
     }
 
     {

--- a/hostd/include/app/hostd_runtime_http_proxy.h
+++ b/hostd/include/app/hostd_runtime_http_proxy.h
@@ -11,6 +11,7 @@ enum class HostdRuntimeProxyPolicy {
   Runtime,
   KnowledgeVault,
   Skills,
+  WebGateway,
 };
 
 struct HostdRuntimeHttpResponse {

--- a/hostd/src/app/hostd_app_assignment_support.cpp
+++ b/hostd/src/app/hostd_app_assignment_support.cpp
@@ -573,6 +573,8 @@ void HostdAppAssignmentSupport::ExecuteRuntimeHttpProxy(
     policy = HostdRuntimeProxyPolicy::KnowledgeVault;
   } else if (policy_name == "skills") {
     policy = HostdRuntimeProxyPolicy::Skills;
+  } else if (policy_name == "webgateway") {
+    policy = HostdRuntimeProxyPolicy::WebGateway;
   }
   const auto headers = runtime_http_proxy_.ParseProxyHeaders(
       payload.value("headers", nlohmann::json::array()));

--- a/hostd/src/app/hostd_runtime_http_proxy.cpp
+++ b/hostd/src/app/hostd_runtime_http_proxy.cpp
@@ -205,6 +205,20 @@ bool HostdRuntimeHttpProxy::IsAllowedProxyPath(
     }
     return false;
   }
+  if (policy == HostdRuntimeProxyPolicy::WebGateway) {
+    if (method == "GET" && route == "/health") {
+      return true;
+    }
+    if (route == "/v1/webgateway" && (method == "GET" || method == "POST")) {
+      return true;
+    }
+    if (route.rfind("/v1/webgateway/", 0) == 0 &&
+        (method == "GET" || method == "POST" || method == "PUT" ||
+         method == "PATCH" || method == "DELETE")) {
+      return true;
+    }
+    return false;
+  }
   return IsAllowedRuntimeProxyPath(method, path);
 }
 
@@ -214,6 +228,9 @@ std::string HostdRuntimeHttpProxy::PolicyLabel(HostdRuntimeProxyPolicy policy) {
   }
   if (policy == HostdRuntimeProxyPolicy::KnowledgeVault) {
     return "knowledge-vault-http";
+  }
+  if (policy == HostdRuntimeProxyPolicy::WebGateway) {
+    return "webgateway-runtime-http";
   }
   return "runtime-direct-http";
 }


### PR DESCRIPTION
## Summary
- route plane WebGateway targets through hostd runtime proxy for remote node-local loopback ports
- add WebGateway-specific hostd proxy policy allowlist
- pass controller DB path through dashboard, plane WebGateway routes, and interaction browsing calls
- cover remote loopback WebGateway target resolution in plane skills tests

## Tests
- cmake --build build/webgateway-debug --target naim-plane-skills-tests naim-hostd --parallel 6
- cmake --build build/webgateway-debug --target naim-controller --parallel 6
- build/webgateway-debug/naim-plane-skills-tests