### PR TITLE
Improve live telemetry runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1537,8 +1537,19 @@ add_executable(
   launcher/src/platform/signal_manager.cpp
   launcher/src/run/hostd_peer_service.cpp
   launcher/src/run/launcher_run_service.cpp
+  hostd/src/app/hostd_command_support.cpp
   hostd/src/app/hostd_controller_transport_support.cpp
+  hostd/src/app/hostd_desired_state_path_support.cpp
+  hostd/src/app/hostd_local_runtime_state_support.cpp
+  hostd/src/app/hostd_local_state_path_support.cpp
+  hostd/src/app/hostd_local_state_repository.cpp
+  hostd/src/app/hostd_observed_state_snapshot_builder.cpp
+  hostd/src/app/hostd_reporting_support.cpp
+  hostd/src/app/hostd_runtime_telemetry_support.cpp
+  hostd/src/app/hostd_system_telemetry_collector.cpp
+  hostd/src/backend/hostd_backend_factory.cpp
   hostd/src/backend/http_hostd_backend.cpp
+  hostd/src/backend/local_db_hostd_backend.cpp
   launcher/src/main.cpp
   launcher/src/app/launcher_app.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -559,6 +559,16 @@ target_link_libraries(naim-plane-observation-matcher-tests PRIVATE naim-common)
 naim_enable_strict_warnings(naim-plane-observation-matcher-tests)
 
 add_executable(
+  naim-telemetry-live-store-tests
+  controller/src/telemetry/telemetry_live_store.cpp
+  controller/src/telemetry/telemetry_live_store_tests.cpp
+)
+target_include_directories(
+  naim-telemetry-live-store-tests PRIVATE common/include controller/include)
+target_link_libraries(naim-telemetry-live-store-tests PRIVATE naim-common)
+naim_enable_strict_warnings(naim-telemetry-live-store-tests)
+
+add_executable(
   naim-read-model-tests
   controller/src/observation/plane_observation_matcher.cpp
   controller/src/infra/controller_runtime_support_service.cpp
@@ -616,6 +626,7 @@ add_executable(
   controller/src/infra/controller_network_manager.cpp
   controller/src/knowledge/knowledge_vault_service_repository.cpp
   controller/src/observation/plane_observation_matcher.cpp
+  controller/src/telemetry/telemetry_live_store.cpp
 )
 target_include_directories(
   naim-hostd-http-tests PRIVATE common/include controller/include)
@@ -1425,6 +1436,7 @@ add_executable(
   controller/src/skills/skills_factory_service.cpp
   controller/src/scheduler/scheduler_service.cpp
   controller/src/read_model/state_aggregate_loader.cpp
+  controller/src/telemetry/telemetry_live_store.cpp
   controller/src/web/web_ui_service.cpp
   controller/src/app/controller_app.cpp
   controller/src/app/controller_composition_root.cpp

--- a/common/include/naim/runtime/runtime_status.h
+++ b/common/include/naim/runtime/runtime_status.h
@@ -135,16 +135,23 @@ struct CpuTelemetrySnapshot {
 
 struct HostTelemetryFrame {
   int contract_version = 1;
+  std::string channel = "host.telemetry.v1";
   std::string node_name;
   std::string plane_name;
   std::string sampled_at;
+  std::string collected_at;
+  std::string expires_at;
   std::uint64_t sequence = 0;
+  std::uint64_t monotonic_ms = 0;
   int interval_ms = 2000;
   int ttl_ms = 10000;
+  std::string lane = "fast";
+  std::string degraded_reason;
   std::vector<RuntimeProcessStatus> instance_runtime;
   GpuTelemetrySnapshot gpu;
   NetworkTelemetrySnapshot network;
   CpuTelemetrySnapshot cpu;
+  DiskTelemetrySnapshot disk;
 };
 
 struct RuntimeStatus {

--- a/common/include/naim/runtime/runtime_status.h
+++ b/common/include/naim/runtime/runtime_status.h
@@ -133,6 +133,20 @@ struct CpuTelemetrySnapshot {
   std::uint64_t used_memory_bytes = 0;
 };
 
+struct HostTelemetryFrame {
+  int contract_version = 1;
+  std::string node_name;
+  std::string plane_name;
+  std::string sampled_at;
+  std::uint64_t sequence = 0;
+  int interval_ms = 2000;
+  int ttl_ms = 10000;
+  std::vector<RuntimeProcessStatus> instance_runtime;
+  GpuTelemetrySnapshot gpu;
+  NetworkTelemetrySnapshot network;
+  CpuTelemetrySnapshot cpu;
+};
+
 struct RuntimeStatus {
   std::string plane_name;
   std::string control_root;
@@ -235,6 +249,8 @@ std::string SerializeNetworkTelemetryJson(const NetworkTelemetrySnapshot& snapsh
 NetworkTelemetrySnapshot DeserializeNetworkTelemetryJson(const std::string& json_text);
 std::string SerializeCpuTelemetryJson(const CpuTelemetrySnapshot& snapshot);
 CpuTelemetrySnapshot DeserializeCpuTelemetryJson(const std::string& json_text);
+std::string SerializeHostTelemetryFrameJson(const HostTelemetryFrame& frame);
+HostTelemetryFrame DeserializeHostTelemetryFrameJson(const std::string& json_text);
 
 std::optional<RuntimeStatus> LoadRuntimeStatusJson(const std::string& path);
 void SaveRuntimeStatusJson(const RuntimeStatus& status, const std::string& path);

--- a/common/src/runtime/runtime_status.cpp
+++ b/common/src/runtime/runtime_status.cpp
@@ -367,25 +367,35 @@ json ToJson(const HostTelemetryFrame& frame) {
   }
   return json{
       {"contract_version", frame.contract_version},
+      {"channel", frame.channel},
       {"node_name", frame.node_name},
       {"plane_name", frame.plane_name},
       {"sampled_at", frame.sampled_at},
+      {"collected_at", frame.collected_at},
+      {"expires_at", frame.expires_at},
       {"sequence", frame.sequence},
+      {"monotonic_ms", frame.monotonic_ms},
       {"interval_ms", frame.interval_ms},
       {"ttl_ms", frame.ttl_ms},
+      {"lane", frame.lane},
+      {"degraded_reason", frame.degraded_reason},
       {"instance_runtime", std::move(instance_runtime)},
       {"gpu", ToJson(frame.gpu)},
       {"network", ToJson(frame.network)},
       {"cpu", ToJson(frame.cpu)},
+      {"disk", ToJson(frame.disk)},
   };
 }
 
 HostTelemetryFrame HostTelemetryFrameFromJson(const json& value) {
   HostTelemetryFrame frame;
   frame.contract_version = value.value("contract_version", 1);
+  frame.channel = value.value("channel", std::string{"host.telemetry.v1"});
   frame.node_name = value.value("node_name", std::string{});
   frame.plane_name = value.value("plane_name", std::string{});
   frame.sampled_at = value.value("sampled_at", std::string{});
+  frame.collected_at = value.value("collected_at", frame.sampled_at);
+  frame.expires_at = value.value("expires_at", std::string{});
   if (value.contains("sequence") && value.at("sequence").is_number_unsigned()) {
     frame.sequence = value.at("sequence").get<std::uint64_t>();
   } else if (value.contains("sequence") && value.at("sequence").is_number_integer()) {
@@ -394,8 +404,19 @@ HostTelemetryFrame HostTelemetryFrameFromJson(const json& value) {
       frame.sequence = static_cast<std::uint64_t>(raw);
     }
   }
+  if (value.contains("monotonic_ms") && value.at("monotonic_ms").is_number_unsigned()) {
+    frame.monotonic_ms = value.at("monotonic_ms").get<std::uint64_t>();
+  } else if (
+      value.contains("monotonic_ms") && value.at("monotonic_ms").is_number_integer()) {
+    const auto raw = value.at("monotonic_ms").get<std::int64_t>();
+    if (raw > 0) {
+      frame.monotonic_ms = static_cast<std::uint64_t>(raw);
+    }
+  }
   frame.interval_ms = value.value("interval_ms", 2000);
   frame.ttl_ms = value.value("ttl_ms", 10000);
+  frame.lane = value.value("lane", std::string{"fast"});
+  frame.degraded_reason = value.value("degraded_reason", std::string{});
   for (const auto& status : value.value("instance_runtime", json::array())) {
     if (status.is_object()) {
       frame.instance_runtime.push_back(RuntimeProcessStatusFromJson(status));
@@ -409,6 +430,9 @@ HostTelemetryFrame HostTelemetryFrameFromJson(const json& value) {
   }
   if (value.contains("cpu") && value.at("cpu").is_object()) {
     frame.cpu = CpuTelemetrySnapshotFromJson(value.at("cpu"));
+  }
+  if (value.contains("disk") && value.at("disk").is_object()) {
+    frame.disk = DiskTelemetrySnapshotFromJson(value.at("disk"));
   }
   return frame;
 }

--- a/common/src/runtime/runtime_status.cpp
+++ b/common/src/runtime/runtime_status.cpp
@@ -360,6 +360,59 @@ CpuTelemetrySnapshot CpuTelemetrySnapshotFromJson(const json& value) {
   return snapshot;
 }
 
+json ToJson(const HostTelemetryFrame& frame) {
+  json instance_runtime = json::array();
+  for (const auto& status : frame.instance_runtime) {
+    instance_runtime.push_back(ToJson(status));
+  }
+  return json{
+      {"contract_version", frame.contract_version},
+      {"node_name", frame.node_name},
+      {"plane_name", frame.plane_name},
+      {"sampled_at", frame.sampled_at},
+      {"sequence", frame.sequence},
+      {"interval_ms", frame.interval_ms},
+      {"ttl_ms", frame.ttl_ms},
+      {"instance_runtime", std::move(instance_runtime)},
+      {"gpu", ToJson(frame.gpu)},
+      {"network", ToJson(frame.network)},
+      {"cpu", ToJson(frame.cpu)},
+  };
+}
+
+HostTelemetryFrame HostTelemetryFrameFromJson(const json& value) {
+  HostTelemetryFrame frame;
+  frame.contract_version = value.value("contract_version", 1);
+  frame.node_name = value.value("node_name", std::string{});
+  frame.plane_name = value.value("plane_name", std::string{});
+  frame.sampled_at = value.value("sampled_at", std::string{});
+  if (value.contains("sequence") && value.at("sequence").is_number_unsigned()) {
+    frame.sequence = value.at("sequence").get<std::uint64_t>();
+  } else if (value.contains("sequence") && value.at("sequence").is_number_integer()) {
+    const auto raw = value.at("sequence").get<std::int64_t>();
+    if (raw > 0) {
+      frame.sequence = static_cast<std::uint64_t>(raw);
+    }
+  }
+  frame.interval_ms = value.value("interval_ms", 2000);
+  frame.ttl_ms = value.value("ttl_ms", 10000);
+  for (const auto& status : value.value("instance_runtime", json::array())) {
+    if (status.is_object()) {
+      frame.instance_runtime.push_back(RuntimeProcessStatusFromJson(status));
+    }
+  }
+  if (value.contains("gpu") && value.at("gpu").is_object()) {
+    frame.gpu = GpuTelemetrySnapshotFromJson(value.at("gpu"));
+  }
+  if (value.contains("network") && value.at("network").is_object()) {
+    frame.network = NetworkTelemetrySnapshotFromJson(value.at("network"));
+  }
+  if (value.contains("cpu") && value.at("cpu").is_object()) {
+    frame.cpu = CpuTelemetrySnapshotFromJson(value.at("cpu"));
+  }
+  return frame;
+}
+
 json ToJson(const RuntimeStatus& status) {
   return json{
       {"plane_name", status.plane_name},
@@ -587,6 +640,14 @@ std::string SerializeCpuTelemetryJson(const CpuTelemetrySnapshot& snapshot) {
 
 CpuTelemetrySnapshot DeserializeCpuTelemetryJson(const std::string& json_text) {
   return CpuTelemetryJsonCodec().Deserialize(json_text);
+}
+
+std::string SerializeHostTelemetryFrameJson(const HostTelemetryFrame& frame) {
+  return ToJson(frame).dump(2);
+}
+
+HostTelemetryFrame DeserializeHostTelemetryFrameJson(const std::string& json_text) {
+  return HostTelemetryFrameFromJson(json::parse(json_text));
 }
 
 std::optional<RuntimeStatus> RuntimeStatusFileStore::Load(const std::string& path) const {

--- a/controller/include/host/hostd_http_service.h
+++ b/controller/include/host/hostd_http_service.h
@@ -70,6 +70,9 @@ class HostdHttpService {
   HttpResponse HandleObservations(
       const std::string& db_path,
       const HttpRequest& request) const;
+  HttpResponse HandleTelemetry(
+      const std::string& db_path,
+      const HttpRequest& request) const;
   HttpResponse HandleEvents(
       const std::string& db_path,
       const HttpRequest& request) const;

--- a/controller/include/http/controller_http_server.h
+++ b/controller/include/http/controller_http_server.h
@@ -64,6 +64,10 @@ class ControllerHttpServer {
       const HttpRequest& request,
       BuildEventPayloadItemFn build_event_payload_item,
       std::shared_ptr<SharedState> state);
+  static void StreamTelemetrySse(
+      SocketHandle client_fd,
+      const HttpRequest& request,
+      std::shared_ptr<SharedState> state);
 
   Deps deps_;
 };

--- a/controller/include/telemetry/telemetry_live_store.h
+++ b/controller/include/telemetry/telemetry_live_store.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <deque>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "naim/runtime/runtime_status.h"
+
+namespace naim::controller {
+
+class TelemetryLiveStore final {
+ public:
+  static TelemetryLiveStore& Instance();
+
+  bool Upsert(naim::HostTelemetryFrame frame);
+  nlohmann::json BuildSnapshot(
+      const std::optional<std::string>& plane_name,
+      int history_seconds) const;
+  std::vector<naim::HostTelemetryFrame> LoadFramesAfter(
+      std::uint64_t sequence,
+      const std::optional<std::string>& plane_name) const;
+  std::uint64_t LatestSequence() const;
+
+ private:
+  struct NodeBuffer {
+    naim::HostTelemetryFrame latest;
+    std::deque<naim::HostTelemetryFrame> history;
+  };
+
+  static bool MatchesPlane(
+      const naim::HostTelemetryFrame& frame,
+      const std::optional<std::string>& plane_name);
+  static nlohmann::json FrameToJson(const naim::HostTelemetryFrame& frame);
+
+  mutable std::mutex mutex_;
+  std::vector<NodeBuffer> nodes_;
+  std::uint64_t latest_sequence_ = 0;
+};
+
+}  // namespace naim::controller

--- a/controller/src/app/controller_route_summary_builder.cpp
+++ b/controller/src/app/controller_route_summary_builder.cpp
@@ -93,6 +93,8 @@ std::string ControllerRouteSummaryBuilder::BuildControllerRoutesSummary(
       "/api/v1/rebalance-plan",
       "/api/v1/events",
       "/api/v1/events/stream",
+      "/api/v1/telemetry/snapshot",
+      "/api/v1/telemetry/stream",
   });
   AppendRoutes(routes, {
       "/api/v1/scheduler-tick",
@@ -107,6 +109,7 @@ std::string ControllerRouteSummaryBuilder::BuildControllerRoutesSummary(
   });
   AppendRoutes(routes, {
       "/api/v1/hostd/hosts",
+      "/api/v1/hostd/telemetry",
       "/api/v1/hostd/peer-links",
       "/api/v1/hostd/file-transfer-tickets",
       "/api/v1/hostd/file-transfer-tickets/validate",

--- a/controller/src/host/hostd_http_service.cpp
+++ b/controller/src/host/hostd_http_service.cpp
@@ -1,5 +1,7 @@
 #include "host/hostd_http_service.h"
 
+#include "telemetry/telemetry_live_store.h"
+
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
@@ -563,6 +565,9 @@ std::optional<HttpResponse> HostdHttpService::HandleRequest(
   }
   if (request.path == "/api/v1/hostd/observations") {
     return HandleObservations(db_path, request);
+  }
+  if (request.path == "/api/v1/hostd/telemetry") {
+    return HandleTelemetry(db_path, request);
   }
   if (request.path == "/api/v1/hostd/events") {
     return HandleEvents(db_path, request);
@@ -2244,6 +2249,55 @@ HttpResponse HostdHttpService::HandleObservations(
         json{{"service", "naim-controller"},
              {"node_name", observation.node_name},
              {"updated", true}});
+  } catch (const std::exception& error) {
+    return support_.build_json_response(
+        500,
+        json{{"status", "internal_error"},
+             {"message", error.what()},
+             {"path", request.path}},
+        {});
+  }
+}
+
+HttpResponse HostdHttpService::HandleTelemetry(
+    const std::string& db_path,
+    const HttpRequest& request) const {
+  if (request.method != "POST") {
+    return support_.build_json_response(405, json{{"status", "method_not_allowed"}}, {});
+  }
+  try {
+    HostdRequestContext context(support_, db_path);
+    const auto authenticated = context.Authenticate(request);
+    if (!authenticated.has_value()) {
+      return context.Json(
+          403,
+          json{{"status", "forbidden"},
+               {"message", "invalid or missing host session"}});
+    }
+    auto host = *authenticated;
+    const json body =
+        context.ParseEncryptedBody(request, &host, "telemetry/upsert");
+    const auto frame = naim::DeserializeHostTelemetryFrameJson(body.dump());
+    if (frame.node_name.empty()) {
+      return context.Json(
+          400,
+          json{{"status", "bad_request"},
+               {"message", "missing required field 'node_name'"}});
+    }
+    if (host.node_name != frame.node_name) {
+      return context.Json(
+          403,
+          json{{"status", "forbidden"},
+               {"message", "node mismatch for host telemetry"}});
+    }
+    const bool updated = naim::controller::TelemetryLiveStore::Instance().Upsert(frame);
+    return context.EncryptedResponse(
+        &host,
+        "telemetry/upsert",
+        json{{"service", "naim-controller"},
+             {"node_name", frame.node_name},
+             {"updated", updated},
+             {"sequence", frame.sequence}});
   } catch (const std::exception& error) {
     return support_.build_json_response(
         500,

--- a/controller/src/http/controller_http_router.cpp
+++ b/controller/src/http/controller_http_router.cpp
@@ -794,6 +794,12 @@ HttpResponse ControllerHttpRouter::HandleRequest(
         json{{"status", "method_not_allowed"}},
         {});
   }
+  if (request.path == "/api/v1/telemetry/stream") {
+    return deps_.build_json_response(
+        405,
+        json{{"status", "method_not_allowed"}},
+        {});
+  }
   if (request.path == "/api/v1/retry-host-assignment") {
     if (request.method != "POST") {
       return deps_.build_json_response(

--- a/controller/src/http/controller_http_server.cpp
+++ b/controller/src/http/controller_http_server.cpp
@@ -4,12 +4,14 @@
 #include <array>
 #include <chrono>
 #include <csignal>
+#include <cstdint>
 #include <iostream>
 #include <stdexcept>
 #include <thread>
 
 #include "http/controller_http_server_support.h"
 #include "infra/controller_network_manager.h"
+#include "telemetry/telemetry_live_store.h"
 
 using nlohmann::json;
 
@@ -31,6 +33,11 @@ struct SseStreamRequest {
   std::optional<std::string> category;
   int limit = 100;
   std::optional<int> last_event_id;
+};
+
+struct TelemetryStreamRequest {
+  std::optional<std::string> plane_name;
+  std::uint64_t last_sequence = 0;
 };
 
 std::optional<std::string> FindQueryString(
@@ -67,6 +74,15 @@ SseStreamRequest ParseSseStreamRequest(const HttpRequest& request) {
     if (header_value.has_value()) {
       stream_request.last_event_id = std::stoi(*header_value);
     }
+  }
+  return stream_request;
+}
+
+TelemetryStreamRequest ParseTelemetryStreamRequest(const HttpRequest& request) {
+  TelemetryStreamRequest stream_request;
+  stream_request.plane_name = FindQueryString(request, "plane");
+  if (const auto since = FindQueryString(request, "since_sequence"); since.has_value()) {
+    stream_request.last_sequence = static_cast<std::uint64_t>(std::stoull(*since));
   }
   return stream_request;
 }
@@ -178,6 +194,91 @@ void ControllerHttpServer::StreamEventsSse(
   ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
 }
 
+void ControllerHttpServer::StreamTelemetrySse(
+    const SocketHandle client_fd,
+    const HttpRequest& request,
+    std::shared_ptr<SharedState> state) {
+  const TelemetryStreamRequest stream_request = ParseTelemetryStreamRequest(request);
+  std::uint64_t last_sequence = stream_request.last_sequence;
+  if (!ControllerNetworkManager::SendSseHeaders(client_fd)) {
+    ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+    return;
+  }
+  if (!ControllerNetworkManager::SendSseCommentFrame(client_fd, " telemetry connected")) {
+    ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+    return;
+  }
+
+  const auto snapshot = TelemetryLiveStore::Instance().BuildSnapshot(
+      stream_request.plane_name,
+      0);
+  if (!ControllerNetworkManager::SendSseEventFrame(
+          client_fd,
+          static_cast<int>(TelemetryLiveStore::Instance().LatestSequence() % 2147483647ULL),
+          "telemetry.snapshot",
+          snapshot.dump())) {
+    ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+    return;
+  }
+  last_sequence = std::max(last_sequence, TelemetryLiveStore::Instance().LatestSequence());
+
+  auto last_keepalive = std::chrono::steady_clock::now();
+  while (!state->stop_requested.load()) {
+    const auto frames =
+        TelemetryLiveStore::Instance().LoadFramesAfter(last_sequence, stream_request.plane_name);
+    for (const auto& frame : frames) {
+      const std::string payload = naim::SerializeHostTelemetryFrameJson(frame);
+      if (!ControllerNetworkManager::SendSseEventFrame(
+              client_fd,
+              static_cast<int>(frame.sequence % 2147483647ULL),
+              "telemetry.node",
+              payload)) {
+        ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+        return;
+      }
+      last_sequence = std::max(last_sequence, frame.sequence);
+      last_keepalive = std::chrono::steady_clock::now();
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if (now - last_keepalive >= std::chrono::seconds(5)) {
+      if (!ControllerNetworkManager::SendSseCommentFrame(
+              client_fd,
+              " telemetry keepalive")) {
+        ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+        return;
+      }
+      last_keepalive = now;
+    }
+
+    naim::platform::PollFd fd_state{};
+    fd_state.fd = client_fd;
+    fd_state.events = POLLIN | POLLERR | POLLHUP;
+    const int poll_result = naim::platform::Poll(&fd_state, 1, 250);
+    if (poll_result < 0) {
+      if (naim::platform::LastSocketErrorWasInterrupted()) {
+        continue;
+      }
+      break;
+    }
+    if (poll_result == 0) {
+      continue;
+    }
+    if ((fd_state.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+      break;
+    }
+    if ((fd_state.revents & POLLIN) != 0) {
+      char scratch[1];
+      const ssize_t read_count = recv(client_fd, scratch, sizeof(scratch), MSG_PEEK);
+      if (read_count <= 0) {
+        break;
+      }
+    }
+  }
+
+  ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+}
+
 int ControllerHttpServer::Serve(const Config& config) {
   auto state = std::make_shared<SharedState>();
   state->stop_requested.store(false);
@@ -258,6 +359,14 @@ int ControllerHttpServer::Serve(const Config& config) {
 
     const HttpRequest request =
         ControllerHttpServerSupport::ParseHttpRequest(request_data);
+    if (request.method == "GET" && request.path == "/api/v1/telemetry/stream") {
+      std::thread(
+          [client_fd, request, state]() {
+            StreamTelemetrySse(client_fd, request, std::move(state));
+          })
+          .detach();
+      continue;
+    }
     if (request.method == "GET" && request.path == "/api/v1/events/stream") {
       std::thread(
           [client_fd,

--- a/controller/src/read_model/read_model_http_service.cpp
+++ b/controller/src/read_model/read_model_http_service.cpp
@@ -3,6 +3,8 @@
 #include <stdexcept>
 #include <utility>
 
+#include "telemetry/telemetry_live_store.h"
+
 using nlohmann::json;
 
 ReadModelHttpService::ReadModelHttpService(ReadModelHttpSupport support)
@@ -53,6 +55,28 @@ std::optional<HttpResponse> ReadModelHttpService::HandleRequest(
               support_.find_query_string(request, "plane"),
               support_.find_query_int(request, "stale_after")
                   .value_or(support_.default_stale_after_seconds())),
+          {});
+    } catch (const std::exception& error) {
+      return support_.build_json_response(
+          500,
+          json{{"status", "internal_error"},
+               {"message", error.what()},
+               {"path", request.path}},
+          {});
+    }
+  }
+
+  if (request.path == "/api/v1/telemetry/snapshot") {
+    if (request.method != "GET") {
+      return support_.build_json_response(
+          405, json{{"status", "method_not_allowed"}}, {});
+    }
+    try {
+      return support_.build_json_response(
+          200,
+          naim::controller::TelemetryLiveStore::Instance().BuildSnapshot(
+              support_.find_query_string(request, "plane"),
+              support_.find_query_int(request, "history_seconds").value_or(0)),
           {});
     } catch (const std::exception& error) {
       return support_.build_json_response(

--- a/controller/src/telemetry/telemetry_live_store.cpp
+++ b/controller/src/telemetry/telemetry_live_store.cpp
@@ -1,6 +1,7 @@
 #include "telemetry/telemetry_live_store.h"
 
 #include <algorithm>
+#include <chrono>
 
 namespace naim::controller {
 
@@ -12,6 +13,9 @@ TelemetryLiveStore& TelemetryLiveStore::Instance() {
 bool TelemetryLiveStore::Upsert(naim::HostTelemetryFrame frame) {
   if (frame.node_name.empty()) {
     return false;
+  }
+  if (frame.channel.empty()) {
+    frame.channel = "host.telemetry.v1";
   }
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = std::find_if(
@@ -115,7 +119,17 @@ bool TelemetryLiveStore::MatchesPlane(
 
 nlohmann::json TelemetryLiveStore::FrameToJson(
     const naim::HostTelemetryFrame& frame) {
-  return nlohmann::json::parse(naim::SerializeHostTelemetryFrameJson(frame));
+  auto payload = nlohmann::json::parse(naim::SerializeHostTelemetryFrameJson(frame));
+  const auto now = std::chrono::system_clock::now().time_since_epoch();
+  const auto now_ms = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
+  const std::uint64_t ttl_ms =
+      frame.ttl_ms > 0 ? static_cast<std::uint64_t>(frame.ttl_ms) : 0;
+  const std::uint64_t expires_at_ms = frame.sequence + ttl_ms;
+  const bool stale = frame.sequence == 0 || ttl_ms == 0 || expires_at_ms <= now_ms;
+  payload["stale"] = stale;
+  payload["expires_in_ms"] = stale ? 0 : expires_at_ms - now_ms;
+  return payload;
 }
 
 }  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_live_store.cpp
+++ b/controller/src/telemetry/telemetry_live_store.cpp
@@ -1,0 +1,121 @@
+#include "telemetry/telemetry_live_store.h"
+
+#include <algorithm>
+
+namespace naim::controller {
+
+TelemetryLiveStore& TelemetryLiveStore::Instance() {
+  static TelemetryLiveStore store;
+  return store;
+}
+
+bool TelemetryLiveStore::Upsert(naim::HostTelemetryFrame frame) {
+  if (frame.node_name.empty()) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = std::find_if(
+      nodes_.begin(),
+      nodes_.end(),
+      [&](const NodeBuffer& candidate) {
+        return candidate.latest.node_name == frame.node_name;
+      });
+  if (it != nodes_.end() && frame.sequence <= it->latest.sequence) {
+    return false;
+  }
+  latest_sequence_ = std::max(latest_sequence_, frame.sequence);
+  if (it == nodes_.end()) {
+    NodeBuffer buffer;
+    buffer.latest = frame;
+    buffer.history.push_back(std::move(frame));
+    nodes_.push_back(std::move(buffer));
+  } else {
+    it->latest = frame;
+    it->history.push_back(std::move(frame));
+    while (it->history.size() > 300) {
+      it->history.pop_front();
+    }
+  }
+  return true;
+}
+
+nlohmann::json TelemetryLiveStore::BuildSnapshot(
+    const std::optional<std::string>& plane_name,
+    const int history_seconds) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  nlohmann::json nodes = nlohmann::json::array();
+  nlohmann::json history = nlohmann::json::array();
+  for (const auto& buffer : nodes_) {
+    if (!MatchesPlane(buffer.latest, plane_name)) {
+      continue;
+    }
+    nodes.push_back(FrameToJson(buffer.latest));
+    if (history_seconds <= 0) {
+      continue;
+    }
+    const std::size_t max_samples =
+        static_cast<std::size_t>(std::max(1, history_seconds / 2));
+    const std::size_t begin =
+        buffer.history.size() > max_samples ? buffer.history.size() - max_samples : 0;
+    for (std::size_t index = begin; index < buffer.history.size(); ++index) {
+      history.push_back(FrameToJson(buffer.history[index]));
+    }
+  }
+  return nlohmann::json{
+      {"service", "naim-controller"},
+      {"plane_name", plane_name.has_value() ? nlohmann::json(*plane_name) : nlohmann::json(nullptr)},
+      {"latest_sequence", latest_sequence_},
+      {"nodes", std::move(nodes)},
+      {"history", std::move(history)},
+  };
+}
+
+std::vector<naim::HostTelemetryFrame> TelemetryLiveStore::LoadFramesAfter(
+    const std::uint64_t sequence,
+    const std::optional<std::string>& plane_name) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<naim::HostTelemetryFrame> frames;
+  for (const auto& buffer : nodes_) {
+    for (const auto& frame : buffer.history) {
+      if (frame.sequence > sequence && MatchesPlane(frame, plane_name)) {
+        frames.push_back(frame);
+      }
+    }
+  }
+  std::sort(
+      frames.begin(),
+      frames.end(),
+      [](const auto& left, const auto& right) {
+        return left.sequence < right.sequence;
+      });
+  return frames;
+}
+
+std::uint64_t TelemetryLiveStore::LatestSequence() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return latest_sequence_;
+}
+
+bool TelemetryLiveStore::MatchesPlane(
+    const naim::HostTelemetryFrame& frame,
+    const std::optional<std::string>& plane_name) {
+  if (!plane_name.has_value() || plane_name->empty()) {
+    return true;
+  }
+  if (frame.plane_name == *plane_name) {
+    return true;
+  }
+  return std::any_of(
+      frame.instance_runtime.begin(),
+      frame.instance_runtime.end(),
+      [&](const naim::RuntimeProcessStatus& status) {
+        return status.instance_name.rfind(*plane_name + "-", 0) == 0;
+      });
+}
+
+nlohmann::json TelemetryLiveStore::FrameToJson(
+    const naim::HostTelemetryFrame& frame) {
+  return nlohmann::json::parse(naim::SerializeHostTelemetryFrameJson(frame));
+}
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -1,5 +1,6 @@
 #include "telemetry/telemetry_live_store.h"
 
+#include <chrono>
 #include <iostream>
 #include <stdexcept>
 
@@ -11,6 +12,12 @@ void Expect(bool condition, const std::string& message) {
   }
 }
 
+std::uint64_t CurrentMillis() {
+  const auto now = std::chrono::system_clock::now().time_since_epoch();
+  return static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
+}
+
 naim::HostTelemetryFrame MakeFrame(
     const std::string& node_name,
     const std::string& plane_name,
@@ -20,6 +27,10 @@ naim::HostTelemetryFrame MakeFrame(
   frame.plane_name = plane_name;
   frame.sequence = sequence;
   frame.sampled_at = "2026-05-04 12:00:00";
+  frame.collected_at = frame.sampled_at;
+  frame.expires_at = "2026-05-04 12:00:10";
+  frame.monotonic_ms = sequence;
+  frame.lane = "fast";
   frame.cpu.source = "procfs";
   frame.cpu.total_memory_bytes = 100;
   frame.cpu.used_memory_bytes = 50;
@@ -63,12 +74,72 @@ void TestPlaneFilter() {
   std::cout << "ok: telemetry-live-store-plane-filter\n";
 }
 
+void TestCoherenceFieldsAndStaleProjection() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  auto fresh = MakeFrame("node-coherent", "plane-coherent", CurrentMillis());
+  fresh.ttl_ms = 60000;
+  fresh.monotonic_ms = 1234;
+  fresh.lane = "full";
+  fresh.degraded_reason = "cpu:procfs-warmup";
+  fresh.disk.source = "hostd";
+  fresh.disk.items.push_back(naim::DiskTelemetryRecord{
+      "root",
+      "plane-coherent",
+      "node-coherent",
+      "/tmp",
+      "",
+      "",
+      "mounted",
+      "healthy",
+      "",
+      100,
+      25,
+      75,
+      1,
+      2,
+      3,
+      4,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      false,
+      true,
+      true,
+      true,
+      {},
+  });
+  Expect(store.Upsert(fresh), "fresh coherent frame should update");
+
+  const auto snapshot = store.BuildSnapshot(std::string("plane-coherent"), 0);
+  Expect(snapshot.at("nodes").size() == 1, "coherent snapshot should include one node");
+  const auto node = snapshot.at("nodes").at(0);
+  Expect(node.at("channel").get<std::string>() == "host.telemetry.v1", "channel should roundtrip");
+  Expect(node.at("lane").get<std::string>() == "full", "lane should roundtrip");
+  Expect(node.at("monotonic_ms").get<std::uint64_t>() == 1234, "monotonic_ms should roundtrip");
+  Expect(
+      node.at("degraded_reason").get<std::string>() == "cpu:procfs-warmup",
+      "degraded reason should roundtrip");
+  Expect(!node.at("stale").get<bool>(), "fresh frame should not be stale");
+  Expect(node.at("disk").at("items").size() == 1, "full frame should include disk telemetry");
+
+  auto stale = MakeFrame("node-stale", "plane-stale", 1);
+  stale.ttl_ms = 1;
+  Expect(store.Upsert(stale), "stale frame should update");
+  const auto stale_snapshot = store.BuildSnapshot(std::string("plane-stale"), 0);
+  Expect(stale_snapshot.at("nodes").at(0).at("stale").get<bool>(), "old frame should be stale");
+  std::cout << "ok: telemetry-live-store-coherence-stale\n";
+}
+
 }  // namespace
 
 int main() {
   try {
     TestUpsertAndSnapshot();
     TestPlaneFilter();
+    TestCoherenceFieldsAndStaleProjection();
     return 0;
   } catch (const std::exception& error) {
     std::cerr << "telemetry_live_store_tests failed: " << error.what() << "\n";

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -1,0 +1,77 @@
+#include "telemetry/telemetry_live_store.h"
+
+#include <iostream>
+#include <stdexcept>
+
+namespace {
+
+void Expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+naim::HostTelemetryFrame MakeFrame(
+    const std::string& node_name,
+    const std::string& plane_name,
+    std::uint64_t sequence) {
+  naim::HostTelemetryFrame frame;
+  frame.node_name = node_name;
+  frame.plane_name = plane_name;
+  frame.sequence = sequence;
+  frame.sampled_at = "2026-05-04 12:00:00";
+  frame.cpu.source = "procfs";
+  frame.cpu.total_memory_bytes = 100;
+  frame.cpu.used_memory_bytes = 50;
+  frame.gpu.source = "nvml";
+  frame.gpu.devices.push_back(naim::GpuDeviceTelemetry{
+      "0",
+      100,
+      25,
+      75,
+      10,
+      45,
+      true,
+      {},
+  });
+  return frame;
+}
+
+void TestUpsertAndSnapshot() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  Expect(store.Upsert(MakeFrame("node-a", "plane-a", 100)), "first frame should update");
+  Expect(!store.Upsert(MakeFrame("node-a", "plane-a", 99)), "older frame should be ignored");
+  Expect(store.Upsert(MakeFrame("node-a", "plane-a", 101)), "newer frame should update");
+
+  const auto snapshot = store.BuildSnapshot(std::nullopt, 10);
+  Expect(snapshot.at("latest_sequence").get<std::uint64_t>() >= 101, "latest sequence should advance");
+  Expect(!snapshot.at("nodes").empty(), "snapshot should include latest nodes");
+  std::cout << "ok: telemetry-live-store-upsert-snapshot\n";
+}
+
+void TestPlaneFilter() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  Expect(store.Upsert(MakeFrame("node-b", "plane-b", 200)), "plane-b frame should update");
+
+  const auto plane_a = store.BuildSnapshot(std::string("plane-a"), 0);
+  const auto plane_b = store.BuildSnapshot(std::string("plane-b"), 0);
+  Expect(plane_a.at("nodes").size() >= 1, "plane-a snapshot should include plane-a node");
+  Expect(plane_b.at("nodes").size() == 1, "plane-b snapshot should include only plane-b node");
+  Expect(
+      plane_b.at("nodes").at(0).at("node_name").get<std::string>() == "node-b",
+      "plane-b snapshot should expose node-b");
+  std::cout << "ok: telemetry-live-store-plane-filter\n";
+}
+
+}  // namespace
+
+int main() {
+  try {
+    TestUpsertAndSnapshot();
+    TestPlaneFilter();
+    return 0;
+  } catch (const std::exception& error) {
+    std::cerr << "telemetry_live_store_tests failed: " << error.what() << "\n";
+    return 1;
+  }
+}

--- a/hostd/include/app/hostd_app_controller_support.h
+++ b/hostd/include/app/hostd_app_controller_support.h
@@ -21,6 +21,8 @@ class HostdAppControllerSupport final : public IHttpHostdBackendSupport {
   naim::HostAssignment ParseAssignmentPayload(const nlohmann::json& payload) const override;
   nlohmann::json BuildHostObservationPayload(
       const naim::HostObservation& observation) const override;
+  nlohmann::json BuildHostTelemetryPayload(
+      const naim::HostTelemetryFrame& frame) const override;
   nlohmann::json BuildDiskRuntimeStatePayload(
       const naim::DiskRuntimeState& state) const override;
   naim::DiskRuntimeState ParseDiskRuntimeStatePayload(

--- a/hostd/include/app/hostd_app_observation_support.h
+++ b/hostd/include/app/hostd_app_observation_support.h
@@ -26,6 +26,11 @@ class HostdAppObservationSupport final : public IHostdObservationSupport {
       naim::HostObservationStatus status,
       const std::string& status_message,
       const std::optional<int>& assignment_id = std::nullopt) const override;
+  naim::HostTelemetryFrame BuildTelemetryFrame(
+      const std::string& node_name,
+      const std::string& state_root,
+      int interval_ms,
+      int ttl_ms) const override;
   void AppendHostdEvent(
       HostdBackend& backend,
       const std::string& category,

--- a/hostd/include/app/hostd_app_observation_support.h
+++ b/hostd/include/app/hostd_app_observation_support.h
@@ -28,9 +28,11 @@ class HostdAppObservationSupport final : public IHostdObservationSupport {
       const std::optional<int>& assignment_id = std::nullopt) const override;
   naim::HostTelemetryFrame BuildTelemetryFrame(
       const std::string& node_name,
+      const std::string& storage_root,
       const std::string& state_root,
       int interval_ms,
-      int ttl_ms) const override;
+      int ttl_ms,
+      bool include_slow_lane) const override;
   void AppendHostdEvent(
       HostdBackend& backend,
       const std::string& category,

--- a/hostd/include/app/hostd_controller_transport_support.h
+++ b/hostd/include/app/hostd_controller_transport_support.h
@@ -5,6 +5,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "naim/runtime/runtime_status.h"
 #include "naim/state/sqlite_store.h"
 
 namespace naim::hostd::controller_transport_support {
@@ -20,6 +21,7 @@ nlohmann::json SendControllerJsonRequest(
 
 naim::HostAssignment ParseAssignmentPayload(const nlohmann::json& payload);
 nlohmann::json BuildHostObservationPayload(const naim::HostObservation& observation);
+nlohmann::json BuildHostTelemetryPayload(const naim::HostTelemetryFrame& frame);
 nlohmann::json BuildDiskRuntimeStatePayload(const naim::DiskRuntimeState& state);
 naim::DiskRuntimeState ParseDiskRuntimeStatePayload(const nlohmann::json& payload);
 

--- a/hostd/include/app/hostd_observed_state_snapshot_builder.h
+++ b/hostd/include/app/hostd_observed_state_snapshot_builder.h
@@ -30,9 +30,11 @@ class HostdObservedStateSnapshotBuilder final {
       const std::optional<int>& assignment_id = std::nullopt) const;
   naim::HostTelemetryFrame BuildTelemetryFrame(
       const std::string& node_name,
+      const std::string& storage_root,
       const std::string& state_root,
       int interval_ms,
-      int ttl_ms) const;
+      int ttl_ms,
+      bool include_slow_lane) const;
 
  private:
   const HostdLocalStateRepository& local_state_repository_;

--- a/hostd/include/app/hostd_observed_state_snapshot_builder.h
+++ b/hostd/include/app/hostd_observed_state_snapshot_builder.h
@@ -28,6 +28,11 @@ class HostdObservedStateSnapshotBuilder final {
       naim::HostObservationStatus status,
       const std::string& status_message,
       const std::optional<int>& assignment_id = std::nullopt) const;
+  naim::HostTelemetryFrame BuildTelemetryFrame(
+      const std::string& node_name,
+      const std::string& state_root,
+      int interval_ms,
+      int ttl_ms) const;
 
  private:
   const HostdLocalStateRepository& local_state_repository_;

--- a/hostd/include/app/hostd_reporting_support.h
+++ b/hostd/include/app/hostd_reporting_support.h
@@ -69,9 +69,11 @@ class HostdReportingSupport final {
       const std::optional<int>& assignment_id = std::nullopt) const;
   naim::HostTelemetryFrame BuildTelemetryFrame(
       const std::string& node_name,
+      const std::string& storage_root,
       const std::string& state_root,
       int interval_ms,
-      int ttl_ms) const;
+      int ttl_ms,
+      bool include_slow_lane) const;
 
  private:
   static std::string SerializeEventPayload(const nlohmann::json& payload);

--- a/hostd/include/app/hostd_reporting_support.h
+++ b/hostd/include/app/hostd_reporting_support.h
@@ -67,6 +67,11 @@ class HostdReportingSupport final {
       naim::HostObservationStatus status,
       const std::string& status_message,
       const std::optional<int>& assignment_id = std::nullopt) const;
+  naim::HostTelemetryFrame BuildTelemetryFrame(
+      const std::string& node_name,
+      const std::string& state_root,
+      int interval_ms,
+      int ttl_ms) const;
 
  private:
   static std::string SerializeEventPayload(const nlohmann::json& payload);

--- a/hostd/include/app/hostd_system_telemetry_collector.h
+++ b/hostd/include/app/hostd_system_telemetry_collector.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -8,6 +10,11 @@
 #include "naim/state/models.h"
 
 namespace naim::hostd {
+
+struct HostdCpuCounterSample {
+  std::uint64_t idle = 0;
+  std::uint64_t total = 0;
+};
 
 class HostdSystemTelemetryCollector final {
  public:
@@ -30,6 +37,7 @@ class HostdSystemTelemetryCollector final {
 
  private:
   HostdCommandSupport command_support_;
+  mutable std::optional<HostdCpuCounterSample> last_cpu_sample_;
 };
 
 }  // namespace naim::hostd

--- a/hostd/include/backend/hostd_backend.h
+++ b/hostd/include/backend/hostd_backend.h
@@ -7,6 +7,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "naim/runtime/runtime_status.h"
 #include "naim/state/sqlite_store.h"
 
 namespace naim::hostd {
@@ -58,6 +59,7 @@ class HostdBackend {
       const std::string& target_node_name,
       const std::string& ticket_id) = 0;
   virtual void UpsertHostObservation(const naim::HostObservation& observation) = 0;
+  virtual void UpsertHostTelemetry(const naim::HostTelemetryFrame& frame) = 0;
   virtual void AppendEvent(const naim::EventRecord& event) = 0;
   virtual void UpsertDiskRuntimeState(const naim::DiskRuntimeState& state) = 0;
   virtual std::optional<naim::DiskRuntimeState> LoadDiskRuntimeState(

--- a/hostd/include/backend/http_hostd_backend.h
+++ b/hostd/include/backend/http_hostd_backend.h
@@ -62,6 +62,7 @@ class HttpHostdBackend final : public HostdBackend {
       const std::string& target_node_name,
       const std::string& ticket_id) override;
   void UpsertHostObservation(const naim::HostObservation& observation) override;
+  void UpsertHostTelemetry(const naim::HostTelemetryFrame& frame) override;
   void AppendEvent(const naim::EventRecord& event) override;
   void UpsertDiskRuntimeState(const naim::DiskRuntimeState& state) override;
   std::optional<naim::DiskRuntimeState> LoadDiskRuntimeState(

--- a/hostd/include/backend/http_hostd_backend_support.h
+++ b/hostd/include/backend/http_hostd_backend_support.h
@@ -5,6 +5,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "naim/runtime/runtime_status.h"
 #include "naim/state/sqlite_store.h"
 
 namespace naim::hostd {
@@ -23,6 +24,8 @@ class IHttpHostdBackendSupport {
   virtual naim::HostAssignment ParseAssignmentPayload(const nlohmann::json& payload) const = 0;
   virtual nlohmann::json BuildHostObservationPayload(
       const naim::HostObservation& observation) const = 0;
+  virtual nlohmann::json BuildHostTelemetryPayload(
+      const naim::HostTelemetryFrame& frame) const = 0;
   virtual nlohmann::json BuildDiskRuntimeStatePayload(
       const naim::DiskRuntimeState& state) const = 0;
   virtual naim::DiskRuntimeState ParseDiskRuntimeStatePayload(

--- a/hostd/include/backend/local_db_hostd_backend.h
+++ b/hostd/include/backend/local_db_hostd_backend.h
@@ -53,6 +53,7 @@ class LocalDbHostdBackend final : public HostdBackend {
       const std::string& target_node_name,
       const std::string& ticket_id) override;
   void UpsertHostObservation(const naim::HostObservation& observation) override;
+  void UpsertHostTelemetry(const naim::HostTelemetryFrame& frame) override;
   void AppendEvent(const naim::EventRecord& event) override;
   void UpsertDiskRuntimeState(const naim::DiskRuntimeState& state) override;
   std::optional<naim::DiskRuntimeState> LoadDiskRuntimeState(

--- a/hostd/include/cli/hostd_cli_command_dispatcher.h
+++ b/hostd/include/cli/hostd_cli_command_dispatcher.h
@@ -41,6 +41,10 @@ class HostdCliCommandDispatcher final {
       const HostdCommandLine& command_line,
       const NaimNodeConfig& node_config,
       const std::string& node_name) const;
+  bool DispatchReportTelemetry(
+      const HostdCommandLine& command_line,
+      const NaimNodeConfig& node_config,
+      const std::string& node_name) const;
   bool DispatchApplyStateOps(
       const HostdCommandLine& command_line,
       const NaimNodeConfig& node_config,

--- a/hostd/include/cli/hostd_command_line.h
+++ b/hostd/include/cli/hostd_command_line.h
@@ -30,6 +30,9 @@ class HostdCommandLine {
   std::optional<std::string> controller_fingerprint() const;
   std::optional<std::string> onboarding_key() const;
   std::optional<std::string> config_path() const;
+  std::optional<int> telemetry_interval_ms() const;
+  std::optional<int> telemetry_ttl_ms() const;
+  bool watch() const;
 
   std::string ResolveDbPath(const std::optional<std::string>& db_arg) const;
   std::string ResolveArtifactsRoot(
@@ -41,6 +44,7 @@ class HostdCommandLine {
 
  private:
   std::optional<std::string> FindOptionValue(const std::string& option_name) const;
+  bool HasFlag(const std::string& flag_name) const;
   static std::string DefaultDbPath();
   static std::string DefaultArtifactsRoot();
   static std::string DefaultStateRoot();

--- a/hostd/include/observation/hostd_observation_service.h
+++ b/hostd/include/observation/hostd_observation_service.h
@@ -23,9 +23,11 @@ class IHostdObservationSupport {
       const std::optional<int>& assignment_id = std::nullopt) const = 0;
   virtual naim::HostTelemetryFrame BuildTelemetryFrame(
       const std::string& node_name,
+      const std::string& storage_root,
       const std::string& state_root,
       int interval_ms,
-      int ttl_ms) const = 0;
+      int ttl_ms,
+      bool include_slow_lane) const = 0;
   virtual void AppendHostdEvent(
       HostdBackend& backend,
       const std::string& category,

--- a/hostd/include/observation/hostd_observation_service.h
+++ b/hostd/include/observation/hostd_observation_service.h
@@ -21,6 +21,11 @@ class IHostdObservationSupport {
       naim::HostObservationStatus status,
       const std::string& status_message,
       const std::optional<int>& assignment_id = std::nullopt) const = 0;
+  virtual naim::HostTelemetryFrame BuildTelemetryFrame(
+      const std::string& node_name,
+      const std::string& state_root,
+      int interval_ms,
+      int ttl_ms) const = 0;
   virtual void AppendHostdEvent(
       HostdBackend& backend,
       const std::string& category,
@@ -56,6 +61,17 @@ class HostdObservationService {
       const std::string& node_name,
       const std::string& storage_root,
       const std::string& state_root) const;
+  void ReportLocalTelemetry(
+      const std::optional<std::string>& db_path,
+      const std::optional<std::string>& controller_url,
+      const std::optional<std::string>& host_private_key_path,
+      const std::optional<std::string>& controller_fingerprint,
+      const std::optional<std::string>& onboarding_key,
+      const std::string& node_name,
+      const std::string& storage_root,
+      const std::string& state_root,
+      int interval_ms,
+      int ttl_ms) const;
 
  private:
   const IHostdBackendFactory& backend_factory_;

--- a/hostd/include/observation/hostd_observation_service.h
+++ b/hostd/include/observation/hostd_observation_service.h
@@ -72,6 +72,17 @@ class HostdObservationService {
       const std::string& state_root,
       int interval_ms,
       int ttl_ms) const;
+  void WatchLocalTelemetry(
+      const std::optional<std::string>& db_path,
+      const std::optional<std::string>& controller_url,
+      const std::optional<std::string>& host_private_key_path,
+      const std::optional<std::string>& controller_fingerprint,
+      const std::optional<std::string>& onboarding_key,
+      const std::string& node_name,
+      const std::string& storage_root,
+      const std::string& state_root,
+      int interval_ms,
+      int ttl_ms) const;
 
  private:
   const IHostdBackendFactory& backend_factory_;

--- a/hostd/src/app/hostd_app_controller_support.cpp
+++ b/hostd/src/app/hostd_app_controller_support.cpp
@@ -32,6 +32,11 @@ nlohmann::json HostdAppControllerSupport::BuildHostObservationPayload(
   return controller_transport_support::BuildHostObservationPayload(observation);
 }
 
+nlohmann::json HostdAppControllerSupport::BuildHostTelemetryPayload(
+    const naim::HostTelemetryFrame& frame) const {
+  return controller_transport_support::BuildHostTelemetryPayload(frame);
+}
+
 nlohmann::json HostdAppControllerSupport::BuildDiskRuntimeStatePayload(
     const naim::DiskRuntimeState& state) const {
   return controller_transport_support::BuildDiskRuntimeStatePayload(state);

--- a/hostd/src/app/hostd_app_observation_support.cpp
+++ b/hostd/src/app/hostd_app_observation_support.cpp
@@ -35,6 +35,18 @@ naim::HostObservation HostdAppObservationSupport::BuildObservedStateSnapshot(
       assignment_id);
 }
 
+naim::HostTelemetryFrame HostdAppObservationSupport::BuildTelemetryFrame(
+    const std::string& node_name,
+    const std::string& state_root,
+    const int interval_ms,
+    const int ttl_ms) const {
+  return reporting_support_.BuildTelemetryFrame(
+      node_name,
+      state_root,
+      interval_ms,
+      ttl_ms);
+}
+
 void HostdAppObservationSupport::AppendHostdEvent(
     HostdBackend& backend,
     const std::string& category,

--- a/hostd/src/app/hostd_app_observation_support.cpp
+++ b/hostd/src/app/hostd_app_observation_support.cpp
@@ -37,14 +37,18 @@ naim::HostObservation HostdAppObservationSupport::BuildObservedStateSnapshot(
 
 naim::HostTelemetryFrame HostdAppObservationSupport::BuildTelemetryFrame(
     const std::string& node_name,
+    const std::string& storage_root,
     const std::string& state_root,
     const int interval_ms,
-    const int ttl_ms) const {
+    const int ttl_ms,
+    const bool include_slow_lane) const {
   return reporting_support_.BuildTelemetryFrame(
       node_name,
+      storage_root,
       state_root,
       interval_ms,
-      ttl_ms);
+      ttl_ms,
+      include_slow_lane);
 }
 
 void HostdAppObservationSupport::AppendHostdEvent(

--- a/hostd/src/app/hostd_bootstrap_model_support_factory_tests.cpp
+++ b/hostd/src/app/hostd_bootstrap_model_support_factory_tests.cpp
@@ -276,6 +276,7 @@ class RelayHostdBackend final : public naim::hostd::HostdBackend {
   }
 
   void UpsertHostObservation(const naim::HostObservation&) override {}
+  void UpsertHostTelemetry(const naim::HostTelemetryFrame&) override {}
   void AppendEvent(const naim::EventRecord&) override {}
   void UpsertDiskRuntimeState(const naim::DiskRuntimeState&) override {}
   std::optional<naim::DiskRuntimeState> LoadDiskRuntimeState(

--- a/hostd/src/app/hostd_bootstrap_transfer_support_tests.cpp
+++ b/hostd/src/app/hostd_bootstrap_transfer_support_tests.cpp
@@ -98,6 +98,7 @@ class RecordingHostdBackend final : public naim::hostd::HostdBackend {
   }
 
   void UpsertHostObservation(const naim::HostObservation&) override {}
+  void UpsertHostTelemetry(const naim::HostTelemetryFrame&) override {}
   void AppendEvent(const naim::EventRecord&) override {}
   void UpsertDiskRuntimeState(const naim::DiskRuntimeState&) override {}
   std::optional<naim::DiskRuntimeState> LoadDiskRuntimeState(

--- a/hostd/src/app/hostd_controller_transport_support.cpp
+++ b/hostd/src/app/hostd_controller_transport_support.cpp
@@ -287,6 +287,10 @@ nlohmann::json BuildHostObservationPayload(const naim::HostObservation& observat
   };
 }
 
+nlohmann::json BuildHostTelemetryPayload(const naim::HostTelemetryFrame& frame) {
+  return json::parse(naim::SerializeHostTelemetryFrameJson(frame));
+}
+
 nlohmann::json BuildDiskRuntimeStatePayload(const naim::DiskRuntimeState& state) {
   return json{
       {"disk_name", state.disk_name},

--- a/hostd/src/app/hostd_observed_state_snapshot_builder.cpp
+++ b/hostd/src/app/hostd_observed_state_snapshot_builder.cpp
@@ -1,8 +1,11 @@
 #include "app/hostd_observed_state_snapshot_builder.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <ctime>
+#include <string>
+#include <vector>
 
 #include "naim/state/state_json.h"
 
@@ -10,8 +13,8 @@ namespace naim::hostd {
 
 namespace {
 
-std::string CurrentTimestampString() {
-  const std::time_t now = std::time(nullptr);
+std::string TimestampString(std::chrono::system_clock::time_point time_point) {
+  const std::time_t now = std::chrono::system_clock::to_time_t(time_point);
   std::tm tm{};
 #if defined(_WIN32)
   localtime_s(&tm, &now);
@@ -29,6 +32,27 @@ std::uint64_t CurrentSequenceMillis() {
   const auto now = std::chrono::system_clock::now().time_since_epoch();
   return static_cast<std::uint64_t>(
       std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
+}
+
+std::uint64_t CurrentMonotonicMillis() {
+  static const auto started_at = std::chrono::steady_clock::now();
+  const auto elapsed = std::chrono::steady_clock::now() - started_at;
+  return static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
+}
+
+std::string JoinReasons(const std::vector<std::string>& reasons) {
+  std::string joined;
+  for (const auto& reason : reasons) {
+    if (reason.empty()) {
+      continue;
+    }
+    if (!joined.empty()) {
+      joined += ", ";
+    }
+    joined += reason;
+  }
+  return joined;
 }
 
 }  // namespace
@@ -113,15 +137,23 @@ naim::HostObservation HostdObservedStateSnapshotBuilder::BuildObservedStateSnaps
 
 naim::HostTelemetryFrame HostdObservedStateSnapshotBuilder::BuildTelemetryFrame(
     const std::string& node_name,
+    const std::string& storage_root,
     const std::string& state_root,
     const int interval_ms,
-    const int ttl_ms) const {
+    const int ttl_ms,
+    const bool include_slow_lane) const {
   naim::HostTelemetryFrame frame;
   frame.node_name = node_name;
-  frame.sampled_at = CurrentTimestampString();
+  const auto sampled_at = std::chrono::system_clock::now();
+  frame.sampled_at = TimestampString(sampled_at);
+  frame.collected_at = frame.sampled_at;
+  frame.expires_at =
+      TimestampString(sampled_at + std::chrono::milliseconds(std::max(1, ttl_ms)));
   frame.sequence = CurrentSequenceMillis();
+  frame.monotonic_ms = CurrentMonotonicMillis();
   frame.interval_ms = interval_ms;
   frame.ttl_ms = ttl_ms;
+  frame.lane = include_slow_lane ? "full" : "fast";
 
   const auto local_state = local_state_repository_.LoadLocalAppliedState(state_root, node_name);
   if (local_state.has_value()) {
@@ -138,6 +170,44 @@ naim::HostTelemetryFrame HostdObservedStateSnapshotBuilder::BuildTelemetryFrame(
       frame.instance_runtime);
   frame.network = system_telemetry_collector_.CollectNetworkTelemetry(state_root);
   frame.cpu = system_telemetry_collector_.CollectCpuTelemetry();
+  if (include_slow_lane) {
+    frame.disk.contract_version = 1;
+    frame.disk.source = "hostd";
+    frame.disk.collected_at = frame.sampled_at;
+    frame.disk.items.push_back(
+        system_telemetry_collector_.BuildStorageRootTelemetry(node_name, storage_root));
+    if (local_state.has_value()) {
+      const auto managed_snapshot =
+          system_telemetry_collector_.CollectDiskTelemetry(*local_state, node_name);
+      frame.disk.degraded = managed_snapshot.degraded;
+      if (!managed_snapshot.source.empty()) {
+        frame.disk.source = managed_snapshot.source;
+      }
+      if (!managed_snapshot.collected_at.empty()) {
+        frame.disk.collected_at = managed_snapshot.collected_at;
+      }
+      frame.disk.items.insert(
+          frame.disk.items.end(),
+          managed_snapshot.items.begin(),
+          managed_snapshot.items.end());
+    }
+  }
+  std::vector<std::string> degraded_reasons;
+  if (frame.cpu.degraded) {
+    degraded_reasons.push_back(frame.cpu.source.empty() ? "cpu" : "cpu:" + frame.cpu.source);
+  }
+  if (frame.gpu.degraded) {
+    degraded_reasons.push_back(frame.gpu.source.empty() ? "gpu" : "gpu:" + frame.gpu.source);
+  }
+  if (frame.network.degraded) {
+    degraded_reasons.push_back(
+        frame.network.source.empty() ? "network" : "network:" + frame.network.source);
+  }
+  if (frame.disk.degraded) {
+    degraded_reasons.push_back(
+        frame.disk.source.empty() ? "disk" : "disk:" + frame.disk.source);
+  }
+  frame.degraded_reason = JoinReasons(degraded_reasons);
   return frame;
 }
 

--- a/hostd/src/app/hostd_observed_state_snapshot_builder.cpp
+++ b/hostd/src/app/hostd_observed_state_snapshot_builder.cpp
@@ -1,8 +1,37 @@
 #include "app/hostd_observed_state_snapshot_builder.h"
 
+#include <chrono>
+#include <cstdint>
+#include <ctime>
+
 #include "naim/state/state_json.h"
 
 namespace naim::hostd {
+
+namespace {
+
+std::string CurrentTimestampString() {
+  const std::time_t now = std::time(nullptr);
+  std::tm tm{};
+#if defined(_WIN32)
+  localtime_s(&tm, &now);
+#else
+  localtime_r(&now, &tm);
+#endif
+  char buffer[32];
+  if (std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &tm) == 0) {
+    return {};
+  }
+  return buffer;
+}
+
+std::uint64_t CurrentSequenceMillis() {
+  const auto now = std::chrono::system_clock::now().time_since_epoch();
+  return static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
+}
+
+}  // namespace
 
 HostdObservedStateSnapshotBuilder::HostdObservedStateSnapshotBuilder(
     const HostdLocalStateRepository& local_state_repository,
@@ -80,6 +109,36 @@ naim::HostObservation HostdObservedStateSnapshotBuilder::BuildObservedStateSnaps
       system_telemetry_collector_.CollectCpuTelemetry());
 
   return observation;
+}
+
+naim::HostTelemetryFrame HostdObservedStateSnapshotBuilder::BuildTelemetryFrame(
+    const std::string& node_name,
+    const std::string& state_root,
+    const int interval_ms,
+    const int ttl_ms) const {
+  naim::HostTelemetryFrame frame;
+  frame.node_name = node_name;
+  frame.sampled_at = CurrentTimestampString();
+  frame.sequence = CurrentSequenceMillis();
+  frame.interval_ms = interval_ms;
+  frame.ttl_ms = ttl_ms;
+
+  const auto local_state = local_state_repository_.LoadLocalAppliedState(state_root, node_name);
+  if (local_state.has_value()) {
+    frame.plane_name = local_state->plane_name;
+  }
+  const naim::DesiredState telemetry_state =
+      local_state.has_value() ? *local_state : naim::DesiredState{};
+  frame.instance_runtime =
+      runtime_telemetry_support_.LoadLocalInstanceRuntimeStatuses(state_root, node_name);
+  runtime_telemetry_support_.ResolveInstanceHostPids(&frame.instance_runtime);
+  frame.gpu = system_telemetry_collector_.CollectGpuTelemetry(
+      telemetry_state,
+      node_name,
+      frame.instance_runtime);
+  frame.network = system_telemetry_collector_.CollectNetworkTelemetry(state_root);
+  frame.cpu = system_telemetry_collector_.CollectCpuTelemetry();
+  return frame;
 }
 
 }  // namespace naim::hostd

--- a/hostd/src/app/hostd_reporting_support.cpp
+++ b/hostd/src/app/hostd_reporting_support.cpp
@@ -133,14 +133,18 @@ naim::HostObservation HostdReportingSupport::BuildObservedStateSnapshot(
 
 naim::HostTelemetryFrame HostdReportingSupport::BuildTelemetryFrame(
     const std::string& node_name,
+    const std::string& storage_root,
     const std::string& state_root,
     const int interval_ms,
-    const int ttl_ms) const {
+    const int ttl_ms,
+    const bool include_slow_lane) const {
   return observed_state_snapshot_builder_.BuildTelemetryFrame(
       node_name,
+      storage_root,
       state_root,
       interval_ms,
-      ttl_ms);
+      ttl_ms,
+      include_slow_lane);
 }
 
 std::string HostdReportingSupport::SerializeEventPayload(

--- a/hostd/src/app/hostd_reporting_support.cpp
+++ b/hostd/src/app/hostd_reporting_support.cpp
@@ -131,6 +131,18 @@ naim::HostObservation HostdReportingSupport::BuildObservedStateSnapshot(
       assignment_id);
 }
 
+naim::HostTelemetryFrame HostdReportingSupport::BuildTelemetryFrame(
+    const std::string& node_name,
+    const std::string& state_root,
+    const int interval_ms,
+    const int ttl_ms) const {
+  return observed_state_snapshot_builder_.BuildTelemetryFrame(
+      node_name,
+      state_root,
+      interval_ms,
+      ttl_ms);
+}
+
 std::string HostdReportingSupport::SerializeEventPayload(
     const nlohmann::json& payload) {
   return payload.dump();

--- a/hostd/src/app/hostd_reporting_support_tests.cpp
+++ b/hostd/src/app/hostd_reporting_support_tests.cpp
@@ -100,6 +100,7 @@ class RecordingHostdBackend : public naim::hostd::HostdBackend {
   }
 
   void UpsertHostObservation(const naim::HostObservation&) override {}
+  void UpsertHostTelemetry(const naim::HostTelemetryFrame&) override {}
 
   void AppendEvent(const naim::EventRecord& event) override {
     events.push_back(event);

--- a/hostd/src/app/hostd_system_telemetry_collector.cpp
+++ b/hostd/src/app/hostd_system_telemetry_collector.cpp
@@ -338,19 +338,14 @@ std::vector<double> CollectCpuTemperatureSamples() {
   return samples;
 }
 
-struct CpuSample {
-  std::uint64_t idle = 0;
-  std::uint64_t total = 0;
-};
-
-std::optional<CpuSample> ReadCpuSample() {
+std::optional<HostdCpuCounterSample> ReadCpuSample() {
   std::ifstream input("/proc/stat");
   if (!input.is_open()) {
     return std::nullopt;
   }
 
   std::string cpu_label;
-  CpuSample sample;
+  HostdCpuCounterSample sample;
   std::uint64_t user = 0;
   std::uint64_t nice = 0;
   std::uint64_t system = 0;
@@ -964,13 +959,17 @@ naim::CpuTelemetrySnapshot HostdSystemTelemetryCollector::CollectCpuTelemetry() 
   snapshot.core_count = static_cast<int>(std::thread::hardware_concurrency());
 
   const auto first = ReadCpuSample();
-  std::this_thread::sleep_for(std::chrono::milliseconds(150));
-  const auto second = ReadCpuSample();
-  if (first.has_value() && second.has_value() && second->total > first->total) {
-    const auto total_delta = static_cast<double>(second->total - first->total);
-    const auto idle_delta = static_cast<double>(second->idle - first->idle);
+  if (first.has_value() && last_cpu_sample_.has_value() &&
+      first->total > last_cpu_sample_->total) {
+    const auto total_delta = static_cast<double>(first->total - last_cpu_sample_->total);
+    const auto idle_delta = static_cast<double>(first->idle - last_cpu_sample_->idle);
     snapshot.utilization_pct =
         total_delta > 0.0 ? std::max(0.0, 100.0 * (1.0 - (idle_delta / total_delta))) : 0.0;
+    last_cpu_sample_ = first;
+  } else if (first.has_value()) {
+    last_cpu_sample_ = first;
+    snapshot.degraded = true;
+    snapshot.source = "procfs-warmup";
   } else {
     snapshot.degraded = true;
     snapshot.source = "procfs-unavailable";

--- a/hostd/src/backend/http_hostd_backend.cpp
+++ b/hostd/src/backend/http_hostd_backend.cpp
@@ -216,6 +216,14 @@ void HttpHostdBackend::UpsertHostObservation(const naim::HostObservation& observ
       "observations/upsert");
 }
 
+void HttpHostdBackend::UpsertHostTelemetry(const naim::HostTelemetryFrame& frame) {
+  EnsureSession(frame.node_name, "uploading telemetry");
+  SendEncryptedControllerJsonRequest(
+      "/api/v1/hostd/telemetry",
+      support_.BuildHostTelemetryPayload(frame),
+      "telemetry/upsert");
+}
+
 void HttpHostdBackend::AppendEvent(const naim::EventRecord& event) {
   if (!event.node_name.empty()) {
     EnsureSession(event.node_name, "appending event");

--- a/hostd/src/backend/local_db_hostd_backend.cpp
+++ b/hostd/src/backend/local_db_hostd_backend.cpp
@@ -87,6 +87,10 @@ void LocalDbHostdBackend::UpsertHostObservation(const naim::HostObservation& obs
   store_.UpsertHostObservation(observation);
 }
 
+void LocalDbHostdBackend::UpsertHostTelemetry(const naim::HostTelemetryFrame&) {
+  // Local DB mode has no long-lived controller process to receive live telemetry.
+}
+
 void LocalDbHostdBackend::AppendEvent(const naim::EventRecord& event) {
   store_.AppendEvent(event);
 }

--- a/hostd/src/cli/hostd_cli_command_dispatcher.cpp
+++ b/hostd/src/cli/hostd_cli_command_dispatcher.cpp
@@ -20,6 +20,7 @@ bool HostdCliCommandDispatcher::Dispatch(
          DispatchShowLocalState(command_line, node_name) ||
          DispatchShowRuntimeStatus(command_line, node_name) ||
          DispatchReportObservedState(command_line, node_config, node_name) ||
+         DispatchReportTelemetry(command_line, node_config, node_name) ||
          DispatchApplyStateOps(command_line, node_config, node_name) ||
          DispatchApplyNextAssignment(command_line, node_config, node_name);
 }
@@ -99,6 +100,29 @@ bool HostdCliCommandDispatcher::DispatchReportObservedState(
       request.common.node_name,
       request.common.storage_root,
       request.common.state_root);
+  return true;
+}
+
+bool HostdCliCommandDispatcher::DispatchReportTelemetry(
+    const HostdCommandLine& command_line,
+    const NaimNodeConfig& node_config,
+    const std::string& node_name) const {
+  if (command_line.command() != "report-telemetry") {
+    return false;
+  }
+  const auto request =
+      resolution_support_.ResolveAssignmentRequest(command_line, node_config, node_name);
+  observation_service_.ReportLocalTelemetry(
+      request.db_path,
+      request.controller_url,
+      request.host_private_key_path,
+      request.controller_fingerprint,
+      request.onboarding_key,
+      request.common.node_name,
+      request.common.storage_root,
+      request.common.state_root,
+      2000,
+      10000);
   return true;
 }
 

--- a/hostd/src/cli/hostd_cli_command_dispatcher.cpp
+++ b/hostd/src/cli/hostd_cli_command_dispatcher.cpp
@@ -112,6 +112,22 @@ bool HostdCliCommandDispatcher::DispatchReportTelemetry(
   }
   const auto request =
       resolution_support_.ResolveAssignmentRequest(command_line, node_config, node_name);
+  const int interval_ms = command_line.telemetry_interval_ms().value_or(2000);
+  const int ttl_ms = command_line.telemetry_ttl_ms().value_or(10000);
+  if (command_line.watch()) {
+    observation_service_.WatchLocalTelemetry(
+        request.db_path,
+        request.controller_url,
+        request.host_private_key_path,
+        request.controller_fingerprint,
+        request.onboarding_key,
+        request.common.node_name,
+        request.common.storage_root,
+        request.common.state_root,
+        interval_ms,
+        ttl_ms);
+    return true;
+  }
   observation_service_.ReportLocalTelemetry(
       request.db_path,
       request.controller_url,
@@ -121,8 +137,8 @@ bool HostdCliCommandDispatcher::DispatchReportTelemetry(
       request.common.node_name,
       request.common.storage_root,
       request.common.state_root,
-      2000,
-      10000);
+      interval_ms,
+      ttl_ms);
   return true;
 }
 

--- a/hostd/src/cli/hostd_command_line.cpp
+++ b/hostd/src/cli/hostd_command_line.cpp
@@ -16,7 +16,7 @@ void HostdCommandLine::PrintUsage(std::ostream& out) const {
       << "  naim-hostd show-local-state --node <node-name> [--state-root <path>]\n"
       << "  naim-hostd show-runtime-status --node <node-name> [--state-root <path>]\n"
       << "  naim-hostd report-observed-state --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--state-root <path>]\n"
-      << "  naim-hostd report-telemetry --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--state-root <path>]\n"
+      << "  naim-hostd report-telemetry --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--state-root <path>] [--watch] [--interval-ms <ms>] [--ttl-ms <ms>]\n"
       << "  naim-hostd apply-state-ops --node <node-name> [--db <path>] [--artifacts-root <path>] [--runtime-root <path>] [--state-root <path>] [--compose-mode skip|exec] [--config <path>]\n"
       << "  naim-hostd apply-next-assignment --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--runtime-root <path>] [--state-root <path>] [--compose-mode skip|exec] [--config <path>]\n";
 }
@@ -73,6 +73,20 @@ std::optional<std::string> HostdCommandLine::config_path() const {
   return FindOptionValue("--config");
 }
 
+std::optional<int> HostdCommandLine::telemetry_interval_ms() const {
+  const auto value = FindOptionValue("--interval-ms");
+  return value.has_value() ? std::optional<int>(std::stoi(*value)) : std::nullopt;
+}
+
+std::optional<int> HostdCommandLine::telemetry_ttl_ms() const {
+  const auto value = FindOptionValue("--ttl-ms");
+  return value.has_value() ? std::optional<int>(std::stoi(*value)) : std::nullopt;
+}
+
+bool HostdCommandLine::watch() const {
+  return HasFlag("--watch");
+}
+
 std::string HostdCommandLine::ResolveDbPath(
     const std::optional<std::string>& db_arg) const {
   return db_arg.value_or(DefaultDbPath());
@@ -108,6 +122,15 @@ std::optional<std::string> HostdCommandLine::FindOptionValue(
     }
   }
   return std::nullopt;
+}
+
+bool HostdCommandLine::HasFlag(const std::string& flag_name) const {
+  for (int index = 2; index < argc_; ++index) {
+    if (std::string(argv_[index]) == flag_name) {
+      return true;
+    }
+  }
+  return false;
 }
 
 std::string HostdCommandLine::DefaultDbPath() {

--- a/hostd/src/cli/hostd_command_line.cpp
+++ b/hostd/src/cli/hostd_command_line.cpp
@@ -16,6 +16,7 @@ void HostdCommandLine::PrintUsage(std::ostream& out) const {
       << "  naim-hostd show-local-state --node <node-name> [--state-root <path>]\n"
       << "  naim-hostd show-runtime-status --node <node-name> [--state-root <path>]\n"
       << "  naim-hostd report-observed-state --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--state-root <path>]\n"
+      << "  naim-hostd report-telemetry --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--state-root <path>]\n"
       << "  naim-hostd apply-state-ops --node <node-name> [--db <path>] [--artifacts-root <path>] [--runtime-root <path>] [--state-root <path>] [--compose-mode skip|exec] [--config <path>]\n"
       << "  naim-hostd apply-next-assignment --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--runtime-root <path>] [--state-root <path>] [--compose-mode skip|exec] [--config <path>]\n";
 }

--- a/hostd/src/observation/hostd_observation_service.cpp
+++ b/hostd/src/observation/hostd_observation_service.cpp
@@ -1,6 +1,9 @@
 #include "observation/hostd_observation_service.h"
 
+#include <chrono>
+#include <algorithm>
 #include <iostream>
+#include <thread>
 
 namespace naim::hostd {
 
@@ -126,6 +129,52 @@ void HostdObservationService::ReportLocalTelemetry(
     std::cout << "plane=" << frame.plane_name << "\n";
   }
   std::cout << "sequence=" << frame.sequence << "\n";
+}
+
+void HostdObservationService::WatchLocalTelemetry(
+    const std::optional<std::string>& db_path,
+    const std::optional<std::string>& controller_url,
+    const std::optional<std::string>& host_private_key_path,
+    const std::optional<std::string>& controller_fingerprint,
+    const std::optional<std::string>& onboarding_key,
+    const std::string& node_name,
+    const std::string& storage_root,
+    const std::string& state_root,
+    const int interval_ms,
+    const int ttl_ms) const {
+  auto backend = backend_factory_.CreateBackend(
+      db_path,
+      controller_url,
+      host_private_key_path,
+      controller_fingerprint,
+      onboarding_key,
+      node_name,
+      storage_root);
+  const auto interval = std::chrono::milliseconds(std::max(250, interval_ms));
+  std::cout << "hostd report-telemetry watch\n";
+  std::cout << "backend=hostd-control\n";
+  std::cout << "node=" << node_name << "\n";
+  std::cout << "interval_ms=" << interval.count() << "\n";
+  std::cout.flush();
+
+  auto next_tick = std::chrono::steady_clock::now();
+  while (true) {
+    next_tick += interval;
+    try {
+      const auto frame = support_.BuildTelemetryFrame(
+          node_name,
+          state_root,
+          static_cast<int>(interval.count()),
+          ttl_ms);
+      backend->UpsertHostTelemetry(frame);
+    } catch (const std::exception& error) {
+      std::cerr << "hostd report-telemetry warning: " << error.what() << "\n";
+    }
+    std::this_thread::sleep_until(next_tick);
+    if (std::chrono::steady_clock::now() > next_tick + interval) {
+      next_tick = std::chrono::steady_clock::now();
+    }
+  }
 }
 
 }  // namespace naim::hostd

--- a/hostd/src/observation/hostd_observation_service.cpp
+++ b/hostd/src/observation/hostd_observation_service.cpp
@@ -94,4 +94,38 @@ void HostdObservationService::ReportLocalObservedState(
       "hostd report-observed-state");
 }
 
+void HostdObservationService::ReportLocalTelemetry(
+    const std::optional<std::string>& db_path,
+    const std::optional<std::string>& controller_url,
+    const std::optional<std::string>& host_private_key_path,
+    const std::optional<std::string>& controller_fingerprint,
+    const std::optional<std::string>& onboarding_key,
+    const std::string& node_name,
+    const std::string& storage_root,
+    const std::string& state_root,
+    const int interval_ms,
+    const int ttl_ms) const {
+  auto backend = backend_factory_.CreateBackend(
+      db_path,
+      controller_url,
+      host_private_key_path,
+      controller_fingerprint,
+      onboarding_key,
+      node_name,
+      storage_root);
+  const auto frame = support_.BuildTelemetryFrame(
+      node_name,
+      state_root,
+      interval_ms,
+      ttl_ms);
+  backend->UpsertHostTelemetry(frame);
+  std::cout << "hostd report-telemetry\n";
+  std::cout << "backend=hostd-control\n";
+  std::cout << "node=" << frame.node_name << "\n";
+  if (!frame.plane_name.empty()) {
+    std::cout << "plane=" << frame.plane_name << "\n";
+  }
+  std::cout << "sequence=" << frame.sequence << "\n";
+}
+
 }  // namespace naim::hostd

--- a/hostd/src/observation/hostd_observation_service.cpp
+++ b/hostd/src/observation/hostd_observation_service.cpp
@@ -118,9 +118,11 @@ void HostdObservationService::ReportLocalTelemetry(
       storage_root);
   const auto frame = support_.BuildTelemetryFrame(
       node_name,
+      storage_root,
       state_root,
       interval_ms,
-      ttl_ms);
+      ttl_ms,
+      true);
   backend->UpsertHostTelemetry(frame);
   std::cout << "hostd report-telemetry\n";
   std::cout << "backend=hostd-control\n";
@@ -151,21 +153,33 @@ void HostdObservationService::WatchLocalTelemetry(
       node_name,
       storage_root);
   const auto interval = std::chrono::milliseconds(std::max(250, interval_ms));
+  const auto slow_interval = std::max(
+      interval * 5,
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::seconds(10)));
   std::cout << "hostd report-telemetry watch\n";
   std::cout << "backend=hostd-control\n";
   std::cout << "node=" << node_name << "\n";
   std::cout << "interval_ms=" << interval.count() << "\n";
+  std::cout << "slow_interval_ms=" << slow_interval.count() << "\n";
   std::cout.flush();
 
   auto next_tick = std::chrono::steady_clock::now();
+  auto next_slow_tick = next_tick;
   while (true) {
     next_tick += interval;
     try {
+      const auto now = std::chrono::steady_clock::now();
+      const bool include_slow_lane = now >= next_slow_tick;
+      if (include_slow_lane) {
+        next_slow_tick = now + slow_interval;
+      }
       const auto frame = support_.BuildTelemetryFrame(
           node_name,
+          storage_root,
           state_root,
           static_cast<int>(interval.count()),
-          ttl_ms);
+          ttl_ms,
+          include_slow_lane);
       backend->UpsertHostTelemetry(frame);
     } catch (const std::exception& error) {
       std::cerr << "hostd report-telemetry warning: " << error.what() << "\n";

--- a/launcher/src/run/hostd_peer_service.cpp
+++ b/launcher/src/run/hostd_peer_service.cpp
@@ -174,6 +174,11 @@ class LauncherHostdBackendSupport final : public naim::hostd::IHttpHostdBackendS
     return naim::hostd::controller_transport_support::BuildHostObservationPayload(observation);
   }
 
+  nlohmann::json BuildHostTelemetryPayload(
+      const naim::HostTelemetryFrame& frame) const override {
+    return naim::hostd::controller_transport_support::BuildHostTelemetryPayload(frame);
+  }
+
   nlohmann::json BuildDiskRuntimeStatePayload(
       const naim::DiskRuntimeState& state) const override {
     return naim::hostd::controller_transport_support::BuildDiskRuntimeStatePayload(state);

--- a/launcher/src/run/launcher_run_service.cpp
+++ b/launcher/src/run/launcher_run_service.cpp
@@ -425,8 +425,12 @@ int LauncherRunService::RunHostdLoop(
   }
   std::cout
       << "next_step=leave hostd running so it can receive assignments and upload telemetry\n";
+  constexpr int kTelemetryIntervalMs = 2000;
+  constexpr int kTelemetryTtlMs = 10000;
   auto next_inventory_report_at = std::chrono::steady_clock::now();
+#if defined(_WIN32)
   auto next_telemetry_report_at = std::chrono::steady_clock::now();
+#endif
   const auto self_update_marker =
       HostdSelfUpdateMarkerPath(options.state_root, options.node_name);
   std::error_code marker_error;
@@ -493,7 +497,7 @@ int LauncherRunService::RunHostdLoop(
     return args;
   };
 
-  const auto build_telemetry_args = [&]() {
+  const auto build_telemetry_args = [&](const bool watch) {
     std::vector<std::string> args = {
         hostd_binary.string(),
         "report-telemetry",
@@ -501,7 +505,14 @@ int LauncherRunService::RunHostdLoop(
         options.node_name,
         "--state-root",
         options.state_root.string(),
+        "--interval-ms",
+        std::to_string(kTelemetryIntervalMs),
+        "--ttl-ms",
+        std::to_string(kTelemetryTtlMs),
     };
+    if (watch) {
+      args.push_back("--watch");
+    }
     if (!options.controller_url.empty()) {
       args.insert(args.end(), {"--controller", options.controller_url});
       if (!options.controller_fingerprint.empty()) {
@@ -532,18 +543,19 @@ int LauncherRunService::RunHostdLoop(
         now + std::chrono::seconds(std::max(1, options.inventory_scan_interval_sec));
   };
 
+#if defined(_WIN32)
   const auto run_telemetry_if_due = [&]() {
-    constexpr int kTelemetryIntervalMs = 2000;
     const auto now = std::chrono::steady_clock::now();
     if (now < next_telemetry_report_at) {
       return;
     }
-    const int telemetry_code = process_runner_.RunCommand(build_telemetry_args());
+    const int telemetry_code = process_runner_.RunCommand(build_telemetry_args(false));
     if (telemetry_code != 0) {
       std::cerr << "naim-node: hostd report-telemetry exit=" << telemetry_code << "\n";
     }
     next_telemetry_report_at = now + std::chrono::milliseconds(kTelemetryIntervalMs);
   };
+#endif
 
   const auto wait_for_self_update_recreate = [&]() -> int {
     peer_service.Stop();
@@ -555,6 +567,7 @@ int LauncherRunService::RunHostdLoop(
 
 #if !defined(_WIN32)
   pid_t apply_pid = -1;
+  pid_t telemetry_pid = -1;
   const auto reap_apply_if_finished = [&]() -> bool {
     if (apply_pid <= 0) {
       return false;
@@ -574,6 +587,29 @@ int LauncherRunService::RunHostdLoop(
     }
     return false;
   };
+
+  const auto reap_telemetry_if_finished = [&]() {
+    if (telemetry_pid <= 0) {
+      return;
+    }
+    const std::optional<int> telemetry_code = PollChildExitCode(telemetry_pid);
+    if (!telemetry_code.has_value()) {
+      return;
+    }
+    if (*telemetry_code != 0) {
+      std::cerr << "naim-node: hostd report-telemetry watch exit=" << *telemetry_code
+                << "\n";
+    }
+    telemetry_pid = -1;
+  };
+
+  const auto start_telemetry_if_needed = [&]() {
+    reap_telemetry_if_finished();
+    if (telemetry_pid <= 0) {
+      telemetry_pid =
+          static_cast<pid_t>(process_runner_.SpawnCommand(build_telemetry_args(true)));
+    }
+  };
 #endif
 
   while (!signal_manager.stop_requested()) {
@@ -588,7 +624,12 @@ int LauncherRunService::RunHostdLoop(
       return wait_for_self_update_recreate();
     }
 #else
+    start_telemetry_if_needed();
     if (reap_apply_if_finished()) {
+      if (telemetry_pid > 0) {
+        StopChildProcess(telemetry_pid);
+        telemetry_pid = -1;
+      }
       return wait_for_self_update_recreate();
     }
     if (apply_pid <= 0) {
@@ -597,24 +638,36 @@ int LauncherRunService::RunHostdLoop(
 #endif
 
     run_report_if_due();
+#if defined(_WIN32)
     run_telemetry_if_due();
+#endif
 
     for (int second = 0;
          second < options.poll_interval_sec && !signal_manager.stop_requested();
          ++second) {
       std::this_thread::sleep_for(std::chrono::seconds(1));
 #if !defined(_WIN32)
+      start_telemetry_if_needed();
       if (reap_apply_if_finished()) {
+        if (telemetry_pid > 0) {
+          StopChildProcess(telemetry_pid);
+          telemetry_pid = -1;
+        }
         return wait_for_self_update_recreate();
       }
 #endif
       run_report_if_due();
+#if defined(_WIN32)
       run_telemetry_if_due();
+#endif
     }
   }
 #if !defined(_WIN32)
   if (apply_pid > 0) {
     StopChildProcess(apply_pid);
+  }
+  if (telemetry_pid > 0) {
+    StopChildProcess(telemetry_pid);
   }
 #endif
   peer_service.Stop();

--- a/launcher/src/run/launcher_run_service.cpp
+++ b/launcher/src/run/launcher_run_service.cpp
@@ -426,6 +426,7 @@ int LauncherRunService::RunHostdLoop(
   std::cout
       << "next_step=leave hostd running so it can receive assignments and upload telemetry\n";
   auto next_inventory_report_at = std::chrono::steady_clock::now();
+  auto next_telemetry_report_at = std::chrono::steady_clock::now();
   const auto self_update_marker =
       HostdSelfUpdateMarkerPath(options.state_root, options.node_name);
   std::error_code marker_error;
@@ -492,6 +493,32 @@ int LauncherRunService::RunHostdLoop(
     return args;
   };
 
+  const auto build_telemetry_args = [&]() {
+    std::vector<std::string> args = {
+        hostd_binary.string(),
+        "report-telemetry",
+        "--node",
+        options.node_name,
+        "--state-root",
+        options.state_root.string(),
+    };
+    if (!options.controller_url.empty()) {
+      args.insert(args.end(), {"--controller", options.controller_url});
+      if (!options.controller_fingerprint.empty()) {
+        args.insert(args.end(), {"--controller-fingerprint", options.controller_fingerprint});
+      }
+      if (!options.onboarding_key.empty()) {
+        args.insert(args.end(), {"--onboarding-key", options.onboarding_key});
+      }
+      if (!options.host_private_key_path.empty()) {
+        args.insert(args.end(), {"--host-private-key", options.host_private_key_path.string()});
+      }
+    } else {
+      args.insert(args.end(), {"--db", options.db_path.string()});
+    }
+    return args;
+  };
+
   const auto run_report_if_due = [&]() {
     const auto now = std::chrono::steady_clock::now();
     if (now < next_inventory_report_at) {
@@ -503,6 +530,19 @@ int LauncherRunService::RunHostdLoop(
     }
     next_inventory_report_at =
         now + std::chrono::seconds(std::max(1, options.inventory_scan_interval_sec));
+  };
+
+  const auto run_telemetry_if_due = [&]() {
+    constexpr int kTelemetryIntervalMs = 2000;
+    const auto now = std::chrono::steady_clock::now();
+    if (now < next_telemetry_report_at) {
+      return;
+    }
+    const int telemetry_code = process_runner_.RunCommand(build_telemetry_args());
+    if (telemetry_code != 0) {
+      std::cerr << "naim-node: hostd report-telemetry exit=" << telemetry_code << "\n";
+    }
+    next_telemetry_report_at = now + std::chrono::milliseconds(kTelemetryIntervalMs);
   };
 
   const auto wait_for_self_update_recreate = [&]() -> int {
@@ -557,6 +597,7 @@ int LauncherRunService::RunHostdLoop(
 #endif
 
     run_report_if_due();
+    run_telemetry_if_due();
 
     for (int second = 0;
          second < options.poll_interval_sec && !signal_manager.stop_requested();
@@ -568,6 +609,7 @@ int LauncherRunService::RunHostdLoop(
       }
 #endif
       run_report_if_due();
+      run_telemetry_if_due();
     }
   }
 #if !defined(_WIN32)

--- a/launcher/src/run/launcher_run_service.cpp
+++ b/launcher/src/run/launcher_run_service.cpp
@@ -1,12 +1,15 @@
 #include "run/launcher_run_service.h"
 
 #include <chrono>
+#include <atomic>
 #include <cerrno>
 #include <csignal>
 #include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <map>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <thread>
@@ -24,6 +27,9 @@
 #include "naim/core/platform_compat.h"
 #include "naim/security/crypto_utils.h"
 #include "naim/state/sqlite_store.h"
+#include "app/hostd_controller_transport_support.h"
+#include "app/hostd_reporting_support.h"
+#include "backend/hostd_backend_factory.h"
 #include "run/hostd_peer_service.h"
 
 namespace naim::launcher {
@@ -98,6 +104,51 @@ void StopChildProcess(pid_t pid) {
   }
 }
 #endif
+
+class LauncherTelemetryBackendSupport final : public naim::hostd::IHttpHostdBackendSupport {
+ public:
+  nlohmann::json SendControllerJsonRequest(
+      const std::string& controller_url,
+      const std::string& method,
+      const std::string& path,
+      const nlohmann::json& payload,
+      const std::map<std::string, std::string>& headers = {}) const override {
+    return naim::hostd::controller_transport_support::SendControllerJsonRequest(
+        controller_url,
+        method,
+        path,
+        payload,
+        headers);
+  }
+
+  naim::HostAssignment ParseAssignmentPayload(const nlohmann::json& payload) const override {
+    return naim::hostd::controller_transport_support::ParseAssignmentPayload(payload);
+  }
+
+  nlohmann::json BuildHostObservationPayload(
+      const naim::HostObservation& observation) const override {
+    return naim::hostd::controller_transport_support::BuildHostObservationPayload(observation);
+  }
+
+  nlohmann::json BuildHostTelemetryPayload(
+      const naim::HostTelemetryFrame& frame) const override {
+    return naim::hostd::controller_transport_support::BuildHostTelemetryPayload(frame);
+  }
+
+  nlohmann::json BuildDiskRuntimeStatePayload(
+      const naim::DiskRuntimeState& state) const override {
+    return naim::hostd::controller_transport_support::BuildDiskRuntimeStatePayload(state);
+  }
+
+  naim::DiskRuntimeState ParseDiskRuntimeStatePayload(
+      const nlohmann::json& payload) const override {
+    return naim::hostd::controller_transport_support::ParseDiskRuntimeStatePayload(payload);
+  }
+
+  std::string Trim(const std::string& value) const override {
+    return naim::hostd::controller_transport_support::Trim(value);
+  }
+};
 
 std::filesystem::path HostdSelfUpdateMarkerPath(
     const std::filesystem::path& state_root,
@@ -497,6 +548,7 @@ int LauncherRunService::RunHostdLoop(
     return args;
   };
 
+#if defined(_WIN32)
   const auto build_telemetry_args = [&](const bool watch) {
     std::vector<std::string> args = {
         hostd_binary.string(),
@@ -529,6 +581,7 @@ int LauncherRunService::RunHostdLoop(
     }
     return args;
   };
+#endif
 
   const auto run_report_if_due = [&]() {
     const auto now = std::chrono::steady_clock::now();
@@ -555,9 +608,88 @@ int LauncherRunService::RunHostdLoop(
     }
     next_telemetry_report_at = now + std::chrono::milliseconds(kTelemetryIntervalMs);
   };
+#else
+  std::atomic_bool telemetry_runtime_stop{false};
+  std::thread telemetry_runtime_thread;
+  const auto stop_telemetry_runtime = [&]() {
+    telemetry_runtime_stop.store(true);
+    if (telemetry_runtime_thread.joinable()) {
+      telemetry_runtime_thread.join();
+    }
+  };
+  const auto start_telemetry_runtime = [&]() {
+    telemetry_runtime_stop.store(false);
+    telemetry_runtime_thread = std::thread([&, telemetry_interval_ms = kTelemetryIntervalMs,
+                                             telemetry_ttl_ms = kTelemetryTtlMs]() {
+      const auto interval = std::chrono::milliseconds(telemetry_interval_ms);
+      const auto slow_interval = std::max(
+          interval * 5,
+          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::seconds(10)));
+      std::cout << "hostd_telemetry_runtime=in-process\n";
+      std::cout << "hostd_telemetry_interval_ms=" << interval.count() << "\n";
+      std::cout << "hostd_telemetry_slow_interval_ms=" << slow_interval.count() << "\n";
+      std::cout.flush();
+      while (!telemetry_runtime_stop.load()) {
+        try {
+          LauncherTelemetryBackendSupport backend_support;
+          naim::hostd::HostdBackendFactory backend_factory(backend_support);
+          auto backend = backend_factory.CreateBackend(
+              options.db_path.empty() ? std::nullopt
+                                      : std::optional<std::string>(options.db_path.string()),
+              options.controller_url.empty() ? std::nullopt
+                                             : std::optional<std::string>(options.controller_url),
+              options.host_private_key_path.empty()
+                  ? std::nullopt
+                  : std::optional<std::string>(options.host_private_key_path.string()),
+              options.controller_fingerprint.empty()
+                  ? std::nullopt
+                  : std::optional<std::string>(options.controller_fingerprint),
+              options.onboarding_key.empty()
+                  ? std::nullopt
+                  : std::optional<std::string>(options.onboarding_key),
+              options.node_name,
+              options.storage_root);
+          naim::hostd::HostdReportingSupport reporting_support;
+          auto next_tick = std::chrono::steady_clock::now();
+          auto next_slow_tick = next_tick;
+          while (!telemetry_runtime_stop.load()) {
+            next_tick += interval;
+            const auto now = std::chrono::steady_clock::now();
+            const bool include_slow_lane = now >= next_slow_tick;
+            if (include_slow_lane) {
+              next_slow_tick = now + slow_interval;
+            }
+            const auto frame = reporting_support.BuildTelemetryFrame(
+                options.node_name,
+                options.storage_root,
+                options.state_root.string(),
+                static_cast<int>(interval.count()),
+                telemetry_ttl_ms,
+                include_slow_lane);
+            backend->UpsertHostTelemetry(frame);
+            while (!telemetry_runtime_stop.load() &&
+                   std::chrono::steady_clock::now() < next_tick) {
+              std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+            if (std::chrono::steady_clock::now() > next_tick + interval) {
+              next_tick = std::chrono::steady_clock::now();
+            }
+          }
+        } catch (const std::exception& error) {
+          if (!telemetry_runtime_stop.load()) {
+            std::cerr << "naim-node: telemetry runtime warning: " << error.what() << "\n";
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+          }
+        }
+      }
+    });
+  };
 #endif
 
   const auto wait_for_self_update_recreate = [&]() -> int {
+#if !defined(_WIN32)
+    stop_telemetry_runtime();
+#endif
     peer_service.Stop();
     for (int second = 0; second < 300 && !signal_manager.stop_requested(); ++second) {
       std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -567,7 +699,6 @@ int LauncherRunService::RunHostdLoop(
 
 #if !defined(_WIN32)
   pid_t apply_pid = -1;
-  pid_t telemetry_pid = -1;
   const auto reap_apply_if_finished = [&]() -> bool {
     if (apply_pid <= 0) {
       return false;
@@ -587,29 +718,7 @@ int LauncherRunService::RunHostdLoop(
     }
     return false;
   };
-
-  const auto reap_telemetry_if_finished = [&]() {
-    if (telemetry_pid <= 0) {
-      return;
-    }
-    const std::optional<int> telemetry_code = PollChildExitCode(telemetry_pid);
-    if (!telemetry_code.has_value()) {
-      return;
-    }
-    if (*telemetry_code != 0) {
-      std::cerr << "naim-node: hostd report-telemetry watch exit=" << *telemetry_code
-                << "\n";
-    }
-    telemetry_pid = -1;
-  };
-
-  const auto start_telemetry_if_needed = [&]() {
-    reap_telemetry_if_finished();
-    if (telemetry_pid <= 0) {
-      telemetry_pid =
-          static_cast<pid_t>(process_runner_.SpawnCommand(build_telemetry_args(true)));
-    }
-  };
+  start_telemetry_runtime();
 #endif
 
   while (!signal_manager.stop_requested()) {
@@ -624,12 +733,7 @@ int LauncherRunService::RunHostdLoop(
       return wait_for_self_update_recreate();
     }
 #else
-    start_telemetry_if_needed();
     if (reap_apply_if_finished()) {
-      if (telemetry_pid > 0) {
-        StopChildProcess(telemetry_pid);
-        telemetry_pid = -1;
-      }
       return wait_for_self_update_recreate();
     }
     if (apply_pid <= 0) {
@@ -647,12 +751,7 @@ int LauncherRunService::RunHostdLoop(
          ++second) {
       std::this_thread::sleep_for(std::chrono::seconds(1));
 #if !defined(_WIN32)
-      start_telemetry_if_needed();
       if (reap_apply_if_finished()) {
-        if (telemetry_pid > 0) {
-          StopChildProcess(telemetry_pid);
-          telemetry_pid = -1;
-        }
         return wait_for_self_update_recreate();
       }
 #endif
@@ -666,9 +765,7 @@ int LauncherRunService::RunHostdLoop(
   if (apply_pid > 0) {
     StopChildProcess(apply_pid);
   }
-  if (telemetry_pid > 0) {
-    StopChildProcess(telemetry_pid);
-  }
+  stop_telemetry_runtime();
 #endif
   peer_service.Stop();
   return 0;

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -1036,19 +1036,47 @@ function summarizeNetworkTelemetryFrame(network) {
   };
 }
 
+function summarizeDiskTelemetryFrame(disk) {
+  const items = Array.isArray(disk?.items) ? disk.items : [];
+  return {
+    available: items.length > 0,
+    degraded: disk?.degraded === true,
+    source: disk?.source || "",
+    collected_at: disk?.collected_at || "",
+    summary: {
+      disk_count: items.length,
+      total_bytes: items.reduce((sum, item) => sum + Number(item?.total_bytes || 0), 0),
+      used_bytes: items.reduce((sum, item) => sum + Number(item?.used_bytes || 0), 0),
+      free_bytes: items.reduce((sum, item) => sum + Number(item?.free_bytes || 0), 0),
+      read_bytes: items.reduce((sum, item) => sum + Number(item?.read_bytes || 0), 0),
+      write_bytes: items.reduce((sum, item) => sum + Number(item?.write_bytes || 0), 0),
+    },
+    items,
+  };
+}
+
 function hostObservationFromTelemetryFrame(frame) {
   if (!frame?.node_name) {
     return null;
   }
   const cpuSnapshot = frame?.cpu || {};
   const instanceRuntime = Array.isArray(frame?.instance_runtime) ? frame.instance_runtime : [];
+  const stale = frame?.stale === true;
   return {
     node_name: frame.node_name,
     plane_name: frame.plane_name || "",
-    status: "healthy",
+    status: stale ? "stale" : "healthy",
     observed_at: frame.sampled_at || null,
     heartbeat_at: frame.sampled_at || null,
     telemetry_sequence: frame.sequence || 0,
+    telemetry_channel: frame.channel || "host.telemetry.v1",
+    telemetry_lane: frame.lane || "fast",
+    telemetry_monotonic_ms: frame.monotonic_ms || 0,
+    telemetry_expires_at: frame.expires_at || "",
+    telemetry_expires_in_ms: frame.expires_in_ms ?? null,
+    telemetry_stale: stale,
+    telemetry_degraded: Boolean(frame?.degraded_reason),
+    telemetry_degraded_reason: frame?.degraded_reason || "",
     runtime_status: { available: instanceRuntime.length > 0 },
     instance_runtimes: {
       available: instanceRuntime.length > 0,
@@ -1063,12 +1091,14 @@ function hostObservationFromTelemetryFrame(frame) {
     },
     gpu_telemetry: summarizeGpuTelemetryFrame(frame?.gpu),
     network_telemetry: summarizeNetworkTelemetryFrame(frame?.network),
+    disk_telemetry: summarizeDiskTelemetryFrame(frame?.disk),
   };
 }
 
 function mergeTelemetryIntoObservationPayload(currentPayload, frames, planeName = "") {
   const currentItems = hostObservationItemsFromPayload(currentPayload);
   const byNode = new Map(currentItems.filter((item) => item?.node_name).map((item) => [item.node_name, item]));
+  let changed = false;
   for (const frame of frames || []) {
     if (planeName && frame?.plane_name && frame.plane_name !== planeName) {
       continue;
@@ -1078,13 +1108,25 @@ function mergeTelemetryIntoObservationPayload(currentPayload, frames, planeName 
       continue;
     }
     const previous = byNode.get(telemetryItem.node_name) || {};
-    byNode.set(telemetryItem.node_name, {
+    const previousSequence = Number(previous.telemetry_sequence || 0);
+    const nextSequence = Number(telemetryItem.telemetry_sequence || 0);
+    if (previousSequence > 0 && nextSequence > 0 && nextSequence <= previousSequence) {
+      continue;
+    }
+    const nextItem = {
       ...previous,
       ...telemetryItem,
       observed_state: previous.observed_state,
       applied_generation: previous.applied_generation,
-      disk_telemetry: previous.disk_telemetry,
-    });
+      disk_telemetry: telemetryItem.disk_telemetry?.available
+        ? telemetryItem.disk_telemetry
+        : previous.disk_telemetry,
+    };
+    byNode.set(telemetryItem.node_name, nextItem);
+    changed = true;
+  }
+  if (!changed && currentPayload) {
+    return currentPayload;
   }
   return {
     ...(currentPayload || {}),
@@ -3895,19 +3937,23 @@ function App() {
       if (validFrames.length === 0) {
         return;
       }
-      setGlobalHostObservations((current) =>
-        mergeTelemetryIntoObservationPayload(current, validFrames),
+      const mergedGlobal = mergeTelemetryIntoObservationPayload(
+        globalHostObservationsRef.current,
+        validFrames,
       );
+      const globalChanged = mergedGlobal !== globalHostObservationsRef.current;
+      if (globalChanged) {
+        globalHostObservationsRef.current = mergedGlobal;
+        setGlobalHostObservations(mergedGlobal);
+      }
       if (selectedPlaneRef.current) {
         setHostObservations((current) =>
           mergeTelemetryIntoObservationPayload(current, validFrames, selectedPlaneRef.current),
         );
       }
-      const mergedGlobal = mergeTelemetryIntoObservationPayload(
-        globalHostObservationsRef.current,
-        validFrames,
-      );
-      globalHostObservationsRef.current = mergedGlobal;
+      if (!globalChanged) {
+        return;
+      }
       const globalItems = hostObservationItemsFromPayload(mergedGlobal);
       const serverSummary = summarizeGlobalObservations(globalItems);
       setMetricHistory((current) =>
@@ -3979,9 +4025,14 @@ function App() {
       fetchJson(queryPath("/api/v1/telemetry/snapshot", { history_seconds: 0 }))
         .then((payload) => {
           const frames = Array.isArray(payload?.nodes) ? payload.nodes : [];
-          setGlobalHostObservations((current) =>
-            mergeTelemetryIntoObservationPayload(current, frames),
+          const mergedGlobal = mergeTelemetryIntoObservationPayload(
+            globalHostObservationsRef.current,
+            frames,
           );
+          if (mergedGlobal !== globalHostObservationsRef.current) {
+            globalHostObservationsRef.current = mergedGlobal;
+            setGlobalHostObservations(mergedGlobal);
+          }
           if (selectedPlaneRef.current) {
             setHostObservations((current) =>
               mergeTelemetryIntoObservationPayload(current, frames, selectedPlaneRef.current),

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -997,6 +997,101 @@ function hostObservationItemsFromPayload(payload) {
   return [];
 }
 
+function summarizeGpuTelemetryFrame(gpu) {
+  const devices = Array.isArray(gpu?.devices) ? gpu.devices : [];
+  return {
+    available: devices.length > 0,
+    degraded: gpu?.degraded === true,
+    source: gpu?.source || "",
+    collected_at: gpu?.collected_at || "",
+    summary: {
+      device_count: devices.length,
+      total_vram_mb: devices.reduce((sum, item) => sum + Number(item?.total_vram_mb || 0), 0),
+      used_vram_mb: devices.reduce((sum, item) => sum + Number(item?.used_vram_mb || 0), 0),
+      free_vram_mb: devices.reduce((sum, item) => sum + Number(item?.free_vram_mb || 0), 0),
+      temperature_device_count: devices.filter((item) => item?.temperature_available).length,
+      hottest_temperature_c: devices.reduce(
+        (max, item) => Math.max(max, Number(item?.temperature_c || 0)),
+        0,
+      ),
+    },
+    devices,
+  };
+}
+
+function summarizeNetworkTelemetryFrame(network) {
+  const interfaces = Array.isArray(network?.interfaces) ? network.interfaces : [];
+  return {
+    available: interfaces.length > 0,
+    degraded: network?.degraded === true,
+    source: network?.source || "",
+    collected_at: network?.collected_at || "",
+    summary: {
+      interface_count: interfaces.length,
+      rx_bytes: interfaces.reduce((sum, item) => sum + Number(item?.rx_bytes || 0), 0),
+      tx_bytes: interfaces.reduce((sum, item) => sum + Number(item?.tx_bytes || 0), 0),
+    },
+    interfaces,
+    peer_discovery: Array.isArray(network?.peer_discovery) ? network.peer_discovery : [],
+  };
+}
+
+function hostObservationFromTelemetryFrame(frame) {
+  if (!frame?.node_name) {
+    return null;
+  }
+  const cpuSnapshot = frame?.cpu || {};
+  const instanceRuntime = Array.isArray(frame?.instance_runtime) ? frame.instance_runtime : [];
+  return {
+    node_name: frame.node_name,
+    plane_name: frame.plane_name || "",
+    status: "healthy",
+    observed_at: frame.sampled_at || null,
+    heartbeat_at: frame.sampled_at || null,
+    telemetry_sequence: frame.sequence || 0,
+    runtime_status: { available: instanceRuntime.length > 0 },
+    instance_runtimes: {
+      available: instanceRuntime.length > 0,
+      items: instanceRuntime,
+    },
+    cpu_telemetry: {
+      available: Boolean(cpuSnapshot?.source),
+      degraded: cpuSnapshot?.degraded === true,
+      source: cpuSnapshot?.source || "",
+      collected_at: cpuSnapshot?.collected_at || "",
+      summary: cpuSnapshot,
+    },
+    gpu_telemetry: summarizeGpuTelemetryFrame(frame?.gpu),
+    network_telemetry: summarizeNetworkTelemetryFrame(frame?.network),
+  };
+}
+
+function mergeTelemetryIntoObservationPayload(currentPayload, frames, planeName = "") {
+  const currentItems = hostObservationItemsFromPayload(currentPayload);
+  const byNode = new Map(currentItems.filter((item) => item?.node_name).map((item) => [item.node_name, item]));
+  for (const frame of frames || []) {
+    if (planeName && frame?.plane_name && frame.plane_name !== planeName) {
+      continue;
+    }
+    const telemetryItem = hostObservationFromTelemetryFrame(frame);
+    if (!telemetryItem?.node_name) {
+      continue;
+    }
+    const previous = byNode.get(telemetryItem.node_name) || {};
+    byNode.set(telemetryItem.node_name, {
+      ...previous,
+      ...telemetryItem,
+      observed_state: previous.observed_state,
+      applied_generation: previous.applied_generation,
+      disk_telemetry: previous.disk_telemetry,
+    });
+  }
+  return {
+    ...(currentPayload || {}),
+    observations: [...byNode.values()],
+  };
+}
+
 function instanceRole(instance) {
   const subrole =
     instance?.labels?.["naim.subrole"] ||
@@ -1964,6 +2059,7 @@ function App() {
   const [dashboard, setDashboard] = useState(null);
   const [hostObservations, setHostObservations] = useState(null);
   const [globalHostObservations, setGlobalHostObservations] = useState(null);
+  const [telemetryHealthy, setTelemetryHealthy] = useState(false);
   const [hostdHosts, setHostdHosts] = useState([]);
   const [protocolRegistry, setProtocolRegistry] = useState({ items: [], summary: {} });
   const [selectedHostNodeName, setSelectedHostNodeName] = useState("");
@@ -2076,6 +2172,8 @@ function App() {
   const liveRefreshSequenceRef = useRef(0);
   const selectedPlaneRef = useRef(selectedPlane);
   const eventSourceRef = useRef(null);
+  const telemetrySourceRef = useRef(null);
+  const globalHostObservationsRef = useRef(null);
   const chatAbortRef = useRef(null);
   const interactionSplitRef = useRef(null);
   const chatTranscriptRef = useRef(null);
@@ -2675,38 +2773,21 @@ function App() {
     try {
       const [
         dashboardPayload,
-        hostObservationsPayload,
-        globalHostObservationsPayload,
         interactionPayload,
       ] = await Promise.all([
         fetchJson(planePath(planeName, "dashboard")),
-        fetchJson(
-          queryPath("/api/v1/host-observations", {
-            plane: planeName,
-            stale_after: 30,
-          }),
-        ),
-        fetchJson(
-          queryPath("/api/v1/host-observations", {
-            stale_after: 30,
-          }),
-        ),
         fetchJson(interactionPath(planeName, "status")),
       ]);
       if (!shouldCommit()) {
         return;
       }
       setDashboard(dashboardPayload);
-      setHostObservations(hostObservationsPayload);
-      setGlobalHostObservations(globalHostObservationsPayload);
       setInteractionStatus(interactionPayload);
 
-      const globalObservationItems = hostObservationItemsFromPayload(
-        globalHostObservationsPayload,
-      );
+      const globalObservationItems = hostObservationItemsFromPayload(globalHostObservations);
       const serverSummary = summarizeGlobalObservations(globalObservationItems);
       const dashboardRuntime = dashboardPayload?.runtime || {};
-      const observationItems = hostObservationItemsFromPayload(hostObservationsPayload);
+      const observationItems = hostObservationItemsFromPayload(hostObservations);
       const observedInstancesCount = observationItems.reduce((count, observation) => {
         const instances = observedInstancesForObservation(observation);
         return count + instances.length;
@@ -3709,6 +3790,10 @@ function App() {
   }, [authState.authenticated, selectedPlane, selectedPage]);
 
   useEffect(() => {
+    globalHostObservationsRef.current = globalHostObservations;
+  }, [globalHostObservations]);
+
+  useEffect(() => {
     if (!authState.authenticated || selectedPage !== "knowledge-vault") {
       return undefined;
     }
@@ -3793,6 +3878,120 @@ function App() {
       }
     };
   }, [authState.authenticated, selectedPlane]);
+
+  useEffect(() => {
+    if (!authState.authenticated) {
+      if (telemetrySourceRef.current) {
+        telemetrySourceRef.current.close();
+        telemetrySourceRef.current = null;
+      }
+      setTelemetryHealthy(false);
+      return undefined;
+    }
+
+    let stopped = false;
+    const applyFrames = (frames) => {
+      const validFrames = (frames || []).filter((frame) => frame?.node_name);
+      if (validFrames.length === 0) {
+        return;
+      }
+      setGlobalHostObservations((current) =>
+        mergeTelemetryIntoObservationPayload(current, validFrames),
+      );
+      if (selectedPlaneRef.current) {
+        setHostObservations((current) =>
+          mergeTelemetryIntoObservationPayload(current, validFrames, selectedPlaneRef.current),
+        );
+      }
+      const mergedGlobal = mergeTelemetryIntoObservationPayload(
+        globalHostObservationsRef.current,
+        validFrames,
+      );
+      globalHostObservationsRef.current = mergedGlobal;
+      const globalItems = hostObservationItemsFromPayload(mergedGlobal);
+      const serverSummary = summarizeGlobalObservations(globalItems);
+      setMetricHistory((current) =>
+        appendMetricHistory(
+          current,
+          buildServerMetricSamples(serverSummary, globalItems.length),
+          Date.now(),
+        ),
+      );
+    };
+
+    fetchJson(queryPath("/api/v1/telemetry/snapshot", { history_seconds: 120 }))
+      .then((payload) => {
+        if (stopped) {
+          return;
+        }
+        applyFrames([...(payload?.history || []), ...(payload?.nodes || [])]);
+      })
+      .catch((error) => {
+        if (error?.status === 401) {
+          handleUnauthorized();
+        }
+      });
+
+    const source = new EventSource(
+      queryPath("/api/v1/telemetry/stream", {
+        plane: selectedPlane || undefined,
+      }),
+    );
+    telemetrySourceRef.current = source;
+    setTelemetryHealthy(false);
+
+    source.onopen = () => {
+      setTelemetryHealthy(true);
+    };
+    source.onerror = () => {
+      setTelemetryHealthy(false);
+    };
+    source.addEventListener("telemetry.snapshot", (event) => {
+      try {
+        const payload = JSON.parse(event.data || "{}");
+        applyFrames(payload.nodes || []);
+      } catch (_) {
+        setTelemetryHealthy(false);
+      }
+    });
+    source.addEventListener("telemetry.node", (event) => {
+      try {
+        applyFrames([JSON.parse(event.data || "{}")]);
+      } catch (_) {
+        setTelemetryHealthy(false);
+      }
+    });
+
+    return () => {
+      stopped = true;
+      source.close();
+      if (telemetrySourceRef.current === source) {
+        telemetrySourceRef.current = null;
+      }
+    };
+  }, [authState.authenticated, selectedPlane]);
+
+  useEffect(() => {
+    if (!authState.authenticated || telemetryHealthy) {
+      return undefined;
+    }
+    const timer = setInterval(() => {
+      fetchJson(queryPath("/api/v1/telemetry/snapshot", { history_seconds: 0 }))
+        .then((payload) => {
+          const frames = Array.isArray(payload?.nodes) ? payload.nodes : [];
+          setGlobalHostObservations((current) =>
+            mergeTelemetryIntoObservationPayload(current, frames),
+          );
+          if (selectedPlaneRef.current) {
+            setHostObservations((current) =>
+              mergeTelemetryIntoObservationPayload(current, frames, selectedPlaneRef.current),
+            );
+          }
+        })
+        .catch(() => {});
+    }, AUTO_REFRESH_MS);
+    return () => clearInterval(timer);
+  }, [authState.authenticated, telemetryHealthy]);
 
   useEffect(() => {
     setSelectedTab("status");
@@ -7634,10 +7833,10 @@ function App() {
     return renderAuthShell();
   }
 
-  const streamLabel = streamHealthy ? "Events live" : "Events reconnecting";
+  const streamLabel = streamHealthy && telemetryHealthy ? "Streams live" : "Streams reconnecting";
   const streamTitle = selectedPlane
-    ? `Global controller event stream; refreshing fleet and selected plane ${selectedPlane}.`
-    : "Global controller event stream; refreshing fleet data.";
+    ? `Controller event and telemetry streams; refreshing selected plane ${selectedPlane}.`
+    : "Controller event and telemetry streams; refreshing fleet data.";
   const lastRefreshTitle = `Last refresh: ${formatTimestamp(lastRefreshAt)}`;
   const lastEventTitle = `Last event: ${lastEventName || "none"}`;
 
@@ -7664,7 +7863,7 @@ function App() {
               <span>{apiHealthy ? "API" : apiError ? "API error" : "API..."}</span>
             </span>
             <span className="status-chip" title={streamTitle}>
-              {statusDot(streamHealthy ? "is-healthy" : selectedPlane ? "is-warning" : "is-booting")}
+              {statusDot(streamHealthy && telemetryHealthy ? "is-healthy" : selectedPlane ? "is-warning" : "is-booting")}
               <span>{streamLabel}</span>
             </span>
             <span className="hero-status-time" title={lastRefreshTitle}>


### PR DESCRIPTION
## Summary
- add coherent live telemetry frame metadata and stale projection
- split host telemetry into fast and full lanes
- run Linux host telemetry in-process from naim-node instead of a child watch command
- reduce WebUI telemetry churn by ignoring stale/older frames and preserving slow-lane disk data

## Tests
- cmake --build build/telemetry-debug --target naim-node naim-hostd naim-controller naim-telemetry-live-store-tests naim-hostd-reporting-support-tests naim-hostd-bootstrap-transfer-support-tests naim-hostd-bootstrap-model-support-factory-tests naim-hostd-http-tests
- ./build/telemetry-debug/naim-telemetry-live-store-tests
- ./build/telemetry-debug/naim-hostd-reporting-support-tests
- ./build/telemetry-debug/naim-hostd-bootstrap-transfer-support-tests
- ./build/telemetry-debug/naim-hostd-bootstrap-model-support-factory-tests
- ./build/telemetry-debug/naim-hostd-http-tests
- npm run build
- hpc1 sandbox build/tests/WebUI build/in-process hostd smoke