### PR TITLE
Move WebGateway browsing into interaction runtime

### DIFF
--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -1302,6 +1302,12 @@ void DesiredStateV2Renderer::RenderInteractionInstance() {
       {"NAIM_CONTROLLER_URL", "http://controller.internal:18080"},
       {"NAIM_CONTROL_ROOT", state_.control_root},
   };
+  if (browsing_json_.value("enabled", false)) {
+    interaction.environment["NAIM_WEBGATEWAY_BASE_URL"] =
+        "http://" + BuildWebGatewayInstanceName() + ":" +
+        std::to_string(kWebGatewayContainerPort) + "/v1/webgateway";
+    interaction.depends_on.push_back(BuildWebGatewayInstanceName());
+  }
   interaction.labels = {
       {"naim.plane", state_.plane_name},
       {"naim.role", "interaction"},

--- a/controller/include/interaction/interaction_types.h
+++ b/controller/include/interaction/interaction_types.h
@@ -98,6 +98,8 @@ struct StreamedInteractionSegmentResult {
   int dialog_estimate_before = 0;
   int dialog_estimate_after = 0;
   double context_compression_ratio = 1.0;
+  nlohmann::json webgateway_summary = nlohmann::json::object();
+  nlohmann::json webgateway_policy = nlohmann::json::object();
 };
 
 struct InteractionSessionResult {
@@ -119,6 +121,8 @@ struct InteractionSessionResult {
   int dialog_estimate_before = 0;
   int dialog_estimate_after = 0;
   double context_compression_ratio = 1.0;
+  nlohmann::json webgateway_summary = nlohmann::json::object();
+  nlohmann::json webgateway_policy = nlohmann::json::object();
 };
 
 struct InteractionRequestContext {

--- a/controller/src/interaction/interaction_http_service.cpp
+++ b/controller/src/interaction/interaction_http_service.cpp
@@ -169,9 +169,6 @@ InteractionHttpService::ResolveRequestContext(
   if (const auto error = ResolveRequestSkills(resolution, request_context)) {
     return error;
   }
-  if (const auto error = ResolveRequestBrowsing(resolution, request_context)) {
-    return error;
-  }
   return ResolveRequestKnowledge(resolution, request_context);
 }
 
@@ -180,17 +177,12 @@ HttpResponse InteractionHttpService::BuildSessionResponse(
     const naim::controller::InteractionRequestContext& request_context,
     const naim::controller::InteractionSessionResult& result) const {
   const naim::controller::InteractionSessionPresenter presenter;
-  naim::controller::InteractionSessionResult reviewed_result = result;
-  naim::controller::InteractionBrowsingService().ReviewInteractionResponse(
-      resolution,
-      request_context,
-      &reviewed_result);
   const auto response_spec =
-      presenter.BuildResponseSpec(resolution, request_context, reviewed_result);
+      presenter.BuildResponseSpec(resolution, request_context, result);
   auto headers =
       naim::controller::InteractionRequestContractSupport{}
           .BuildInteractionResponseHeaders(request_context.request_id);
-  for (const auto& [name, value] : BuildCompressionHeaders(reviewed_result)) {
+  for (const auto& [name, value] : BuildCompressionHeaders(result)) {
     headers[name] = value;
   }
   return support_.BuildJsonResponse(

--- a/controller/src/interaction/interaction_service.cpp
+++ b/controller/src/interaction/interaction_service.cpp
@@ -368,7 +368,9 @@ InteractionJsonResponseSpec InteractionSessionPresenter::BuildResponseSpec(
   const auto skill_resolution_mode =
       request_contract_support.RequestSkillResolutionMode(request_context);
   const auto browsing_summary =
-      request_contract_support.RequestBrowsingSummary(request_context);
+      result.webgateway_summary.is_object() && !result.webgateway_summary.empty()
+          ? result.webgateway_summary
+          : request_contract_support.RequestBrowsingSummary(request_context);
   const auto skills_session_id =
       request_contract_support.RequestSkillsSessionId(request_context);
   nlohmann::json session_payload = BuildSessionPayload(result);
@@ -876,6 +878,17 @@ InteractionSessionResult InteractionSessionExecutor::Execute(
         upstream.headers, "x-naim-dialog-estimate-after", 0);
     result.context_compression_ratio = ParseDoubleHeader(
         upstream.headers, "x-naim-context-compression-ratio", 1.0);
+    if (upstream_payload.contains("webgateway") &&
+        upstream_payload.at("webgateway").is_object()) {
+      result.webgateway_summary = upstream_payload.at("webgateway");
+    } else if (upstream_payload.contains("_naim_webgateway_context") &&
+               upstream_payload.at("_naim_webgateway_context").is_object()) {
+      result.webgateway_summary = upstream_payload.at("_naim_webgateway_context");
+    }
+    if (upstream_payload.contains("_naim_webgateway_policy") &&
+        upstream_payload.at("_naim_webgateway_policy").is_object()) {
+      result.webgateway_policy = upstream_payload.at("_naim_webgateway_policy");
+    }
 
     if (result.marker_seen &&
         session_reached_target_length_(policy, result.total_completion_tokens)) {

--- a/runtime/interaction/include/interaction/interaction_runtime_server.h
+++ b/runtime/interaction/include/interaction/interaction_runtime_server.h
@@ -25,6 +25,7 @@ struct InteractionRuntimeConfig {
   std::string listen_host = "0.0.0.0";
   int port = 18110;
   std::string upstream_base = "http://127.0.0.1:8000/v1";
+  std::string webgateway_base_url;
 };
 
 class InteractionRuntimeServer final {
@@ -70,6 +71,15 @@ class InteractionRuntimeServer final {
       const naim::controller::PlaneInteractionResolution& resolution,
       naim::controller::InteractionRequestContext* request_context) const;
   std::optional<naim::controller::ControllerEndpointTarget> ResolvePlaneNetworkSkillsTarget(
+      const naim::DesiredState& desired_state) const;
+  int ResolvePlaneOwnedBrowsing(
+      const naim::controller::PlaneInteractionResolution& resolution,
+      naim::controller::InteractionRequestContext* request_context) const;
+  void ReviewPlaneOwnedBrowsingResponse(
+      const naim::controller::PlaneInteractionResolution& resolution,
+      const naim::controller::InteractionRequestContext& request_context,
+      HttpResponse* response) const;
+  std::optional<naim::controller::ControllerEndpointTarget> ResolvePlaneNetworkWebGatewayTarget(
       const naim::DesiredState& desired_state) const;
   nlohmann::json LoadPlaneStatePayload() const;
   nlohmann::json LoadPlaneStatePayloadFromSnapshot() const;

--- a/runtime/interaction/src/interaction_runtime_server.cpp
+++ b/runtime/interaction/src/interaction_runtime_server.cpp
@@ -7,6 +7,7 @@
 #include <csignal>
 #include <fstream>
 #include <map>
+#include <optional>
 #include <stdexcept>
 #include <thread>
 
@@ -31,6 +32,12 @@ constexpr const char* kAppliedSkillsPayloadKey = "_naim_applied_skills";
 constexpr const char* kAutoAppliedSkillsPayloadKey = "_naim_auto_applied_skills";
 constexpr const char* kSkillsSessionIdPayloadKey = "_naim_skills_session_id";
 constexpr const char* kSkillResolutionModePayloadKey = "_naim_skill_resolution_mode";
+constexpr const char* kBrowsingSystemInstructionPayloadKey =
+    "_naim_browsing_system_instruction";
+constexpr const char* kBrowsingSummaryPayloadKey = "_naim_browsing_summary";
+constexpr const char* kWebGatewayContextPayloadKey = "_naim_webgateway_context";
+constexpr const char* kWebGatewayPolicyPayloadKey = "_naim_webgateway_policy";
+constexpr const char* kWebGatewayReviewPayloadKey = "_naim_webgateway_review";
 
 void SignalHandler(int) {
   if (g_stop_requested != nullptr) {
@@ -109,6 +116,173 @@ std::string BuildSkillsSystemInstruction(const nlohmann::json& skills) {
     instruction += "\n\nInstructions:\n" + content;
   }
   return instruction;
+}
+
+std::string ReadJsonStringOrDefault(
+    const nlohmann::json& payload,
+    const std::string& key,
+    std::string default_value = {}) {
+  const auto it = payload.find(key);
+  if (it == payload.end() || it->is_null() || !it->is_string()) {
+    return default_value;
+  }
+  return it->get<std::string>();
+}
+
+std::string LastUserMessageContent(
+    const naim::controller::InteractionRequestContext& context) {
+  if (!context.payload.contains("messages") ||
+      !context.payload.at("messages").is_array()) {
+    return "";
+  }
+  const auto& messages = context.payload.at("messages");
+  for (auto it = messages.rbegin(); it != messages.rend(); ++it) {
+    if (it->is_object() && it->value("role", std::string{}) == "user" &&
+        it->contains("content") && it->at("content").is_string()) {
+      return it->at("content").get<std::string>();
+    }
+  }
+  return "";
+}
+
+nlohmann::json ConversationSlice(
+    const naim::controller::InteractionRequestContext& context) {
+  if (context.payload.contains("messages") &&
+      context.payload.at("messages").is_array()) {
+    return context.payload.at("messages");
+  }
+  return nlohmann::json::array();
+}
+
+std::string ReadPersistedBrowsingMode(
+    const naim::controller::InteractionRequestContext& context) {
+  const nlohmann::json& state =
+      context.payload.contains(naim::controller::kInteractionSessionContextStatePayloadKey) &&
+              context.payload.at(naim::controller::kInteractionSessionContextStatePayloadKey)
+                  .is_object()
+          ? context.payload.at(naim::controller::kInteractionSessionContextStatePayloadKey)
+          : context.session_context_state;
+  if (!state.is_object()) {
+    return "auto";
+  }
+  const std::string mode = state.value("browsing_mode", std::string{});
+  if (mode == "enabled" || mode == "disabled") {
+    return mode;
+  }
+  return "auto";
+}
+
+nlohmann::json BuildDisabledWebGatewayContext() {
+  return nlohmann::json{
+      {"mode", "disabled"},
+      {"mode_source", "default_off"},
+      {"plane_enabled", false},
+      {"ready", false},
+      {"session_backend", "broker_fallback"},
+      {"rendered_browser_enabled", true},
+      {"rendered_browser_ready", false},
+      {"login_enabled", false},
+      {"toggle_only", false},
+      {"decision", "disabled"},
+      {"reason", "web_mode_disabled"},
+      {"lookup_state", "disabled"},
+      {"lookup_attempted", false},
+      {"lookup_required", false},
+      {"evidence_attached", false},
+      {"searches", nlohmann::json::array()},
+      {"sources", nlohmann::json::array()},
+      {"errors", nlohmann::json::array()},
+      {"refusal", nullptr},
+      {"response_policy", nlohmann::json::object()},
+  };
+}
+
+nlohmann::json BuildUnavailableWebGatewayContext(
+    const std::string& reason,
+    const std::string& error_message) {
+  nlohmann::json context = BuildDisabledWebGatewayContext();
+  context["mode"] = "enabled";
+  context["mode_source"] = "webgateway_unreachable";
+  context["plane_enabled"] = true;
+  context["decision"] = "unavailable";
+  context["reason"] = reason.empty() ? "webgateway_unavailable" : reason;
+  context["lookup_state"] = "required_but_unavailable";
+  context["lookup_attempted"] = false;
+  context["lookup_required"] = true;
+  context["response_policy"] = nlohmann::json{
+      {"must_disclose_web_unavailable", true},
+      {"must_not_suggest_local_access", false},
+      {"must_refuse_upload", false},
+      {"must_use_only_evidence", false},
+      {"must_not_claim_unverified_web_lookup", true},
+      {"blocked_reason", nullptr},
+      {"unavailable_disclaimer",
+       "Web browsing was unavailable for this request, so I could not verify fresh public sources online."},
+  };
+  if (!error_message.empty()) {
+    context["errors"] = nlohmann::json::array(
+        {nlohmann::json{{"code", reason.empty() ? "webgateway_unavailable" : reason},
+                        {"message", error_message}}});
+  }
+  return context;
+}
+
+void ApplyWebGatewayPayload(
+    naim::controller::InteractionRequestContext* context,
+    const nlohmann::json& webgateway_context,
+    const nlohmann::json& response_policy,
+    const std::string& model_instruction,
+    const std::optional<std::string>& refusal,
+    const std::string& decision) {
+  if (context == nullptr) {
+    return;
+  }
+  if (!model_instruction.empty()) {
+    context->payload[kBrowsingSystemInstructionPayloadKey] = model_instruction;
+  }
+  context->payload[kBrowsingSummaryPayloadKey] = webgateway_context;
+  context->payload[kWebGatewayContextPayloadKey] = webgateway_context;
+  context->payload[kWebGatewayPolicyPayloadKey] = response_policy;
+  context->payload[kWebGatewayReviewPayloadKey] =
+      nlohmann::json{
+          {"decision", decision},
+          {"response_policy", response_policy},
+          {"refusal", refusal.has_value() ? nlohmann::json(*refusal) : nlohmann::json(nullptr)},
+      };
+}
+
+std::optional<std::string> ExtractAssistantContent(const nlohmann::json& payload) {
+  if (!payload.is_object() || !payload.contains("choices") ||
+      !payload.at("choices").is_array() || payload.at("choices").empty() ||
+      !payload.at("choices").at(0).is_object()) {
+    return std::nullopt;
+  }
+  const auto& choice = payload.at("choices").at(0);
+  if (choice.contains("message") && choice.at("message").is_object() &&
+      choice.at("message").contains("content") &&
+      choice.at("message").at("content").is_string()) {
+    return choice.at("message").at("content").get<std::string>();
+  }
+  if (choice.contains("text") && choice.at("text").is_string()) {
+    return choice.at("text").get<std::string>();
+  }
+  return std::nullopt;
+}
+
+void SetAssistantContent(nlohmann::json* payload, const std::string& content) {
+  if (payload == nullptr || !payload->is_object() || !payload->contains("choices") ||
+      !payload->at("choices").is_array() || payload->at("choices").empty() ||
+      !payload->at("choices").at(0).is_object()) {
+    return;
+  }
+  auto& choice = payload->at("choices").at(0);
+  if (choice.contains("message") && choice.at("message").is_object()) {
+    choice.at("message")["content"] = content;
+    return;
+  }
+  if (choice.contains("text")) {
+    choice["text"] = content;
+  }
 }
 
 void SetNoResolvedSkills(naim::controller::InteractionRequestContext* context) {
@@ -359,6 +533,10 @@ HttpResponse InteractionRuntimeServer::ExecuteNonStream(const HttpRequest& reque
   }
   const auto local_started_at = std::chrono::steady_clock::now();
   auto execution = BuildRuntimeExecution(request);
+  const auto browsing_started_at = std::chrono::steady_clock::now();
+  const int browsing_resolve_ms =
+      ResolvePlaneOwnedBrowsing(execution.resolution, &execution.request_context);
+  const auto browsing_finished_at = std::chrono::steady_clock::now();
   const auto compression_started_at = std::chrono::steady_clock::now();
   naim::controller::InteractionContextCompressionService().Apply(
       execution.resolution,
@@ -378,9 +556,20 @@ HttpResponse InteractionRuntimeServer::ExecuteNonStream(const HttpRequest& reque
       "/chat/completions",
       upstream_body,
       {{"Accept", "application/json"}});
+  ReviewPlaneOwnedBrowsingResponse(
+      execution.resolution,
+      execution.request_context,
+      &response);
   for (const auto& [name, value] : BuildCompressionHeaders(execution.request_context)) {
     response.headers[name] = value;
   }
+  response.headers["x-naim-webgateway-resolve-ms"] =
+      std::to_string(browsing_resolve_ms);
+  response.headers["x-naim-webgateway-total-ms"] =
+      std::to_string(static_cast<int>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              browsing_finished_at - browsing_started_at)
+              .count()));
   AddRuntimeTelemetryHeaders(
       &response,
       execution.local_raw_execution,
@@ -410,6 +599,10 @@ void InteractionRuntimeServer::ExecuteStream(
   const auto local_started_at = std::chrono::steady_clock::now();
   auto execution = BuildRuntimeExecution(request);
   execution.force_stream = true;
+  const auto browsing_started_at = std::chrono::steady_clock::now();
+  const int browsing_resolve_ms =
+      ResolvePlaneOwnedBrowsing(execution.resolution, &execution.request_context);
+  const auto browsing_finished_at = std::chrono::steady_clock::now();
   const auto compression_started_at = std::chrono::steady_clock::now();
   naim::controller::InteractionContextCompressionService().Apply(
       execution.resolution,
@@ -432,6 +625,13 @@ void InteractionRuntimeServer::ExecuteStream(
       execution.local_raw_execution ? "true" : "false";
   response_headers["x-naim-skills-resolve-ms"] =
       std::to_string(execution.skills_resolve_ms);
+  response_headers["x-naim-webgateway-resolve-ms"] =
+      std::to_string(browsing_resolve_ms);
+  response_headers["x-naim-webgateway-total-ms"] =
+      std::to_string(static_cast<int>(
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              browsing_finished_at - browsing_started_at)
+              .count()));
   response_headers["x-naim-context-compression-ms"] =
       std::to_string(static_cast<int>(
           std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -745,6 +945,223 @@ InteractionRuntimeServer::ResolvePlaneNetworkSkillsTarget(
   target.host = it->name;
   target.port = port;
   target.raw = "http://" + target.host + ":" + std::to_string(target.port);
+  target.node_name = it->node_name;
+  target.route_mode = "plane-network";
+  target.route_via_hostd_proxy = false;
+  return target;
+}
+
+int InteractionRuntimeServer::ResolvePlaneOwnedBrowsing(
+    const naim::controller::PlaneInteractionResolution& resolution,
+    naim::controller::InteractionRequestContext* request_context) const {
+  const auto started_at = std::chrono::steady_clock::now();
+  if (request_context == nullptr) {
+    throw std::invalid_argument("interaction request context is required");
+  }
+  if (!resolution.desired_state.browsing.has_value() ||
+      !resolution.desired_state.browsing->enabled) {
+    ApplyWebGatewayPayload(
+        request_context,
+        BuildDisabledWebGatewayContext(),
+        nlohmann::json::object(),
+        "",
+        std::nullopt,
+        "disabled");
+    return 0;
+  }
+
+  const auto target = ResolvePlaneNetworkWebGatewayTarget(resolution.desired_state);
+  if (!target.has_value()) {
+    const nlohmann::json context =
+        BuildUnavailableWebGatewayContext("webgateway_target_missing", "");
+    ApplyWebGatewayPayload(
+        request_context,
+        context,
+        context.value("response_policy", nlohmann::json::object()),
+        "WebGateway could not provide usable evidence for this request. If online verification matters, state that web browsing was unavailable.",
+        std::nullopt,
+        "unavailable");
+    return static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now() - started_at)
+                                .count());
+  }
+
+  nlohmann::json resolve_payload = {
+      {"plane_name", resolution.desired_state.plane_name},
+      {"conversation_slice", ConversationSlice(*request_context)},
+      {"latest_user_message", LastUserMessageContent(*request_context)},
+      {"web_mode", ReadPersistedBrowsingMode(*request_context)},
+      {"plane_policy",
+       nlohmann::json{
+           {"enabled", true},
+           {"browser_session_enabled",
+            resolution.desired_state.browsing->policy.has_value()
+                ? nlohmann::json(
+                      resolution.desired_state.browsing->policy->browser_session_enabled)
+                : nlohmann::json(false)},
+           {"rendered_browser_enabled",
+            resolution.desired_state.browsing->policy.has_value()
+                ? nlohmann::json(
+                      resolution.desired_state.browsing->policy->rendered_browser_enabled)
+                : nlohmann::json(true)},
+       }},
+  };
+
+  try {
+    const HttpResponse response = SendControllerHttpRequest(
+        *target,
+        "POST",
+        "/resolve",
+        resolve_payload.dump(),
+        JsonHeaders());
+    if (response.status_code != 200) {
+      const nlohmann::json context = BuildUnavailableWebGatewayContext(
+          "webgateway_upstream_failed",
+          "WebGateway returned status " + std::to_string(response.status_code));
+      ApplyWebGatewayPayload(
+          request_context,
+          context,
+          context.value("response_policy", nlohmann::json::object()),
+          "WebGateway could not provide usable evidence for this request. If online verification matters, state that web browsing was unavailable.",
+          std::nullopt,
+          "unavailable");
+    } else {
+      const nlohmann::json payload =
+          response.body.empty() ? nlohmann::json::object()
+                                : nlohmann::json::parse(response.body, nullptr, false);
+      if (!payload.is_object()) {
+        throw std::runtime_error("WebGateway returned malformed resolve payload");
+      }
+      const nlohmann::json webgateway_context =
+          payload.contains("context") && payload.at("context").is_object()
+              ? payload.at("context")
+              : BuildDisabledWebGatewayContext();
+      const nlohmann::json response_policy =
+          payload.contains("response_policy") && payload.at("response_policy").is_object()
+              ? payload.at("response_policy")
+              : webgateway_context.value("response_policy", nlohmann::json::object());
+      const auto refusal_it = payload.find("refusal");
+      std::optional<std::string> refusal = std::nullopt;
+      if (refusal_it != payload.end() && refusal_it->is_string()) {
+        refusal = refusal_it->get<std::string>();
+      }
+      ApplyWebGatewayPayload(
+          request_context,
+          webgateway_context,
+          response_policy,
+          ReadJsonStringOrDefault(payload, "model_instruction"),
+          refusal,
+          ReadJsonStringOrDefault(payload, "decision", "disabled"));
+    }
+  } catch (const std::exception& error) {
+    const nlohmann::json context =
+        BuildUnavailableWebGatewayContext("webgateway_unavailable", error.what());
+    ApplyWebGatewayPayload(
+        request_context,
+        context,
+        context.value("response_policy", nlohmann::json::object()),
+        "WebGateway could not provide usable evidence for this request. If online verification matters, state that web browsing was unavailable.",
+        std::nullopt,
+        "unavailable");
+  }
+  return static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::steady_clock::now() - started_at)
+                              .count());
+}
+
+void InteractionRuntimeServer::ReviewPlaneOwnedBrowsingResponse(
+    const naim::controller::PlaneInteractionResolution& resolution,
+    const naim::controller::InteractionRequestContext& request_context,
+    HttpResponse* response) const {
+  if (response == nullptr || response->status_code != 200 || response->body.empty() ||
+      !request_context.payload.contains(kWebGatewayReviewPayloadKey) ||
+      !request_context.payload.at(kWebGatewayReviewPayloadKey).is_object() ||
+      !resolution.desired_state.browsing.has_value() ||
+      !resolution.desired_state.browsing->enabled) {
+    return;
+  }
+  nlohmann::json body = nlohmann::json::parse(response->body, nullptr, false);
+  if (!body.is_object()) {
+    return;
+  }
+  const auto draft = ExtractAssistantContent(body);
+  if (!draft.has_value()) {
+    return;
+  }
+  const auto target = ResolvePlaneNetworkWebGatewayTarget(resolution.desired_state);
+  if (!target.has_value()) {
+    body[kWebGatewayContextPayloadKey] =
+        request_context.payload.value(kWebGatewayContextPayloadKey, nlohmann::json::object());
+    body["webgateway"] = body[kWebGatewayContextPayloadKey];
+    response->body = body.dump();
+    return;
+  }
+
+  nlohmann::json review_payload =
+      request_context.payload.at(kWebGatewayReviewPayloadKey);
+  review_payload["draft_model_answer"] = *draft;
+  try {
+    const HttpResponse review_response = SendControllerHttpRequest(
+        *target,
+        "POST",
+        "/review-response",
+        review_payload.dump(),
+        JsonHeaders());
+    if (review_response.status_code == 200 && !review_response.body.empty()) {
+      const nlohmann::json review =
+          nlohmann::json::parse(review_response.body, nullptr, false);
+      if (review.is_object() && review.contains("corrected_answer") &&
+          review.at("corrected_answer").is_string()) {
+        SetAssistantContent(&body, review.at("corrected_answer").get<std::string>());
+      }
+      body["_naim_webgateway_review_result"] = review;
+    }
+  } catch (const std::exception&) {
+  }
+  body[kWebGatewayContextPayloadKey] =
+      request_context.payload.value(kWebGatewayContextPayloadKey, nlohmann::json::object());
+  body[kWebGatewayPolicyPayloadKey] =
+      request_context.payload.value(kWebGatewayPolicyPayloadKey, nlohmann::json::object());
+  body["webgateway"] = body[kWebGatewayContextPayloadKey];
+  response->body = body.dump();
+}
+
+std::optional<naim::controller::ControllerEndpointTarget>
+InteractionRuntimeServer::ResolvePlaneNetworkWebGatewayTarget(
+    const naim::DesiredState& desired_state) const {
+  if (!config_.webgateway_base_url.empty()) {
+    auto target = ParseControllerEndpointTarget(config_.webgateway_base_url);
+    target.route_mode = "plane-network";
+    target.route_via_hostd_proxy = false;
+    return target;
+  }
+  const auto it = std::find_if(
+      desired_state.instances.begin(),
+      desired_state.instances.end(),
+      [](const naim::InstanceSpec& instance) {
+        return instance.role == naim::InstanceRole::Browsing;
+      });
+  if (it == desired_state.instances.end() || it->name.empty()) {
+    return std::nullopt;
+  }
+
+  int port = 18130;
+  if (const auto env_it = it->environment.find("NAIM_WEBGATEWAY_PORT");
+      env_it != it->environment.end()) {
+    port = ParsePositiveIntOr(env_it->second, port);
+  }
+  for (const auto& published : it->published_ports) {
+    if (published.container_port > 0) {
+      port = published.container_port;
+      break;
+    }
+  }
+  naim::controller::ControllerEndpointTarget target;
+  target.host = it->name;
+  target.port = port;
+  target.base_path = "/v1/webgateway";
+  target.raw = "http://" + target.host + ":" + std::to_string(target.port) +
+               target.base_path;
   target.node_name = it->node_name;
   target.route_mode = "plane-network";
   target.route_via_hostd_proxy = false;

--- a/runtime/interaction/src/interaction_runtime_server_tests.cpp
+++ b/runtime/interaction/src/interaction_runtime_server_tests.cpp
@@ -59,6 +59,13 @@ naim::DesiredState BuildDesiredState() {
   state.interaction->system_prompt = "You are a test assistant.";
   state.skills = naim::SkillsSettings{};
   state.skills->enabled = true;
+  naim::BrowsingSettings browsing;
+  browsing.enabled = true;
+  naim::BrowsingPolicySettings browsing_policy;
+  browsing_policy.browser_session_enabled = true;
+  browsing_policy.rendered_browser_enabled = true;
+  browsing.policy = browsing_policy;
+  state.browsing = browsing;
 
   naim::InstanceSpec skills;
   skills.name = "skills-test-plane";
@@ -68,6 +75,15 @@ naim::DesiredState BuildDesiredState() {
   skills.environment["NAIM_SKILLS_PORT"] = "18120";
   skills.published_ports.push_back(naim::PublishedPort{"127.0.0.1", 26182, 18120});
   state.instances.push_back(skills);
+
+  naim::InstanceSpec webgateway;
+  webgateway.name = "webgateway-test-plane";
+  webgateway.role = naim::InstanceRole::Browsing;
+  webgateway.plane_name = state.plane_name;
+  webgateway.node_name = "hpc1";
+  webgateway.environment["NAIM_WEBGATEWAY_PORT"] = "18130";
+  webgateway.published_ports.push_back(naim::PublishedPort{"127.0.0.1", 26183, 18130});
+  state.instances.push_back(webgateway);
   return state;
 }
 
@@ -155,6 +171,41 @@ void TestPlaneNetworkSkillsTargetUsesContainerPort() {
   Expect(!target->route_via_hostd_proxy, "plane-network skills target should not use hostd proxy");
 }
 
+void TestPlaneNetworkWebGatewayTargetUsesPlaneDns() {
+  TempDir temp;
+  auto server = BuildServer(temp.path());
+  const auto target = server.ResolvePlaneNetworkWebGatewayTarget(BuildDesiredState());
+  Expect(target.has_value(), "webgateway plane-network target should resolve");
+  Expect(target->host == "webgateway-test-plane",
+         "webgateway target should use instance DNS name");
+  Expect(target->port == 18130, "webgateway target should use container port");
+  Expect(target->base_path == "/v1/webgateway",
+         "webgateway target should use runtime API base path");
+  Expect(!target->route_via_hostd_proxy,
+         "plane-network webgateway target should not use hostd proxy");
+}
+
+void TestPlaneOwnedBrowsingDisabledDoesNotUseController() {
+  TempDir temp;
+  auto state = BuildDesiredState();
+  state.browsing->enabled = false;
+  auto server = BuildServer(temp.path());
+  naim::controller::PlaneInteractionResolution resolution;
+  resolution.desired_state = state;
+  naim::controller::InteractionRequestContext context;
+  context.payload = nlohmann::json{
+      {"messages",
+       nlohmann::json::array(
+           {nlohmann::json{{"role", "user"}, {"content", "hello"}}})}};
+  const int elapsed = server.ResolvePlaneOwnedBrowsing(resolution, &context);
+  Expect(elapsed == 0, "disabled webgateway should not perform a runtime lookup");
+  Expect(context.payload.contains("_naim_webgateway_context"),
+         "disabled webgateway should still expose context");
+  Expect(context.payload.at("_naim_webgateway_context").value("mode", std::string{}) ==
+             "disabled",
+         "disabled webgateway context should mark disabled mode");
+}
+
 }  // namespace
 
 int main() {
@@ -163,6 +214,8 @@ int main() {
     TestRawRequestFallsBackWithoutSnapshot();
     TestWrappedRequestNeverUsesRawProxy();
     TestPlaneNetworkSkillsTargetUsesContainerPort();
+    TestPlaneNetworkWebGatewayTargetUsesPlaneDns();
+    TestPlaneOwnedBrowsingDisabledDoesNotUseController();
     std::cout << "ok: interaction-runtime-server-fast-path-tests\n";
     return 0;
   } catch (const std::exception& error) {

--- a/runtime/interaction/src/main.cpp
+++ b/runtime/interaction/src/main.cpp
@@ -38,11 +38,16 @@ int main() {
     config.upstream_base = GetEnvOr(
         "NAIM_INTERACTION_UPSTREAM_BASE",
         "http://127.0.0.1:8000/v1");
+    config.webgateway_base_url = GetEnvOr("NAIM_WEBGATEWAY_BASE_URL", "");
 
     std::cout << "[naim-interaction] booting plane=" << config.plane_name
               << " instance=" << config.instance_name << "\n";
     std::cout << "[naim-interaction] status_path=" << config.status_path.string() << "\n";
     std::cout << "[naim-interaction] upstream_base=" << config.upstream_base << "\n";
+    if (!config.webgateway_base_url.empty()) {
+      std::cout << "[naim-interaction] webgateway_base_url="
+                << config.webgateway_base_url << "\n";
+    }
     std::cout << "[naim-interaction] port=" << config.port << "\n";
     std::cout.flush();
 


### PR DESCRIPTION
## Summary
- move WebGateway resolve/review from controller hot path into plane-owned interaction runtime
- add plane-local WebGateway base URL to interaction instance env when WebGateway is enabled
- return runtime WebGateway summary in interaction responses so controller can present it without calling WebGateway
- keep controller WebGateway proxy as operator/status path only

## Tests
- cmake --build build/webgateway-debug --target naim-interaction-runtime-server-tests naim-controller naim-interactiond --parallel 6
- build/webgateway-debug/naim-interaction-runtime-server-tests
- cmake --build build/webgateway-debug --target naim-plane-skills-tests --parallel 6
- build/webgateway-debug/naim-plane-skills-tests
- cmake --build build/webgateway-debug --target naim-state-v2-tests naim-state-v2-projector-tests --parallel 6
- build/webgateway-debug/naim-state-v2-tests
- build/webgateway-debug/naim-state-v2-projector-tests