### PR TITLE
Add telemetry bus backpressure

### DIFF
--- a/common/include/naim/runtime/runtime_status.h
+++ b/common/include/naim/runtime/runtime_status.h
@@ -147,6 +147,15 @@ struct HostTelemetryFrame {
   int ttl_ms = 10000;
   std::string lane = "fast";
   std::string degraded_reason;
+  std::uint64_t collector_duration_ms = 0;
+  std::uint64_t publish_duration_ms = 0;
+  std::uint64_t publisher_queue_delay_ms = 0;
+  std::uint64_t telemetry_bus_depth = 0;
+  std::uint64_t telemetry_dropped_frames = 0;
+  std::uint64_t publish_error_count = 0;
+  int adaptive_interval_ms = 2000;
+  std::string adaptive_reason;
+  std::string last_publish_error;
   std::vector<RuntimeProcessStatus> instance_runtime;
   GpuTelemetrySnapshot gpu;
   NetworkTelemetrySnapshot network;

--- a/common/src/runtime/runtime_status.cpp
+++ b/common/src/runtime/runtime_status.cpp
@@ -379,6 +379,15 @@ json ToJson(const HostTelemetryFrame& frame) {
       {"ttl_ms", frame.ttl_ms},
       {"lane", frame.lane},
       {"degraded_reason", frame.degraded_reason},
+      {"collector_duration_ms", frame.collector_duration_ms},
+      {"publish_duration_ms", frame.publish_duration_ms},
+      {"publisher_queue_delay_ms", frame.publisher_queue_delay_ms},
+      {"telemetry_bus_depth", frame.telemetry_bus_depth},
+      {"telemetry_dropped_frames", frame.telemetry_dropped_frames},
+      {"publish_error_count", frame.publish_error_count},
+      {"adaptive_interval_ms", frame.adaptive_interval_ms},
+      {"adaptive_reason", frame.adaptive_reason},
+      {"last_publish_error", frame.last_publish_error},
       {"instance_runtime", std::move(instance_runtime)},
       {"gpu", ToJson(frame.gpu)},
       {"network", ToJson(frame.network)},
@@ -417,6 +426,21 @@ HostTelemetryFrame HostTelemetryFrameFromJson(const json& value) {
   frame.ttl_ms = value.value("ttl_ms", 10000);
   frame.lane = value.value("lane", std::string{"fast"});
   frame.degraded_reason = value.value("degraded_reason", std::string{});
+  frame.collector_duration_ms =
+      value.value("collector_duration_ms", static_cast<std::uint64_t>(0));
+  frame.publish_duration_ms =
+      value.value("publish_duration_ms", static_cast<std::uint64_t>(0));
+  frame.publisher_queue_delay_ms =
+      value.value("publisher_queue_delay_ms", static_cast<std::uint64_t>(0));
+  frame.telemetry_bus_depth =
+      value.value("telemetry_bus_depth", static_cast<std::uint64_t>(0));
+  frame.telemetry_dropped_frames =
+      value.value("telemetry_dropped_frames", static_cast<std::uint64_t>(0));
+  frame.publish_error_count =
+      value.value("publish_error_count", static_cast<std::uint64_t>(0));
+  frame.adaptive_interval_ms = value.value("adaptive_interval_ms", frame.interval_ms);
+  frame.adaptive_reason = value.value("adaptive_reason", std::string{});
+  frame.last_publish_error = value.value("last_publish_error", std::string{});
   for (const auto& status : value.value("instance_runtime", json::array())) {
     if (status.is_object()) {
       frame.instance_runtime.push_back(RuntimeProcessStatusFromJson(status));

--- a/controller/include/telemetry/telemetry_live_store.h
+++ b/controller/include/telemetry/telemetry_live_store.h
@@ -29,16 +29,21 @@ class TelemetryLiveStore final {
   struct NodeBuffer {
     naim::HostTelemetryFrame latest;
     std::deque<naim::HostTelemetryFrame> history;
+    std::uint64_t dropped_frames_total = 0;
+    std::uint64_t last_pruned_sequence = 0;
   };
 
   static bool MatchesPlane(
       const naim::HostTelemetryFrame& frame,
       const std::optional<std::string>& plane_name);
   static nlohmann::json FrameToJson(const naim::HostTelemetryFrame& frame);
+  static constexpr std::size_t HistoryCapacity();
+  static constexpr std::size_t StreamBatchLimit();
 
   mutable std::mutex mutex_;
   std::vector<NodeBuffer> nodes_;
   std::uint64_t latest_sequence_ = 0;
+  std::uint64_t dropped_frames_total_ = 0;
 };
 
 }  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_live_store.cpp
+++ b/controller/src/telemetry/telemetry_live_store.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 
 namespace naim::controller {
 
@@ -36,8 +37,11 @@ bool TelemetryLiveStore::Upsert(naim::HostTelemetryFrame frame) {
   } else {
     it->latest = frame;
     it->history.push_back(std::move(frame));
-    while (it->history.size() > 300) {
+    while (it->history.size() > HistoryCapacity()) {
+      it->last_pruned_sequence = it->history.front().sequence;
       it->history.pop_front();
+      ++it->dropped_frames_total;
+      ++dropped_frames_total_;
     }
   }
   return true;
@@ -53,7 +57,10 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
     if (!MatchesPlane(buffer.latest, plane_name)) {
       continue;
     }
-    nodes.push_back(FrameToJson(buffer.latest));
+    auto node = FrameToJson(buffer.latest);
+    node["controller_dropped_frames_total"] = buffer.dropped_frames_total;
+    node["controller_last_pruned_sequence"] = buffer.last_pruned_sequence;
+    nodes.push_back(std::move(node));
     if (history_seconds <= 0) {
       continue;
     }
@@ -69,6 +76,10 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
       {"service", "naim-controller"},
       {"plane_name", plane_name.has_value() ? nlohmann::json(*plane_name) : nlohmann::json(nullptr)},
       {"latest_sequence", latest_sequence_},
+      {"telemetry_overloaded", dropped_frames_total_ > 0},
+      {"dropped_frames_total", dropped_frames_total_},
+      {"history_capacity", HistoryCapacity()},
+      {"stream_batch_limit", StreamBatchLimit()},
       {"nodes", std::move(nodes)},
       {"history", std::move(history)},
   };
@@ -92,6 +103,10 @@ std::vector<naim::HostTelemetryFrame> TelemetryLiveStore::LoadFramesAfter(
       [](const auto& left, const auto& right) {
         return left.sequence < right.sequence;
       });
+  if (frames.size() > StreamBatchLimit()) {
+    const auto erase_count = static_cast<std::ptrdiff_t>(frames.size() - StreamBatchLimit());
+    frames.erase(frames.begin(), frames.begin() + erase_count);
+  }
   return frames;
 }
 
@@ -129,7 +144,17 @@ nlohmann::json TelemetryLiveStore::FrameToJson(
   const bool stale = frame.sequence == 0 || ttl_ms == 0 || expires_at_ms <= now_ms;
   payload["stale"] = stale;
   payload["expires_in_ms"] = stale ? 0 : expires_at_ms - now_ms;
+  payload["controller_ingest_delay_ms"] =
+      frame.sequence > 0 && now_ms >= frame.sequence ? now_ms - frame.sequence : 0;
   return payload;
+}
+
+constexpr std::size_t TelemetryLiveStore::HistoryCapacity() {
+  return 300;
+}
+
+constexpr std::size_t TelemetryLiveStore::StreamBatchLimit() {
+  return 128;
 }
 
 }  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -31,6 +31,13 @@ naim::HostTelemetryFrame MakeFrame(
   frame.expires_at = "2026-05-04 12:00:10";
   frame.monotonic_ms = sequence;
   frame.lane = "fast";
+  frame.collector_duration_ms = 2;
+  frame.publish_duration_ms = 3;
+  frame.publisher_queue_delay_ms = 4;
+  frame.telemetry_bus_depth = 1;
+  frame.telemetry_dropped_frames = 0;
+  frame.adaptive_interval_ms = 2000;
+  frame.adaptive_reason = "test";
   frame.cpu.source = "procfs";
   frame.cpu.total_memory_bytes = 100;
   frame.cpu.used_memory_bytes = 50;
@@ -120,6 +127,21 @@ void TestCoherenceFieldsAndStaleProjection() {
   Expect(node.at("lane").get<std::string>() == "full", "lane should roundtrip");
   Expect(node.at("monotonic_ms").get<std::uint64_t>() == 1234, "monotonic_ms should roundtrip");
   Expect(
+      node.at("collector_duration_ms").get<std::uint64_t>() == 2,
+      "collector duration should roundtrip");
+  Expect(
+      node.at("publish_duration_ms").get<std::uint64_t>() == 3,
+      "publish duration should roundtrip");
+  Expect(
+      node.at("publisher_queue_delay_ms").get<std::uint64_t>() == 4,
+      "queue delay should roundtrip");
+  Expect(
+      node.at("adaptive_reason").get<std::string>() == "test",
+      "adaptive reason should roundtrip");
+  Expect(
+      node.contains("controller_ingest_delay_ms"),
+      "controller ingest delay should be projected");
+  Expect(
       node.at("degraded_reason").get<std::string>() == "cpu:procfs-warmup",
       "degraded reason should roundtrip");
   Expect(!node.at("stale").get<bool>(), "fresh frame should not be stale");
@@ -133,6 +155,33 @@ void TestCoherenceFieldsAndStaleProjection() {
   std::cout << "ok: telemetry-live-store-coherence-stale\n";
 }
 
+void TestBackpressureProjection() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  for (std::uint64_t index = 0; index < 320; ++index) {
+    Expect(
+        store.Upsert(MakeFrame("node-backpressure", "plane-backpressure", 1000 + index)),
+        "backpressure frame should update");
+  }
+  const auto snapshot = store.BuildSnapshot(std::string("plane-backpressure"), 600);
+  Expect(snapshot.at("telemetry_overloaded").get<bool>(), "snapshot should expose overload");
+  Expect(
+      snapshot.at("dropped_frames_total").get<std::uint64_t>() >= 20,
+      "snapshot should count dropped frames");
+  Expect(
+      snapshot.at("history_capacity").get<std::size_t>() == 300,
+      "snapshot should expose history capacity");
+  Expect(
+      snapshot.at("stream_batch_limit").get<std::size_t>() == 128,
+      "snapshot should expose stream batch limit");
+  Expect(
+      snapshot.at("nodes").at(0).at("controller_dropped_frames_total").get<std::uint64_t>() >= 20,
+      "node should expose dropped frames");
+  const auto frames = store.LoadFramesAfter(1000, std::string("plane-backpressure"));
+  Expect(frames.size() == 128, "stream load should be capped");
+  Expect(frames.front().sequence > 1000, "stream cap should retain newer frames");
+  std::cout << "ok: telemetry-live-store-backpressure\n";
+}
+
 }  // namespace
 
 int main() {
@@ -140,6 +189,7 @@ int main() {
     TestUpsertAndSnapshot();
     TestPlaneFilter();
     TestCoherenceFieldsAndStaleProjection();
+    TestBackpressureProjection();
     return 0;
   } catch (const std::exception& error) {
     std::cerr << "telemetry_live_store_tests failed: " << error.what() << "\n";

--- a/hostd/src/cli/hostd_command_line.cpp
+++ b/hostd/src/cli/hostd_command_line.cpp
@@ -16,7 +16,7 @@ void HostdCommandLine::PrintUsage(std::ostream& out) const {
       << "  naim-hostd show-local-state --node <node-name> [--state-root <path>]\n"
       << "  naim-hostd show-runtime-status --node <node-name> [--state-root <path>]\n"
       << "  naim-hostd report-observed-state --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--state-root <path>]\n"
-      << "  naim-hostd report-telemetry --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--state-root <path>] [--watch] [--interval-ms <ms>] [--ttl-ms <ms>]\n"
+      << "  naim-hostd report-telemetry --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--state-root <path>] [--watch diagnostic] [--interval-ms <ms>] [--ttl-ms <ms>]\n"
       << "  naim-hostd apply-state-ops --node <node-name> [--db <path>] [--artifacts-root <path>] [--runtime-root <path>] [--state-root <path>] [--compose-mode skip|exec] [--config <path>]\n"
       << "  naim-hostd apply-next-assignment --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--runtime-root <path>] [--state-root <path>] [--compose-mode skip|exec] [--config <path>]\n";
 }

--- a/hostd/src/observation/hostd_observation_service.cpp
+++ b/hostd/src/observation/hostd_observation_service.cpp
@@ -157,6 +157,7 @@ void HostdObservationService::WatchLocalTelemetry(
       interval * 5,
       std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::seconds(10)));
   std::cout << "hostd report-telemetry watch\n";
+  std::cout << "mode=diagnostic\n";
   std::cout << "backend=hostd-control\n";
   std::cout << "node=" << node_name << "\n";
   std::cout << "interval_ms=" << interval.count() << "\n";

--- a/launcher/src/run/launcher_run_service.cpp
+++ b/launcher/src/run/launcher_run_service.cpp
@@ -1,10 +1,13 @@
 #include "run/launcher_run_service.h"
 
+#include <algorithm>
 #include <chrono>
 #include <atomic>
 #include <cerrno>
 #include <csignal>
 #include <cctype>
+#include <condition_variable>
+#include <deque>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -13,7 +16,9 @@
 #include <sstream>
 #include <stdexcept>
 #include <thread>
+#include <utility>
 #include <vector>
+#include <mutex>
 
 #include <nlohmann/json.hpp>
 
@@ -149,6 +154,113 @@ class LauncherTelemetryBackendSupport final : public naim::hostd::IHttpHostdBack
     return naim::hostd::controller_transport_support::Trim(value);
   }
 };
+
+struct LauncherTelemetryBusItem {
+  naim::HostTelemetryFrame frame;
+  std::chrono::steady_clock::time_point enqueued_at;
+};
+
+class LauncherTelemetryBus final {
+ public:
+  void Publish(naim::HostTelemetryFrame frame) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (queue_.size() >= kCapacity) {
+      queue_.pop_front();
+      ++dropped_frames_;
+    }
+    queue_.push_back(LauncherTelemetryBusItem{std::move(frame), std::chrono::steady_clock::now()});
+    cv_.notify_one();
+  }
+
+  std::optional<LauncherTelemetryBusItem> WaitPop(const std::atomic_bool& stop_requested) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait_for(lock, std::chrono::milliseconds(250), [&]() {
+      return stop_requested.load() || !queue_.empty();
+    });
+    if (queue_.empty()) {
+      return std::nullopt;
+    }
+    auto item = std::move(queue_.front());
+    queue_.pop_front();
+    return item;
+  }
+
+  void Stop() {
+    cv_.notify_all();
+  }
+
+  std::uint64_t DroppedFrames() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return dropped_frames_;
+  }
+
+  std::size_t Depth() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return queue_.size();
+  }
+
+ private:
+  static constexpr std::size_t kCapacity = 16;
+
+  mutable std::mutex mutex_;
+  std::condition_variable cv_;
+  std::deque<LauncherTelemetryBusItem> queue_;
+  std::uint64_t dropped_frames_ = 0;
+};
+
+struct LauncherTelemetryRuntimeMetrics {
+  std::atomic<std::uint64_t> last_publish_duration_ms{0};
+  std::atomic<std::uint64_t> publish_error_count{0};
+  std::string last_publish_error;
+  mutable std::mutex error_mutex;
+};
+
+std::uint64_t DurationMillis(
+    const std::chrono::steady_clock::time_point started_at,
+    const std::chrono::steady_clock::time_point finished_at) {
+  return static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(finished_at - started_at).count());
+}
+
+struct LauncherTelemetryCadence {
+  std::chrono::milliseconds interval;
+  std::string reason;
+};
+
+LauncherTelemetryCadence ResolveTelemetryCadence(const naim::HostTelemetryFrame& frame) {
+  if (frame.plane_name.empty() && frame.instance_runtime.empty()) {
+    return {std::chrono::seconds(10), "idle-no-plane"};
+  }
+  const bool has_not_ready = std::any_of(
+      frame.instance_runtime.begin(),
+      frame.instance_runtime.end(),
+      [](const naim::RuntimeProcessStatus& status) {
+        return !status.ready || status.runtime_phase == "starting" ||
+               status.runtime_phase == "deploying" || status.runtime_phase == "loading";
+      });
+  if (has_not_ready) {
+    return {std::chrono::seconds(1), "plane-changing"};
+  }
+  if (!frame.instance_runtime.empty()) {
+    return {std::chrono::seconds(5), "stable-runtime"};
+  }
+  return {std::chrono::seconds(3), "plane-without-runtime"};
+}
+
+std::string LoadLastPublishError(const LauncherTelemetryRuntimeMetrics& metrics) {
+  std::lock_guard<std::mutex> lock(metrics.error_mutex);
+  return metrics.last_publish_error;
+}
+
+void StoreLastPublishError(
+    LauncherTelemetryRuntimeMetrics* metrics,
+    const std::string& error) {
+  if (metrics == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(metrics->error_mutex);
+  metrics->last_publish_error = error;
+}
 
 std::filesystem::path HostdSelfUpdateMarkerPath(
     const std::filesystem::path& state_root,
@@ -610,25 +722,85 @@ int LauncherRunService::RunHostdLoop(
   };
 #else
   std::atomic_bool telemetry_runtime_stop{false};
-  std::thread telemetry_runtime_thread;
+  LauncherTelemetryBus telemetry_bus;
+  LauncherTelemetryRuntimeMetrics telemetry_metrics;
+  std::thread telemetry_collector_thread;
+  std::thread telemetry_publisher_thread;
   const auto stop_telemetry_runtime = [&]() {
     telemetry_runtime_stop.store(true);
-    if (telemetry_runtime_thread.joinable()) {
-      telemetry_runtime_thread.join();
+    telemetry_bus.Stop();
+    if (telemetry_collector_thread.joinable()) {
+      telemetry_collector_thread.join();
+    }
+    if (telemetry_publisher_thread.joinable()) {
+      telemetry_publisher_thread.join();
     }
   };
   const auto start_telemetry_runtime = [&]() {
     telemetry_runtime_stop.store(false);
-    telemetry_runtime_thread = std::thread([&, telemetry_interval_ms = kTelemetryIntervalMs,
-                                             telemetry_ttl_ms = kTelemetryTtlMs]() {
-      const auto interval = std::chrono::milliseconds(telemetry_interval_ms);
-      const auto slow_interval = std::max(
-          interval * 5,
-          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::seconds(10)));
+    telemetry_collector_thread = std::thread([&, telemetry_interval_ms = kTelemetryIntervalMs,
+                                               telemetry_ttl_ms = kTelemetryTtlMs]() {
+      auto interval = std::chrono::milliseconds(telemetry_interval_ms);
+      auto slow_interval = std::max(
+          interval * 6,
+          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::seconds(30)));
       std::cout << "hostd_telemetry_runtime=in-process\n";
-      std::cout << "hostd_telemetry_interval_ms=" << interval.count() << "\n";
-      std::cout << "hostd_telemetry_slow_interval_ms=" << slow_interval.count() << "\n";
+      std::cout << "hostd_telemetry_bus=bounded-local\n";
+      std::cout << "hostd_telemetry_initial_interval_ms=" << interval.count() << "\n";
+      std::cout << "hostd_telemetry_initial_slow_interval_ms=" << slow_interval.count() << "\n";
       std::cout.flush();
+      while (!telemetry_runtime_stop.load()) {
+        try {
+          naim::hostd::HostdReportingSupport reporting_support;
+          auto next_tick = std::chrono::steady_clock::now();
+          auto next_slow_tick = next_tick;
+          while (!telemetry_runtime_stop.load()) {
+            next_tick += interval;
+            const auto now = std::chrono::steady_clock::now();
+            const bool include_slow_lane = now >= next_slow_tick;
+            if (include_slow_lane) {
+              next_slow_tick = now + slow_interval;
+            }
+            const auto collect_started_at = std::chrono::steady_clock::now();
+            auto frame = reporting_support.BuildTelemetryFrame(
+                options.node_name,
+                options.storage_root,
+                options.state_root.string(),
+                static_cast<int>(interval.count()),
+                telemetry_ttl_ms,
+                include_slow_lane);
+            const auto collect_finished_at = std::chrono::steady_clock::now();
+            const auto cadence = ResolveTelemetryCadence(frame);
+            frame.collector_duration_ms = DurationMillis(collect_started_at, collect_finished_at);
+            frame.publish_duration_ms = telemetry_metrics.last_publish_duration_ms.load();
+            frame.telemetry_bus_depth = telemetry_bus.Depth();
+            frame.telemetry_dropped_frames = telemetry_bus.DroppedFrames();
+            frame.publish_error_count = telemetry_metrics.publish_error_count.load();
+            frame.adaptive_interval_ms = static_cast<int>(cadence.interval.count());
+            frame.adaptive_reason = cadence.reason;
+            frame.last_publish_error = LoadLastPublishError(telemetry_metrics);
+            telemetry_bus.Publish(std::move(frame));
+            interval = cadence.interval;
+            slow_interval = std::max(
+                interval * 6,
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::seconds(30)));
+            while (!telemetry_runtime_stop.load() &&
+                   std::chrono::steady_clock::now() < next_tick) {
+              std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+            if (std::chrono::steady_clock::now() > next_tick + interval) {
+              next_tick = std::chrono::steady_clock::now();
+            }
+          }
+        } catch (const std::exception& error) {
+          if (!telemetry_runtime_stop.load()) {
+            std::cerr << "naim-node: telemetry collector warning: " << error.what() << "\n";
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+          }
+        }
+      }
+    });
+    telemetry_publisher_thread = std::thread([&]() {
       while (!telemetry_runtime_stop.load()) {
         try {
           LauncherTelemetryBackendSupport backend_support;
@@ -649,35 +821,30 @@ int LauncherRunService::RunHostdLoop(
                   : std::optional<std::string>(options.onboarding_key),
               options.node_name,
               options.storage_root);
-          naim::hostd::HostdReportingSupport reporting_support;
-          auto next_tick = std::chrono::steady_clock::now();
-          auto next_slow_tick = next_tick;
           while (!telemetry_runtime_stop.load()) {
-            next_tick += interval;
-            const auto now = std::chrono::steady_clock::now();
-            const bool include_slow_lane = now >= next_slow_tick;
-            if (include_slow_lane) {
-              next_slow_tick = now + slow_interval;
+            auto item = telemetry_bus.WaitPop(telemetry_runtime_stop);
+            if (!item.has_value()) {
+              continue;
             }
-            const auto frame = reporting_support.BuildTelemetryFrame(
-                options.node_name,
-                options.storage_root,
-                options.state_root.string(),
-                static_cast<int>(interval.count()),
-                telemetry_ttl_ms,
-                include_slow_lane);
-            backend->UpsertHostTelemetry(frame);
-            while (!telemetry_runtime_stop.load() &&
-                   std::chrono::steady_clock::now() < next_tick) {
-              std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            }
-            if (std::chrono::steady_clock::now() > next_tick + interval) {
-              next_tick = std::chrono::steady_clock::now();
-            }
+            item->frame.publisher_queue_delay_ms =
+                DurationMillis(item->enqueued_at, std::chrono::steady_clock::now());
+            item->frame.telemetry_bus_depth = telemetry_bus.Depth();
+            item->frame.telemetry_dropped_frames = telemetry_bus.DroppedFrames();
+            item->frame.publish_error_count = telemetry_metrics.publish_error_count.load();
+            item->frame.publish_duration_ms =
+                telemetry_metrics.last_publish_duration_ms.load();
+            item->frame.last_publish_error = LoadLastPublishError(telemetry_metrics);
+            const auto publish_started_at = std::chrono::steady_clock::now();
+            backend->UpsertHostTelemetry(item->frame);
+            telemetry_metrics.last_publish_duration_ms.store(
+                DurationMillis(publish_started_at, std::chrono::steady_clock::now()));
+            StoreLastPublishError(&telemetry_metrics, "");
           }
         } catch (const std::exception& error) {
           if (!telemetry_runtime_stop.load()) {
-            std::cerr << "naim-node: telemetry runtime warning: " << error.what() << "\n";
+            telemetry_metrics.publish_error_count.fetch_add(1);
+            StoreLastPublishError(&telemetry_metrics, error.what());
+            std::cerr << "naim-node: telemetry publisher warning: " << error.what() << "\n";
             std::this_thread::sleep_for(std::chrono::seconds(1));
           }
         }

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -52,6 +52,11 @@ import {
   normalizeKnowledgeResults,
   summarizeKnowledgeGraph,
 } from "./knowledgeVault.js";
+import {
+  createTelemetryStore,
+  reduceTelemetryStore,
+  selectTelemetryFrames,
+} from "./telemetryStore.js";
 
 const REFRESH_DEBOUNCE_MS = 350;
 const AUTO_REFRESH_MS = 5000;
@@ -1077,6 +1082,18 @@ function hostObservationFromTelemetryFrame(frame) {
     telemetry_stale: stale,
     telemetry_degraded: Boolean(frame?.degraded_reason),
     telemetry_degraded_reason: frame?.degraded_reason || "",
+    telemetry_collector_duration_ms: Number(frame?.collector_duration_ms || 0),
+    telemetry_publish_duration_ms: Number(frame?.publish_duration_ms || 0),
+    telemetry_queue_delay_ms: Number(frame?.publisher_queue_delay_ms || 0),
+    telemetry_bus_depth: Number(frame?.telemetry_bus_depth || 0),
+    telemetry_dropped_frames: Number(
+      frame?.controller_dropped_frames_total ?? frame?.telemetry_dropped_frames ?? 0,
+    ),
+    telemetry_publish_errors: Number(frame?.publish_error_count || 0),
+    telemetry_adaptive_interval_ms: Number(frame?.adaptive_interval_ms || frame?.interval_ms || 0),
+    telemetry_adaptive_reason: frame?.adaptive_reason || "",
+    telemetry_controller_ingest_delay_ms: Number(frame?.controller_ingest_delay_ms || 0),
+    telemetry_last_publish_error: frame?.last_publish_error || "",
     runtime_status: { available: instanceRuntime.length > 0 },
     instance_runtimes: {
       available: instanceRuntime.length > 0,
@@ -2216,6 +2233,8 @@ function App() {
   const eventSourceRef = useRef(null);
   const telemetrySourceRef = useRef(null);
   const globalHostObservationsRef = useRef(null);
+  const globalTelemetryStoreRef = useRef(createTelemetryStore());
+  const planeTelemetryStoreRef = useRef(createTelemetryStore());
   const chatAbortRef = useRef(null);
   const interactionSplitRef = useRef(null);
   const chatTranscriptRef = useRef(null);
@@ -2225,6 +2244,7 @@ function App() {
 
   useEffect(() => {
     selectedPlaneRef.current = selectedPlane;
+    planeTelemetryStoreRef.current = createTelemetryStore();
   }, [selectedPlane]);
 
   function resetProtectedData() {
@@ -2233,6 +2253,9 @@ function App() {
     setDashboard(null);
     setHostObservations(null);
     setGlobalHostObservations(null);
+    globalHostObservationsRef.current = null;
+    globalTelemetryStoreRef.current = createTelemetryStore();
+    planeTelemetryStoreRef.current = createTelemetryStore();
     setHostdHosts([]);
     setDiskState(null);
     setRolloutState(null);
@@ -3937,18 +3960,36 @@ function App() {
       if (validFrames.length === 0) {
         return;
       }
-      const mergedGlobal = mergeTelemetryIntoObservationPayload(
-        globalHostObservationsRef.current,
-        validFrames,
-      );
+      const globalResult = reduceTelemetryStore(globalTelemetryStoreRef.current, validFrames);
+      if (globalResult.changed) {
+        globalTelemetryStoreRef.current = globalResult.store;
+      }
+      const mergedGlobal = globalResult.acceptedFrames.length > 0
+        ? mergeTelemetryIntoObservationPayload(
+            globalHostObservationsRef.current,
+            globalResult.acceptedFrames,
+          )
+        : globalHostObservationsRef.current;
       const globalChanged = mergedGlobal !== globalHostObservationsRef.current;
       if (globalChanged) {
         globalHostObservationsRef.current = mergedGlobal;
         setGlobalHostObservations(mergedGlobal);
       }
       if (selectedPlaneRef.current) {
+        const planeResult = reduceTelemetryStore(
+          planeTelemetryStoreRef.current,
+          validFrames,
+          selectedPlaneRef.current,
+        );
+        if (planeResult.changed) {
+          planeTelemetryStoreRef.current = planeResult.store;
+        }
         setHostObservations((current) =>
-          mergeTelemetryIntoObservationPayload(current, validFrames, selectedPlaneRef.current),
+          mergeTelemetryIntoObservationPayload(
+            current,
+            selectTelemetryFrames(planeTelemetryStoreRef.current),
+            selectedPlaneRef.current,
+          ),
         );
       }
       if (!globalChanged) {
@@ -4025,17 +4066,38 @@ function App() {
       fetchJson(queryPath("/api/v1/telemetry/snapshot", { history_seconds: 0 }))
         .then((payload) => {
           const frames = Array.isArray(payload?.nodes) ? payload.nodes : [];
-          const mergedGlobal = mergeTelemetryIntoObservationPayload(
-            globalHostObservationsRef.current,
-            frames,
-          );
+          const globalResult = reduceTelemetryStore(globalTelemetryStoreRef.current, frames);
+          if (!globalResult.changed && !selectedPlaneRef.current) {
+            return;
+          }
+          if (globalResult.changed) {
+            globalTelemetryStoreRef.current = globalResult.store;
+          }
+          const mergedGlobal = globalResult.acceptedFrames.length > 0
+            ? mergeTelemetryIntoObservationPayload(
+                globalHostObservationsRef.current,
+                globalResult.acceptedFrames,
+              )
+            : globalHostObservationsRef.current;
           if (mergedGlobal !== globalHostObservationsRef.current) {
             globalHostObservationsRef.current = mergedGlobal;
             setGlobalHostObservations(mergedGlobal);
           }
           if (selectedPlaneRef.current) {
+            const planeResult = reduceTelemetryStore(
+              planeTelemetryStoreRef.current,
+              frames,
+              selectedPlaneRef.current,
+            );
+            if (planeResult.changed) {
+              planeTelemetryStoreRef.current = planeResult.store;
+            }
             setHostObservations((current) =>
-              mergeTelemetryIntoObservationPayload(current, frames, selectedPlaneRef.current),
+              mergeTelemetryIntoObservationPayload(
+                current,
+                selectTelemetryFrames(planeTelemetryStoreRef.current),
+                selectedPlaneRef.current,
+              ),
             );
           }
         })
@@ -5211,6 +5273,24 @@ function App() {
                   <div className="metric-row"><span>Knowledge Vault</span><strong>{knowledgeVaultServiceLabel(host)}</strong></div>
                 </>
               ) : null}
+            </div>
+          </section>
+          <section className="subpanel">
+            <div className="subpanel-header">
+              <h3>Telemetry pipeline</h3>
+              <span className="subpanel-meta">Collector, bus, publisher, and controller timing.</span>
+            </div>
+            <div className="metric-grid">
+              <div className="metric-row"><span>Cadence</span><strong>{host?.telemetry_adaptive_interval_ms ? `${host.telemetry_adaptive_interval_ms} ms` : "n/a"}</strong></div>
+              <div className="metric-row"><span>Cadence reason</span><strong>{host?.telemetry_adaptive_reason || "n/a"}</strong></div>
+              <div className="metric-row"><span>Collect</span><strong>{host?.telemetry_collector_duration_ms ? `${host.telemetry_collector_duration_ms} ms` : "n/a"}</strong></div>
+              <div className="metric-row"><span>Publish</span><strong>{host?.telemetry_publish_duration_ms ? `${host.telemetry_publish_duration_ms} ms` : "n/a"}</strong></div>
+              <div className="metric-row"><span>Queue delay</span><strong>{host?.telemetry_queue_delay_ms ? `${host.telemetry_queue_delay_ms} ms` : "n/a"}</strong></div>
+              <div className="metric-row"><span>Controller ingest</span><strong>{host?.telemetry_controller_ingest_delay_ms ? `${host.telemetry_controller_ingest_delay_ms} ms` : "n/a"}</strong></div>
+              <div className="metric-row"><span>Bus depth</span><strong>{host?.telemetry_bus_depth ?? "n/a"}</strong></div>
+              <div className="metric-row"><span>Dropped frames</span><strong>{host?.telemetry_dropped_frames ?? 0}</strong></div>
+              <div className="metric-row"><span>Publish errors</span><strong>{host?.telemetry_publish_errors ?? 0}</strong></div>
+              <div className="metric-row"><span>Last publish error</span><strong>{host?.telemetry_last_publish_error || "none"}</strong></div>
             </div>
           </section>
           {lanPeers.length > 0 ? (

--- a/ui/operator-react/src/telemetryStore.js
+++ b/ui/operator-react/src/telemetryStore.js
@@ -1,0 +1,76 @@
+export function createTelemetryStore() {
+  return {
+    byNode: {},
+    latestSequence: 0,
+    droppedFramesTotal: 0,
+    overloaded: false,
+  };
+}
+
+function shouldAcceptFrame(previous, frame) {
+  const previousSequence = Number(previous?.sequence || 0);
+  const nextSequence = Number(frame?.sequence || 0);
+  if (!frame?.node_name || nextSequence <= 0) {
+    return false;
+  }
+  return previousSequence <= 0 || nextSequence > previousSequence;
+}
+
+export function reduceTelemetryStore(store, frames, planeName = "") {
+  const current = store || createTelemetryStore();
+  let changed = false;
+  const acceptedFrames = [];
+  const nextByNode = { ...(current.byNode || {}) };
+
+  for (const frame of frames || []) {
+    if (!frame?.node_name) {
+      continue;
+    }
+    if (planeName && frame?.plane_name && frame.plane_name !== planeName) {
+      continue;
+    }
+    const previous = nextByNode[frame.node_name];
+    if (!shouldAcceptFrame(previous, frame)) {
+      continue;
+    }
+    nextByNode[frame.node_name] = frame;
+    acceptedFrames.push(frame);
+    changed = true;
+  }
+
+  if (!changed) {
+    return { store: current, acceptedFrames: [], changed: false };
+  }
+
+  const latestSequence = Math.max(
+    Number(current.latestSequence || 0),
+    ...acceptedFrames.map((frame) => Number(frame?.sequence || 0)),
+  );
+  const droppedFramesTotal = Math.max(
+    Number(current.droppedFramesTotal || 0),
+    ...acceptedFrames.map((frame) =>
+      Number(frame?.controller_dropped_frames_total ?? frame?.telemetry_dropped_frames ?? 0),
+    ),
+  );
+  const overloaded =
+    Boolean(current.overloaded) ||
+    acceptedFrames.some((frame) => frame?.telemetry_overloaded === true) ||
+    droppedFramesTotal > 0;
+
+  return {
+    store: {
+      byNode: nextByNode,
+      latestSequence,
+      droppedFramesTotal,
+      overloaded,
+    },
+    acceptedFrames,
+    changed: true,
+  };
+}
+
+export function selectTelemetryFrames(store) {
+  return Object.values(store?.byNode || {}).sort(
+    (left, right) => Number(left?.sequence || 0) - Number(right?.sequence || 0),
+  );
+}


### PR DESCRIPTION
## Summary
- mark hostd telemetry watch mode as diagnostic and keep production telemetry in naim-node runtime
- add bounded node-local telemetry bus with separate collector and publisher loops
- add adaptive telemetry cadence for idle, changing, and stable runtime states
- expose collector, queue, publish, controller ingest, backpressure, and adaptive timing fields in telemetry frames
- cap controller live telemetry history/stream batches and expose overload counters
- add a normalized WebUI telemetry store and node-level telemetry pipeline metrics

## Tests
- cmake --build build/telemetry-debug --target naim-node naim-hostd naim-controller naim-telemetry-live-store-tests
- ./build/telemetry-debug/naim-telemetry-live-store-tests
- cmake --build build/telemetry-debug --target naim-hostd-reporting-support-tests naim-hostd-bootstrap-transfer-support-tests naim-hostd-bootstrap-model-support-factory-tests naim-hostd-http-tests
- ./build/telemetry-debug/naim-hostd-reporting-support-tests
- ./build/telemetry-debug/naim-hostd-bootstrap-transfer-support-tests
- ./build/telemetry-debug/naim-hostd-bootstrap-model-support-factory-tests
- ./build/telemetry-debug/naim-hostd-http-tests
- npm run build
- local naim-node hostd bounded-local bus smoke
- hpc1 sandbox build/tests/WebUI build/bus smoke