### PR TITLE
Add telemetry stream contract

### DIFF
--- a/common/include/naim/runtime/runtime_status.h
+++ b/common/include/naim/runtime/runtime_status.h
@@ -135,14 +135,19 @@ struct CpuTelemetrySnapshot {
 
 struct HostTelemetryFrame {
   int contract_version = 1;
+  std::string schema_version = "host.telemetry.v2";
   std::string channel = "host.telemetry.v1";
+  std::string source = "hostd";
   std::string node_name;
+  std::string node_id;
   std::string plane_name;
+  std::string plane_id;
   std::string sampled_at;
   std::string collected_at;
   std::string expires_at;
   std::uint64_t sequence = 0;
   std::uint64_t monotonic_ms = 0;
+  std::uint64_t monotonic_timestamp_ms = 0;
   int interval_ms = 2000;
   int ttl_ms = 10000;
   std::string lane = "fast";
@@ -156,6 +161,10 @@ struct HostTelemetryFrame {
   int adaptive_interval_ms = 2000;
   std::string adaptive_reason;
   std::string last_publish_error;
+  std::uint64_t plane_instance_count = 0;
+  std::uint64_t plane_ready_instance_count = 0;
+  std::uint64_t plane_not_ready_instance_count = 0;
+  std::string plane_runtime_health = "unknown";
   std::vector<RuntimeProcessStatus> instance_runtime;
   GpuTelemetrySnapshot gpu;
   NetworkTelemetrySnapshot network;

--- a/common/src/runtime/runtime_status.cpp
+++ b/common/src/runtime/runtime_status.cpp
@@ -367,14 +367,20 @@ json ToJson(const HostTelemetryFrame& frame) {
   }
   return json{
       {"contract_version", frame.contract_version},
+      {"schema_version", frame.schema_version},
       {"channel", frame.channel},
+      {"source", frame.source},
       {"node_name", frame.node_name},
+      {"node_id", frame.node_id.empty() ? frame.node_name : frame.node_id},
       {"plane_name", frame.plane_name},
+      {"plane_id", frame.plane_id.empty() ? frame.plane_name : frame.plane_id},
       {"sampled_at", frame.sampled_at},
       {"collected_at", frame.collected_at},
       {"expires_at", frame.expires_at},
       {"sequence", frame.sequence},
       {"monotonic_ms", frame.monotonic_ms},
+      {"monotonic_timestamp_ms",
+       frame.monotonic_timestamp_ms > 0 ? frame.monotonic_timestamp_ms : frame.monotonic_ms},
       {"interval_ms", frame.interval_ms},
       {"ttl_ms", frame.ttl_ms},
       {"lane", frame.lane},
@@ -388,6 +394,10 @@ json ToJson(const HostTelemetryFrame& frame) {
       {"adaptive_interval_ms", frame.adaptive_interval_ms},
       {"adaptive_reason", frame.adaptive_reason},
       {"last_publish_error", frame.last_publish_error},
+      {"plane_instance_count", frame.plane_instance_count},
+      {"plane_ready_instance_count", frame.plane_ready_instance_count},
+      {"plane_not_ready_instance_count", frame.plane_not_ready_instance_count},
+      {"plane_runtime_health", frame.plane_runtime_health},
       {"instance_runtime", std::move(instance_runtime)},
       {"gpu", ToJson(frame.gpu)},
       {"network", ToJson(frame.network)},
@@ -399,9 +409,13 @@ json ToJson(const HostTelemetryFrame& frame) {
 HostTelemetryFrame HostTelemetryFrameFromJson(const json& value) {
   HostTelemetryFrame frame;
   frame.contract_version = value.value("contract_version", 1);
+  frame.schema_version = value.value("schema_version", std::string{"host.telemetry.v2"});
   frame.channel = value.value("channel", std::string{"host.telemetry.v1"});
+  frame.source = value.value("source", std::string{"hostd"});
   frame.node_name = value.value("node_name", std::string{});
+  frame.node_id = value.value("node_id", frame.node_name);
   frame.plane_name = value.value("plane_name", std::string{});
+  frame.plane_id = value.value("plane_id", frame.plane_name);
   frame.sampled_at = value.value("sampled_at", std::string{});
   frame.collected_at = value.value("collected_at", frame.sampled_at);
   frame.expires_at = value.value("expires_at", std::string{});
@@ -422,6 +436,21 @@ HostTelemetryFrame HostTelemetryFrameFromJson(const json& value) {
       frame.monotonic_ms = static_cast<std::uint64_t>(raw);
     }
   }
+  if (value.contains("monotonic_timestamp_ms") &&
+      value.at("monotonic_timestamp_ms").is_number_unsigned()) {
+    frame.monotonic_timestamp_ms =
+        value.at("monotonic_timestamp_ms").get<std::uint64_t>();
+  } else if (
+      value.contains("monotonic_timestamp_ms") &&
+      value.at("monotonic_timestamp_ms").is_number_integer()) {
+    const auto raw = value.at("monotonic_timestamp_ms").get<std::int64_t>();
+    if (raw > 0) {
+      frame.monotonic_timestamp_ms = static_cast<std::uint64_t>(raw);
+    }
+  }
+  if (frame.monotonic_timestamp_ms == 0) {
+    frame.monotonic_timestamp_ms = frame.monotonic_ms;
+  }
   frame.interval_ms = value.value("interval_ms", 2000);
   frame.ttl_ms = value.value("ttl_ms", 10000);
   frame.lane = value.value("lane", std::string{"fast"});
@@ -441,6 +470,13 @@ HostTelemetryFrame HostTelemetryFrameFromJson(const json& value) {
   frame.adaptive_interval_ms = value.value("adaptive_interval_ms", frame.interval_ms);
   frame.adaptive_reason = value.value("adaptive_reason", std::string{});
   frame.last_publish_error = value.value("last_publish_error", std::string{});
+  frame.plane_instance_count =
+      value.value("plane_instance_count", static_cast<std::uint64_t>(0));
+  frame.plane_ready_instance_count =
+      value.value("plane_ready_instance_count", static_cast<std::uint64_t>(0));
+  frame.plane_not_ready_instance_count =
+      value.value("plane_not_ready_instance_count", static_cast<std::uint64_t>(0));
+  frame.plane_runtime_health = value.value("plane_runtime_health", std::string{"unknown"});
   for (const auto& status : value.value("instance_runtime", json::array())) {
     if (status.is_object()) {
       frame.instance_runtime.push_back(RuntimeProcessStatusFromJson(status));
@@ -457,6 +493,18 @@ HostTelemetryFrame HostTelemetryFrameFromJson(const json& value) {
   }
   if (value.contains("disk") && value.at("disk").is_object()) {
     frame.disk = DiskTelemetrySnapshotFromJson(value.at("disk"));
+  }
+  if (frame.plane_instance_count == 0 && !frame.instance_runtime.empty()) {
+    frame.plane_instance_count = frame.instance_runtime.size();
+    for (const auto& status : frame.instance_runtime) {
+      if (status.ready) {
+        ++frame.plane_ready_instance_count;
+      }
+    }
+    frame.plane_not_ready_instance_count =
+        frame.plane_instance_count - frame.plane_ready_instance_count;
+    frame.plane_runtime_health =
+        frame.plane_not_ready_instance_count > 0 ? "changing" : "ready";
   }
   return frame;
 }

--- a/controller/include/telemetry/telemetry_live_store.h
+++ b/controller/include/telemetry/telemetry_live_store.h
@@ -14,6 +14,16 @@ namespace naim::controller {
 
 class TelemetryLiveStore final {
  public:
+  struct StreamDelta {
+    std::vector<naim::HostTelemetryFrame> frames;
+    bool replay_required = false;
+    std::string replay_reason;
+    std::uint64_t requested_sequence = 0;
+    std::uint64_t first_available_sequence = 0;
+    std::uint64_t latest_sequence = 0;
+    std::uint64_t dropped_frames_total = 0;
+  };
+
   static TelemetryLiveStore& Instance();
 
   bool Upsert(naim::HostTelemetryFrame frame);
@@ -21,6 +31,9 @@ class TelemetryLiveStore final {
       const std::optional<std::string>& plane_name,
       int history_seconds) const;
   std::vector<naim::HostTelemetryFrame> LoadFramesAfter(
+      std::uint64_t sequence,
+      const std::optional<std::string>& plane_name) const;
+  StreamDelta LoadStreamDeltaAfter(
       std::uint64_t sequence,
       const std::optional<std::string>& plane_name) const;
   std::uint64_t LatestSequence() const;
@@ -37,8 +50,25 @@ class TelemetryLiveStore final {
       const naim::HostTelemetryFrame& frame,
       const std::optional<std::string>& plane_name);
   static nlohmann::json FrameToJson(const naim::HostTelemetryFrame& frame);
+  static nlohmann::json BuildLatencyBreakdown(
+      const naim::HostTelemetryFrame& frame,
+      std::uint64_t controller_ingest_delay_ms);
+  static nlohmann::json BuildTelemetryHealth(
+      const naim::HostTelemetryFrame& frame,
+      const NodeBuffer& buffer,
+      std::uint64_t now_ms,
+      std::uint64_t controller_ingest_delay_ms);
+  static nlohmann::json BuildDownsampledHistory(
+      const std::vector<const NodeBuffer*>& buffers,
+      int history_seconds,
+      std::uint64_t now_ms);
+  static nlohmann::json BuildPlaneAggregates(
+      const std::vector<const NodeBuffer*>& buffers,
+      std::uint64_t now_ms);
   static constexpr std::size_t HistoryCapacity();
   static constexpr std::size_t StreamBatchLimit();
+  static constexpr std::uint64_t WarmBucketMs();
+  static constexpr std::uint64_t ColdBucketMs();
 
   mutable std::mutex mutex_;
   std::vector<NodeBuffer> nodes_;

--- a/controller/src/http/controller_http_server.cpp
+++ b/controller/src/http/controller_http_server.cpp
@@ -83,6 +83,12 @@ TelemetryStreamRequest ParseTelemetryStreamRequest(const HttpRequest& request) {
   stream_request.plane_name = FindQueryString(request, "plane");
   if (const auto since = FindQueryString(request, "since_sequence"); since.has_value()) {
     stream_request.last_sequence = static_cast<std::uint64_t>(std::stoull(*since));
+  } else {
+    const auto header_value =
+        ControllerHttpServerSupport::FindHeaderString(request, "last-event-id");
+    if (header_value.has_value()) {
+      stream_request.last_sequence = static_cast<std::uint64_t>(std::stoull(*header_value));
+    }
   }
   return stream_request;
 }
@@ -209,24 +215,61 @@ void ControllerHttpServer::StreamTelemetrySse(
     return;
   }
 
-  const auto snapshot = TelemetryLiveStore::Instance().BuildSnapshot(
-      stream_request.plane_name,
-      0);
-  if (!ControllerNetworkManager::SendSseEventFrame(
-          client_fd,
-          static_cast<int>(TelemetryLiveStore::Instance().LatestSequence() % 2147483647ULL),
-          "telemetry.snapshot",
-          snapshot.dump())) {
-    ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
-    return;
+  auto initial_delta = TelemetryLiveStore::Instance().LoadStreamDeltaAfter(
+      last_sequence,
+      stream_request.plane_name);
+  if (last_sequence == 0 || initial_delta.replay_required) {
+    auto snapshot = TelemetryLiveStore::Instance().BuildSnapshot(
+        stream_request.plane_name,
+        0);
+    snapshot["replay"] = nlohmann::json{
+        {"required", initial_delta.replay_required},
+        {"reason", initial_delta.replay_reason},
+        {"requested_sequence", initial_delta.requested_sequence},
+        {"first_available_sequence", initial_delta.first_available_sequence},
+        {"latest_sequence", initial_delta.latest_sequence},
+        {"dropped_frames_total", initial_delta.dropped_frames_total},
+    };
+    if (!ControllerNetworkManager::SendSseEventFrame(
+            client_fd,
+            static_cast<int>(TelemetryLiveStore::Instance().LatestSequence() % 2147483647ULL),
+            "telemetry.snapshot",
+            snapshot.dump())) {
+      ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+      return;
+    }
+    last_sequence = std::max(last_sequence, TelemetryLiveStore::Instance().LatestSequence());
   }
-  last_sequence = std::max(last_sequence, TelemetryLiveStore::Instance().LatestSequence());
 
   auto last_keepalive = std::chrono::steady_clock::now();
   while (!state->stop_requested.load()) {
-    const auto frames =
-        TelemetryLiveStore::Instance().LoadFramesAfter(last_sequence, stream_request.plane_name);
-    for (const auto& frame : frames) {
+    auto delta =
+        TelemetryLiveStore::Instance().LoadStreamDeltaAfter(last_sequence, stream_request.plane_name);
+    if (delta.replay_required) {
+      auto snapshot = TelemetryLiveStore::Instance().BuildSnapshot(
+          stream_request.plane_name,
+          0);
+      snapshot["replay"] = nlohmann::json{
+          {"required", true},
+          {"reason", delta.replay_reason},
+          {"requested_sequence", delta.requested_sequence},
+          {"first_available_sequence", delta.first_available_sequence},
+          {"latest_sequence", delta.latest_sequence},
+          {"dropped_frames_total", delta.dropped_frames_total},
+      };
+      if (!ControllerNetworkManager::SendSseEventFrame(
+              client_fd,
+              static_cast<int>(delta.latest_sequence % 2147483647ULL),
+              "telemetry.snapshot",
+              snapshot.dump())) {
+        ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+        return;
+      }
+      last_sequence = std::max(last_sequence, delta.latest_sequence);
+      last_keepalive = std::chrono::steady_clock::now();
+      continue;
+    }
+    for (const auto& frame : delta.frames) {
       const std::string payload = naim::SerializeHostTelemetryFrameJson(frame);
       if (!ControllerNetworkManager::SendSseEventFrame(
               client_fd,

--- a/controller/src/telemetry/telemetry_live_store.cpp
+++ b/controller/src/telemetry/telemetry_live_store.cpp
@@ -3,8 +3,39 @@
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <map>
 
 namespace naim::controller {
+namespace {
+
+std::uint64_t CurrentUnixMillis() {
+  const auto now = std::chrono::system_clock::now().time_since_epoch();
+  return static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
+}
+
+std::uint64_t ControllerIngestDelayMs(
+    const naim::HostTelemetryFrame& frame,
+    const std::uint64_t now_ms) {
+  return frame.sequence > 0 && now_ms >= frame.sequence ? now_ms - frame.sequence : 0;
+}
+
+std::string PlaneKeyForFrame(const naim::HostTelemetryFrame& frame) {
+  return frame.plane_name.empty() ? std::string{"unassigned"} : frame.plane_name;
+}
+
+double GpuUtilizationAverage(const naim::HostTelemetryFrame& frame) {
+  if (frame.gpu.devices.empty()) {
+    return 0.0;
+  }
+  double sum = 0.0;
+  for (const auto& device : frame.gpu.devices) {
+    sum += static_cast<double>(device.gpu_utilization_pct);
+  }
+  return sum / static_cast<double>(frame.gpu.devices.size());
+}
+
+}  // namespace
 
 TelemetryLiveStore& TelemetryLiveStore::Instance() {
   static TelemetryLiveStore store;
@@ -17,6 +48,21 @@ bool TelemetryLiveStore::Upsert(naim::HostTelemetryFrame frame) {
   }
   if (frame.channel.empty()) {
     frame.channel = "host.telemetry.v1";
+  }
+  if (frame.schema_version.empty()) {
+    frame.schema_version = "host.telemetry.v2";
+  }
+  if (frame.source.empty()) {
+    frame.source = "hostd";
+  }
+  if (frame.node_id.empty()) {
+    frame.node_id = frame.node_name;
+  }
+  if (frame.plane_id.empty()) {
+    frame.plane_id = frame.plane_name;
+  }
+  if (frame.monotonic_timestamp_ms == 0) {
+    frame.monotonic_timestamp_ms = frame.monotonic_ms;
   }
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = std::find_if(
@@ -51,13 +97,23 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
     const std::optional<std::string>& plane_name,
     const int history_seconds) const {
   std::lock_guard<std::mutex> lock(mutex_);
+  const auto now_ms = CurrentUnixMillis();
+  std::vector<const NodeBuffer*> matched_buffers;
   nlohmann::json nodes = nlohmann::json::array();
   nlohmann::json history = nlohmann::json::array();
   for (const auto& buffer : nodes_) {
     if (!MatchesPlane(buffer.latest, plane_name)) {
       continue;
     }
+    matched_buffers.push_back(&buffer);
     auto node = FrameToJson(buffer.latest);
+    const auto controller_ingest_delay_ms =
+        ControllerIngestDelayMs(buffer.latest, now_ms);
+    node["telemetry_health"] = BuildTelemetryHealth(
+        buffer.latest,
+        buffer,
+        now_ms,
+        controller_ingest_delay_ms);
     node["controller_dropped_frames_total"] = buffer.dropped_frames_total;
     node["controller_last_pruned_sequence"] = buffer.last_pruned_sequence;
     nodes.push_back(std::move(node));
@@ -72,16 +128,37 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
       history.push_back(FrameToJson(buffer.history[index]));
     }
   }
+  const bool overloaded = dropped_frames_total_ > 0;
   return nlohmann::json{
+      {"schema_version", "telemetry.snapshot.v2"},
       {"service", "naim-controller"},
+      {"transport", "sse-primary"},
+      {"delivery_mode", "streaming-first"},
       {"plane_name", plane_name.has_value() ? nlohmann::json(*plane_name) : nlohmann::json(nullptr)},
       {"latest_sequence", latest_sequence_},
-      {"telemetry_overloaded", dropped_frames_total_ > 0},
+      {"telemetry_overloaded", overloaded},
       {"dropped_frames_total", dropped_frames_total_},
       {"history_capacity", HistoryCapacity()},
       {"stream_batch_limit", StreamBatchLimit()},
+      {"retention",
+       nlohmann::json{
+           {"hot_history_capacity", HistoryCapacity()},
+           {"warm_bucket_ms", WarmBucketMs()},
+           {"cold_bucket_ms", ColdBucketMs()},
+       }},
+      {"telemetry_health",
+       nlohmann::json{
+           {"status", overloaded ? "overloaded" : "ok"},
+           {"last_frame_age_ms",
+            latest_sequence_ > 0 && now_ms >= latest_sequence_ ? now_ms - latest_sequence_ : 0},
+           {"dropped_frames_total", dropped_frames_total_},
+           {"stream_batch_limit", StreamBatchLimit()},
+       }},
+      {"planes", BuildPlaneAggregates(matched_buffers, now_ms)},
       {"nodes", std::move(nodes)},
       {"history", std::move(history)},
+      {"downsampled_history",
+       BuildDownsampledHistory(matched_buffers, history_seconds, now_ms)},
   };
 }
 
@@ -110,6 +187,53 @@ std::vector<naim::HostTelemetryFrame> TelemetryLiveStore::LoadFramesAfter(
   return frames;
 }
 
+TelemetryLiveStore::StreamDelta TelemetryLiveStore::LoadStreamDeltaAfter(
+    const std::uint64_t sequence,
+    const std::optional<std::string>& plane_name) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  StreamDelta delta;
+  delta.requested_sequence = sequence;
+  delta.latest_sequence = latest_sequence_;
+  delta.dropped_frames_total = dropped_frames_total_;
+  std::vector<naim::HostTelemetryFrame> frames;
+  std::uint64_t first_available = 0;
+  for (const auto& buffer : nodes_) {
+    if (!MatchesPlane(buffer.latest, plane_name)) {
+      continue;
+    }
+    if (!buffer.history.empty()) {
+      const auto node_first = buffer.history.front().sequence;
+      first_available = first_available == 0 ? node_first : std::min(first_available, node_first);
+      if (sequence > 0 && sequence < node_first && buffer.last_pruned_sequence > 0) {
+        delta.replay_required = true;
+        delta.replay_reason = "requested-sequence-pruned";
+      }
+    }
+    for (const auto& frame : buffer.history) {
+      if (frame.sequence > sequence) {
+        frames.push_back(frame);
+      }
+    }
+  }
+  delta.first_available_sequence = first_available;
+  std::sort(
+      frames.begin(),
+      frames.end(),
+      [](const auto& left, const auto& right) {
+        return left.sequence < right.sequence;
+      });
+  if (frames.size() > StreamBatchLimit()) {
+    delta.replay_required = true;
+    if (delta.replay_reason.empty()) {
+      delta.replay_reason = "stream-batch-truncated";
+    }
+    const auto erase_count = static_cast<std::ptrdiff_t>(frames.size() - StreamBatchLimit());
+    frames.erase(frames.begin(), frames.begin() + erase_count);
+  }
+  delta.frames = std::move(frames);
+  return delta;
+}
+
 std::uint64_t TelemetryLiveStore::LatestSequence() const {
   std::lock_guard<std::mutex> lock(mutex_);
   return latest_sequence_;
@@ -135,18 +259,247 @@ bool TelemetryLiveStore::MatchesPlane(
 nlohmann::json TelemetryLiveStore::FrameToJson(
     const naim::HostTelemetryFrame& frame) {
   auto payload = nlohmann::json::parse(naim::SerializeHostTelemetryFrameJson(frame));
-  const auto now = std::chrono::system_clock::now().time_since_epoch();
-  const auto now_ms = static_cast<std::uint64_t>(
-      std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
+  const auto now_ms = CurrentUnixMillis();
   const std::uint64_t ttl_ms =
       frame.ttl_ms > 0 ? static_cast<std::uint64_t>(frame.ttl_ms) : 0;
   const std::uint64_t expires_at_ms = frame.sequence + ttl_ms;
   const bool stale = frame.sequence == 0 || ttl_ms == 0 || expires_at_ms <= now_ms;
   payload["stale"] = stale;
   payload["expires_in_ms"] = stale ? 0 : expires_at_ms - now_ms;
-  payload["controller_ingest_delay_ms"] =
-      frame.sequence > 0 && now_ms >= frame.sequence ? now_ms - frame.sequence : 0;
+  const auto controller_ingest_delay_ms = ControllerIngestDelayMs(frame, now_ms);
+  payload["controller_ingest_delay_ms"] = controller_ingest_delay_ms;
+  payload["last_frame_age_ms"] = controller_ingest_delay_ms;
+  payload["telemetry_health_status"] =
+      stale ? "stale"
+            : frame.telemetry_dropped_frames > 0 || frame.publish_error_count > 0
+                ? "degraded"
+                : "ok";
+  payload["latency_breakdown"] = BuildLatencyBreakdown(frame, controller_ingest_delay_ms);
+  payload["transport"] = nlohmann::json{
+      {"primary", "sse"},
+      {"fallback", "snapshot-poll"},
+      {"sequence", frame.sequence},
+      {"schema_version", frame.schema_version},
+  };
   return payload;
+}
+
+nlohmann::json TelemetryLiveStore::BuildLatencyBreakdown(
+    const naim::HostTelemetryFrame& frame,
+    const std::uint64_t controller_ingest_delay_ms) {
+  const std::uint64_t total_observed_ms =
+      frame.collector_duration_ms + frame.publisher_queue_delay_ms +
+      frame.publish_duration_ms + controller_ingest_delay_ms;
+  return nlohmann::json{
+      {"collect_ms", frame.collector_duration_ms},
+      {"queue_ms", frame.publisher_queue_delay_ms},
+      {"publish_ms", frame.publish_duration_ms},
+      {"controller_ingest_ms", controller_ingest_delay_ms},
+      {"total_observed_ms", total_observed_ms},
+  };
+}
+
+nlohmann::json TelemetryLiveStore::BuildTelemetryHealth(
+    const naim::HostTelemetryFrame& frame,
+    const NodeBuffer& buffer,
+    const std::uint64_t now_ms,
+    const std::uint64_t controller_ingest_delay_ms) {
+  const std::uint64_t ttl_ms =
+      frame.ttl_ms > 0 ? static_cast<std::uint64_t>(frame.ttl_ms) : 0;
+  const bool stale =
+      frame.sequence == 0 || ttl_ms == 0 || frame.sequence + ttl_ms <= now_ms;
+  std::string status = "ok";
+  if (stale) {
+    status = "stale";
+  } else if (
+      buffer.dropped_frames_total > 0 || frame.telemetry_dropped_frames > 0 ||
+      frame.publish_error_count > 0 || !frame.degraded_reason.empty()) {
+    status = "degraded";
+  }
+  return nlohmann::json{
+      {"status", status},
+      {"last_frame_age_ms", controller_ingest_delay_ms},
+      {"dropped_frames_total", buffer.dropped_frames_total},
+      {"publish_error_count", frame.publish_error_count},
+      {"publish_error", frame.last_publish_error},
+      {"degraded_reason", frame.degraded_reason},
+  };
+}
+
+namespace {
+
+struct BucketAccumulator {
+  std::string node_name;
+  std::string plane_name;
+  std::uint64_t bucket_start_ms = 0;
+  std::uint64_t bucket_ms = 0;
+  std::uint64_t first_sequence = 0;
+  std::uint64_t last_sequence = 0;
+  std::uint64_t sample_count = 0;
+  double cpu_utilization_sum = 0.0;
+  double gpu_utilization_sum = 0.0;
+  double max_gpu_utilization_pct = 0.0;
+  std::uint64_t max_queue_delay_ms = 0;
+  std::uint64_t max_publish_ms = 0;
+  std::uint64_t max_controller_ingest_ms = 0;
+};
+
+}  // namespace
+
+nlohmann::json TelemetryLiveStore::BuildDownsampledHistory(
+    const std::vector<const NodeBuffer*>& buffers,
+    const int history_seconds,
+    const std::uint64_t now_ms) {
+  if (history_seconds <= 0) {
+    return nlohmann::json::array();
+  }
+  std::map<std::string, BucketAccumulator> buckets;
+  const std::uint64_t horizon_ms =
+      static_cast<std::uint64_t>(std::max(1, history_seconds)) * 1000ULL;
+  for (const auto* buffer : buffers) {
+    if (buffer == nullptr) {
+      continue;
+    }
+    for (const auto& frame : buffer->history) {
+      if (frame.sequence == 0 || now_ms > frame.sequence + horizon_ms) {
+        continue;
+      }
+      const std::uint64_t age_ms = now_ms >= frame.sequence ? now_ms - frame.sequence : 0;
+      const std::uint64_t bucket_ms = age_ms <= WarmBucketMs() ? WarmBucketMs() : ColdBucketMs();
+      const std::uint64_t bucket_start_ms = (frame.sequence / bucket_ms) * bucket_ms;
+      const auto key =
+          frame.node_name + "|" + PlaneKeyForFrame(frame) + "|" +
+          std::to_string(bucket_ms) + "|" + std::to_string(bucket_start_ms);
+      auto& bucket = buckets[key];
+      if (bucket.sample_count == 0) {
+        bucket.node_name = frame.node_name;
+        bucket.plane_name = PlaneKeyForFrame(frame);
+        bucket.bucket_start_ms = bucket_start_ms;
+        bucket.bucket_ms = bucket_ms;
+        bucket.first_sequence = frame.sequence;
+      }
+      bucket.last_sequence = std::max(bucket.last_sequence, frame.sequence);
+      bucket.sample_count += 1;
+      bucket.cpu_utilization_sum += frame.cpu.utilization_pct;
+      const double gpu_util = GpuUtilizationAverage(frame);
+      bucket.gpu_utilization_sum += gpu_util;
+      bucket.max_gpu_utilization_pct = std::max(bucket.max_gpu_utilization_pct, gpu_util);
+      bucket.max_queue_delay_ms =
+          std::max(bucket.max_queue_delay_ms, frame.publisher_queue_delay_ms);
+      bucket.max_publish_ms = std::max(bucket.max_publish_ms, frame.publish_duration_ms);
+      bucket.max_controller_ingest_ms = std::max(
+          bucket.max_controller_ingest_ms,
+          ControllerIngestDelayMs(frame, now_ms));
+    }
+  }
+  nlohmann::json result = nlohmann::json::array();
+  for (const auto& [_, bucket] : buckets) {
+    const double count = static_cast<double>(std::max<std::uint64_t>(1, bucket.sample_count));
+    result.push_back(nlohmann::json{
+        {"node_name", bucket.node_name},
+        {"plane_name", bucket.plane_name},
+        {"bucket_start_ms", bucket.bucket_start_ms},
+        {"bucket_ms", bucket.bucket_ms},
+        {"sample_count", bucket.sample_count},
+        {"first_sequence", bucket.first_sequence},
+        {"last_sequence", bucket.last_sequence},
+        {"avg_cpu_utilization_pct", bucket.cpu_utilization_sum / count},
+        {"avg_gpu_utilization_pct", bucket.gpu_utilization_sum / count},
+        {"max_gpu_utilization_pct", bucket.max_gpu_utilization_pct},
+        {"max_queue_delay_ms", bucket.max_queue_delay_ms},
+        {"max_publish_ms", bucket.max_publish_ms},
+        {"max_controller_ingest_ms", bucket.max_controller_ingest_ms},
+    });
+  }
+  return result;
+}
+
+nlohmann::json TelemetryLiveStore::BuildPlaneAggregates(
+    const std::vector<const NodeBuffer*>& buffers,
+    const std::uint64_t now_ms) {
+  struct PlaneAccumulator {
+    std::string plane_name;
+    std::uint64_t node_count = 0;
+    std::uint64_t stale_nodes = 0;
+    std::uint64_t degraded_nodes = 0;
+    std::uint64_t dropped_frames_total = 0;
+    std::uint64_t latest_sequence = 0;
+    std::uint64_t max_last_frame_age_ms = 0;
+    std::uint64_t max_queue_delay_ms = 0;
+    std::uint64_t max_publish_ms = 0;
+    std::uint64_t max_controller_ingest_ms = 0;
+    std::uint64_t gpu_count = 0;
+    std::uint64_t plane_instance_count = 0;
+    std::uint64_t plane_ready_instance_count = 0;
+    std::uint64_t plane_not_ready_instance_count = 0;
+    double gpu_utilization_sum = 0.0;
+  };
+  std::map<std::string, PlaneAccumulator> planes;
+  for (const auto* buffer : buffers) {
+    if (buffer == nullptr) {
+      continue;
+    }
+    const auto& frame = buffer->latest;
+    auto& plane = planes[PlaneKeyForFrame(frame)];
+    if (plane.plane_name.empty()) {
+      plane.plane_name = PlaneKeyForFrame(frame);
+    }
+    const auto ingest_ms = ControllerIngestDelayMs(frame, now_ms);
+    const auto health = BuildTelemetryHealth(frame, *buffer, now_ms, ingest_ms);
+    plane.node_count += 1;
+    plane.latest_sequence = std::max(plane.latest_sequence, frame.sequence);
+    plane.dropped_frames_total += buffer->dropped_frames_total;
+    plane.max_last_frame_age_ms = std::max(plane.max_last_frame_age_ms, ingest_ms);
+    plane.max_queue_delay_ms = std::max(plane.max_queue_delay_ms, frame.publisher_queue_delay_ms);
+    plane.max_publish_ms = std::max(plane.max_publish_ms, frame.publish_duration_ms);
+    plane.max_controller_ingest_ms = std::max(plane.max_controller_ingest_ms, ingest_ms);
+    plane.gpu_count += frame.gpu.devices.size();
+    plane.plane_instance_count += frame.plane_instance_count;
+    plane.plane_ready_instance_count += frame.plane_ready_instance_count;
+    plane.plane_not_ready_instance_count += frame.plane_not_ready_instance_count;
+    plane.gpu_utilization_sum += GpuUtilizationAverage(frame);
+    if (health.value("status", std::string{"ok"}) == "stale") {
+      plane.stale_nodes += 1;
+    } else if (health.value("status", std::string{"ok"}) == "degraded") {
+      plane.degraded_nodes += 1;
+    }
+  }
+  nlohmann::json result = nlohmann::json::array();
+  for (const auto& [_, plane] : planes) {
+    const bool overloaded = plane.dropped_frames_total > 0;
+    std::string status = "ok";
+    if (plane.stale_nodes > 0) {
+      status = "stale";
+    } else if (plane.degraded_nodes > 0 || overloaded) {
+      status = "degraded";
+    }
+    const double node_count = static_cast<double>(std::max<std::uint64_t>(1, plane.node_count));
+    result.push_back(nlohmann::json{
+        {"plane_name", plane.plane_name},
+        {"status", status},
+        {"node_count", plane.node_count},
+        {"stale_nodes", plane.stale_nodes},
+        {"degraded_nodes", plane.degraded_nodes},
+        {"dropped_frames_total", plane.dropped_frames_total},
+        {"latest_sequence", plane.latest_sequence},
+        {"max_last_frame_age_ms", plane.max_last_frame_age_ms},
+        {"latency",
+         nlohmann::json{
+             {"max_queue_delay_ms", plane.max_queue_delay_ms},
+             {"max_publish_ms", plane.max_publish_ms},
+             {"max_controller_ingest_ms", plane.max_controller_ingest_ms},
+         }},
+        {"gpu_count", plane.gpu_count},
+        {"runtime",
+         nlohmann::json{
+             {"instance_count", plane.plane_instance_count},
+             {"ready_instance_count", plane.plane_ready_instance_count},
+             {"not_ready_instance_count", plane.plane_not_ready_instance_count},
+         }},
+        {"avg_gpu_utilization_pct", plane.gpu_utilization_sum / node_count},
+    });
+  }
+  return result;
 }
 
 constexpr std::size_t TelemetryLiveStore::HistoryCapacity() {
@@ -155,6 +508,14 @@ constexpr std::size_t TelemetryLiveStore::HistoryCapacity() {
 
 constexpr std::size_t TelemetryLiveStore::StreamBatchLimit() {
   return 128;
+}
+
+constexpr std::uint64_t TelemetryLiveStore::WarmBucketMs() {
+  return 10000;
+}
+
+constexpr std::uint64_t TelemetryLiveStore::ColdBucketMs() {
+  return 60000;
 }
 
 }  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -24,12 +24,17 @@ naim::HostTelemetryFrame MakeFrame(
     std::uint64_t sequence) {
   naim::HostTelemetryFrame frame;
   frame.node_name = node_name;
+  frame.node_id = node_name;
   frame.plane_name = plane_name;
+  frame.plane_id = plane_name;
+  frame.schema_version = "host.telemetry.v2";
+  frame.source = "hostd";
   frame.sequence = sequence;
   frame.sampled_at = "2026-05-04 12:00:00";
   frame.collected_at = frame.sampled_at;
   frame.expires_at = "2026-05-04 12:00:10";
   frame.monotonic_ms = sequence;
+  frame.monotonic_timestamp_ms = sequence;
   frame.lane = "fast";
   frame.collector_duration_ms = 2;
   frame.publish_duration_ms = 3;
@@ -38,6 +43,10 @@ naim::HostTelemetryFrame MakeFrame(
   frame.telemetry_dropped_frames = 0;
   frame.adaptive_interval_ms = 2000;
   frame.adaptive_reason = "test";
+  frame.plane_instance_count = 2;
+  frame.plane_ready_instance_count = 1;
+  frame.plane_not_ready_instance_count = 1;
+  frame.plane_runtime_health = "changing";
   frame.cpu.source = "procfs";
   frame.cpu.total_memory_bytes = 100;
   frame.cpu.used_memory_bytes = 50;
@@ -86,6 +95,7 @@ void TestCoherenceFieldsAndStaleProjection() {
   auto fresh = MakeFrame("node-coherent", "plane-coherent", CurrentMillis());
   fresh.ttl_ms = 60000;
   fresh.monotonic_ms = 1234;
+  fresh.monotonic_timestamp_ms = 1234;
   fresh.lane = "full";
   fresh.degraded_reason = "cpu:procfs-warmup";
   fresh.disk.source = "hostd";
@@ -123,9 +133,25 @@ void TestCoherenceFieldsAndStaleProjection() {
   const auto snapshot = store.BuildSnapshot(std::string("plane-coherent"), 0);
   Expect(snapshot.at("nodes").size() == 1, "coherent snapshot should include one node");
   const auto node = snapshot.at("nodes").at(0);
+  Expect(
+      snapshot.at("schema_version").get<std::string>() == "telemetry.snapshot.v2",
+      "snapshot schema should be versioned");
+  Expect(
+      snapshot.at("transport").get<std::string>() == "sse-primary",
+      "snapshot should declare streaming transport");
+  Expect(snapshot.contains("planes"), "snapshot should include plane aggregates");
+  Expect(snapshot.contains("downsampled_history"), "snapshot should include downsampled history");
+  Expect(
+      node.at("schema_version").get<std::string>() == "host.telemetry.v2",
+      "frame schema should roundtrip");
+  Expect(node.at("source").get<std::string>() == "hostd", "source should roundtrip");
+  Expect(node.at("node_id").get<std::string>() == "node-coherent", "node_id should roundtrip");
   Expect(node.at("channel").get<std::string>() == "host.telemetry.v1", "channel should roundtrip");
   Expect(node.at("lane").get<std::string>() == "full", "lane should roundtrip");
   Expect(node.at("monotonic_ms").get<std::uint64_t>() == 1234, "monotonic_ms should roundtrip");
+  Expect(
+      node.at("monotonic_timestamp_ms").get<std::uint64_t>() == 1234,
+      "monotonic timestamp alias should roundtrip");
   Expect(
       node.at("collector_duration_ms").get<std::uint64_t>() == 2,
       "collector duration should roundtrip");
@@ -139,8 +165,16 @@ void TestCoherenceFieldsAndStaleProjection() {
       node.at("adaptive_reason").get<std::string>() == "test",
       "adaptive reason should roundtrip");
   Expect(
+      node.at("plane_runtime_health").get<std::string>() == "changing",
+      "plane runtime health should roundtrip");
+  Expect(
       node.contains("controller_ingest_delay_ms"),
       "controller ingest delay should be projected");
+  Expect(node.contains("latency_breakdown"), "latency breakdown should be projected");
+  Expect(node.contains("telemetry_health"), "telemetry health should be projected");
+  Expect(
+      node.at("telemetry_health").at("status").get<std::string>() == "degraded",
+      "degraded frame should project degraded health");
   Expect(
       node.at("degraded_reason").get<std::string>() == "cpu:procfs-warmup",
       "degraded reason should roundtrip");
@@ -179,7 +213,28 @@ void TestBackpressureProjection() {
   const auto frames = store.LoadFramesAfter(1000, std::string("plane-backpressure"));
   Expect(frames.size() == 128, "stream load should be capped");
   Expect(frames.front().sequence > 1000, "stream cap should retain newer frames");
+  const auto delta = store.LoadStreamDeltaAfter(1000, std::string("plane-backpressure"));
+  Expect(delta.replay_required, "stream delta should request replay after truncation");
+  Expect(delta.frames.size() == 128, "stream delta should be capped");
+  Expect(delta.first_available_sequence > 0, "stream delta should expose first available sequence");
   std::cout << "ok: telemetry-live-store-backpressure\n";
+}
+
+void TestPlaneAggregatesAndDownsampling() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  const auto now = CurrentMillis();
+  Expect(store.Upsert(MakeFrame("node-plane-agg-a", "plane-agg", now - 1000)), "agg a");
+  Expect(store.Upsert(MakeFrame("node-plane-agg-b", "plane-agg", now - 500)), "agg b");
+  const auto snapshot = store.BuildSnapshot(std::string("plane-agg"), 120);
+  Expect(!snapshot.at("planes").empty(), "snapshot should include plane aggregate");
+  const auto plane = snapshot.at("planes").at(0);
+  Expect(plane.at("plane_name").get<std::string>() == "plane-agg", "aggregate plane name");
+  Expect(plane.at("node_count").get<std::uint64_t>() == 2, "aggregate should count nodes");
+  Expect(
+      plane.at("runtime").at("instance_count").get<std::uint64_t>() == 4,
+      "aggregate should sum local runtime instances");
+  Expect(!snapshot.at("downsampled_history").empty(), "downsampled history should be populated");
+  std::cout << "ok: telemetry-live-store-plane-aggregates-downsampling\n";
 }
 
 }  // namespace
@@ -190,6 +245,7 @@ int main() {
     TestPlaneFilter();
     TestCoherenceFieldsAndStaleProjection();
     TestBackpressureProjection();
+    TestPlaneAggregatesAndDownsampling();
     return 0;
   } catch (const std::exception& error) {
     std::cerr << "telemetry_live_store_tests failed: " << error.what() << "\n";

--- a/hostd/src/app/hostd_observed_state_snapshot_builder.cpp
+++ b/hostd/src/app/hostd_observed_state_snapshot_builder.cpp
@@ -144,6 +144,8 @@ naim::HostTelemetryFrame HostdObservedStateSnapshotBuilder::BuildTelemetryFrame(
     const bool include_slow_lane) const {
   naim::HostTelemetryFrame frame;
   frame.node_name = node_name;
+  frame.node_id = node_name;
+  frame.source = "hostd";
   const auto sampled_at = std::chrono::system_clock::now();
   frame.sampled_at = TimestampString(sampled_at);
   frame.collected_at = frame.sampled_at;
@@ -151,6 +153,7 @@ naim::HostTelemetryFrame HostdObservedStateSnapshotBuilder::BuildTelemetryFrame(
       TimestampString(sampled_at + std::chrono::milliseconds(std::max(1, ttl_ms)));
   frame.sequence = CurrentSequenceMillis();
   frame.monotonic_ms = CurrentMonotonicMillis();
+  frame.monotonic_timestamp_ms = frame.monotonic_ms;
   frame.interval_ms = interval_ms;
   frame.ttl_ms = ttl_ms;
   frame.lane = include_slow_lane ? "full" : "fast";
@@ -158,12 +161,27 @@ naim::HostTelemetryFrame HostdObservedStateSnapshotBuilder::BuildTelemetryFrame(
   const auto local_state = local_state_repository_.LoadLocalAppliedState(state_root, node_name);
   if (local_state.has_value()) {
     frame.plane_name = local_state->plane_name;
+    frame.plane_id = local_state->plane_name;
   }
   const naim::DesiredState telemetry_state =
       local_state.has_value() ? *local_state : naim::DesiredState{};
   frame.instance_runtime =
       runtime_telemetry_support_.LoadLocalInstanceRuntimeStatuses(state_root, node_name);
   runtime_telemetry_support_.ResolveInstanceHostPids(&frame.instance_runtime);
+  frame.plane_instance_count = frame.instance_runtime.size();
+  for (const auto& runtime : frame.instance_runtime) {
+    if (runtime.ready) {
+      ++frame.plane_ready_instance_count;
+    }
+  }
+  frame.plane_not_ready_instance_count =
+      frame.plane_instance_count - frame.plane_ready_instance_count;
+  if (frame.plane_instance_count == 0) {
+    frame.plane_runtime_health = frame.plane_name.empty() ? "idle" : "no-runtime";
+  } else {
+    frame.plane_runtime_health =
+        frame.plane_not_ready_instance_count > 0 ? "changing" : "ready";
+  }
   frame.gpu = system_telemetry_collector_.CollectGpuTelemetry(
       telemetry_state,
       node_name,

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -53,6 +53,7 @@ import {
   summarizeKnowledgeGraph,
 } from "./knowledgeVault.js";
 import {
+  applyTelemetrySnapshotMetadata,
   createTelemetryStore,
   reduceTelemetryStore,
   selectTelemetryFrames,
@@ -1074,12 +1075,19 @@ function hostObservationFromTelemetryFrame(frame) {
     observed_at: frame.sampled_at || null,
     heartbeat_at: frame.sampled_at || null,
     telemetry_sequence: frame.sequence || 0,
+    telemetry_schema_version: frame.schema_version || "host.telemetry.v1",
+    telemetry_source: frame.source || "hostd",
+    telemetry_node_id: frame.node_id || frame.node_name,
+    telemetry_plane_id: frame.plane_id || frame.plane_name || "",
     telemetry_channel: frame.channel || "host.telemetry.v1",
     telemetry_lane: frame.lane || "fast",
     telemetry_monotonic_ms: frame.monotonic_ms || 0,
+    telemetry_monotonic_timestamp_ms: frame.monotonic_timestamp_ms || frame.monotonic_ms || 0,
     telemetry_expires_at: frame.expires_at || "",
     telemetry_expires_in_ms: frame.expires_in_ms ?? null,
     telemetry_stale: stale,
+    telemetry_health_status: frame?.telemetry_health?.status || frame?.telemetry_health_status || (stale ? "stale" : "ok"),
+    telemetry_last_frame_age_ms: Number(frame?.telemetry_health?.last_frame_age_ms ?? frame?.last_frame_age_ms ?? 0),
     telemetry_degraded: Boolean(frame?.degraded_reason),
     telemetry_degraded_reason: frame?.degraded_reason || "",
     telemetry_collector_duration_ms: Number(frame?.collector_duration_ms || 0),
@@ -1093,7 +1101,12 @@ function hostObservationFromTelemetryFrame(frame) {
     telemetry_adaptive_interval_ms: Number(frame?.adaptive_interval_ms || frame?.interval_ms || 0),
     telemetry_adaptive_reason: frame?.adaptive_reason || "",
     telemetry_controller_ingest_delay_ms: Number(frame?.controller_ingest_delay_ms || 0),
+    telemetry_latency_total_ms: Number(frame?.latency_breakdown?.total_observed_ms || 0),
     telemetry_last_publish_error: frame?.last_publish_error || "",
+    telemetry_plane_instance_count: Number(frame?.plane_instance_count || 0),
+    telemetry_plane_ready_instance_count: Number(frame?.plane_ready_instance_count || 0),
+    telemetry_plane_not_ready_instance_count: Number(frame?.plane_not_ready_instance_count || 0),
+    telemetry_plane_runtime_health: frame?.plane_runtime_health || "unknown",
     runtime_status: { available: instanceRuntime.length > 0 },
     instance_runtimes: {
       available: instanceRuntime.length > 0,
@@ -4005,13 +4018,26 @@ function App() {
         ),
       );
     };
+    const applySnapshotPayload = (payload) => {
+      globalTelemetryStoreRef.current = applyTelemetrySnapshotMetadata(
+        globalTelemetryStoreRef.current,
+        payload,
+      );
+      if (selectedPlaneRef.current) {
+        planeTelemetryStoreRef.current = applyTelemetrySnapshotMetadata(
+          planeTelemetryStoreRef.current,
+          payload,
+        );
+      }
+      applyFrames([...(payload?.history || []), ...(payload?.nodes || [])]);
+    };
 
     fetchJson(queryPath("/api/v1/telemetry/snapshot", { history_seconds: 120 }))
       .then((payload) => {
         if (stopped) {
           return;
         }
-        applyFrames([...(payload?.history || []), ...(payload?.nodes || [])]);
+        applySnapshotPayload(payload);
       })
       .catch((error) => {
         if (error?.status === 401) {
@@ -4022,6 +4048,9 @@ function App() {
     const source = new EventSource(
       queryPath("/api/v1/telemetry/stream", {
         plane: selectedPlane || undefined,
+        since_sequence: selectedPlane
+          ? planeTelemetryStoreRef.current?.latestSequence || undefined
+          : globalTelemetryStoreRef.current?.latestSequence || undefined,
       }),
     );
     telemetrySourceRef.current = source;
@@ -4036,7 +4065,7 @@ function App() {
     source.addEventListener("telemetry.snapshot", (event) => {
       try {
         const payload = JSON.parse(event.data || "{}");
-        applyFrames(payload.nodes || []);
+        applySnapshotPayload(payload);
       } catch (_) {
         setTelemetryHealthy(false);
       }
@@ -4066,6 +4095,10 @@ function App() {
       fetchJson(queryPath("/api/v1/telemetry/snapshot", { history_seconds: 0 }))
         .then((payload) => {
           const frames = Array.isArray(payload?.nodes) ? payload.nodes : [];
+          globalTelemetryStoreRef.current = applyTelemetrySnapshotMetadata(
+            globalTelemetryStoreRef.current,
+            payload,
+          );
           const globalResult = reduceTelemetryStore(globalTelemetryStoreRef.current, frames);
           if (!globalResult.changed && !selectedPlaneRef.current) {
             return;
@@ -4084,6 +4117,10 @@ function App() {
             setGlobalHostObservations(mergedGlobal);
           }
           if (selectedPlaneRef.current) {
+            planeTelemetryStoreRef.current = applyTelemetrySnapshotMetadata(
+              planeTelemetryStoreRef.current,
+              payload,
+            );
             const planeResult = reduceTelemetryStore(
               planeTelemetryStoreRef.current,
               frames,
@@ -5281,12 +5318,19 @@ function App() {
               <span className="subpanel-meta">Collector, bus, publisher, and controller timing.</span>
             </div>
             <div className="metric-grid">
+              <div className="metric-row"><span>Schema</span><strong>{host?.telemetry_schema_version || "n/a"}</strong></div>
+              <div className="metric-row"><span>Source</span><strong>{host?.telemetry_source || "n/a"}</strong></div>
+              <div className="metric-row"><span>Health</span><strong>{host?.telemetry_health_status || "n/a"}</strong></div>
+              <div className="metric-row"><span>Plane runtime</span><strong>{host?.telemetry_plane_runtime_health || "n/a"}</strong></div>
+              <div className="metric-row"><span>Plane ready</span><strong>{`${host?.telemetry_plane_ready_instance_count ?? 0}/${host?.telemetry_plane_instance_count ?? 0}`}</strong></div>
+              <div className="metric-row"><span>Frame age</span><strong>{host?.telemetry_last_frame_age_ms ? `${host.telemetry_last_frame_age_ms} ms` : "n/a"}</strong></div>
               <div className="metric-row"><span>Cadence</span><strong>{host?.telemetry_adaptive_interval_ms ? `${host.telemetry_adaptive_interval_ms} ms` : "n/a"}</strong></div>
               <div className="metric-row"><span>Cadence reason</span><strong>{host?.telemetry_adaptive_reason || "n/a"}</strong></div>
               <div className="metric-row"><span>Collect</span><strong>{host?.telemetry_collector_duration_ms ? `${host.telemetry_collector_duration_ms} ms` : "n/a"}</strong></div>
               <div className="metric-row"><span>Publish</span><strong>{host?.telemetry_publish_duration_ms ? `${host.telemetry_publish_duration_ms} ms` : "n/a"}</strong></div>
               <div className="metric-row"><span>Queue delay</span><strong>{host?.telemetry_queue_delay_ms ? `${host.telemetry_queue_delay_ms} ms` : "n/a"}</strong></div>
               <div className="metric-row"><span>Controller ingest</span><strong>{host?.telemetry_controller_ingest_delay_ms ? `${host.telemetry_controller_ingest_delay_ms} ms` : "n/a"}</strong></div>
+              <div className="metric-row"><span>Total observed</span><strong>{host?.telemetry_latency_total_ms ? `${host.telemetry_latency_total_ms} ms` : "n/a"}</strong></div>
               <div className="metric-row"><span>Bus depth</span><strong>{host?.telemetry_bus_depth ?? "n/a"}</strong></div>
               <div className="metric-row"><span>Dropped frames</span><strong>{host?.telemetry_dropped_frames ?? 0}</strong></div>
               <div className="metric-row"><span>Publish errors</span><strong>{host?.telemetry_publish_errors ?? 0}</strong></div>

--- a/ui/operator-react/src/telemetryStore.js
+++ b/ui/operator-react/src/telemetryStore.js
@@ -4,6 +4,9 @@ export function createTelemetryStore() {
     latestSequence: 0,
     droppedFramesTotal: 0,
     overloaded: false,
+    schemaVersion: "telemetry.store.v2",
+    lastReplayRequired: false,
+    lastReplayReason: "",
   };
 }
 
@@ -56,6 +59,9 @@ export function reduceTelemetryStore(store, frames, planeName = "") {
     Boolean(current.overloaded) ||
     acceptedFrames.some((frame) => frame?.telemetry_overloaded === true) ||
     droppedFramesTotal > 0;
+  const replayRequired =
+    Boolean(current.lastReplayRequired) ||
+    acceptedFrames.some((frame) => frame?.replay?.required === true);
 
   return {
     store: {
@@ -63,9 +69,31 @@ export function reduceTelemetryStore(store, frames, planeName = "") {
       latestSequence,
       droppedFramesTotal,
       overloaded,
+      schemaVersion: "telemetry.store.v2",
+      lastReplayRequired: replayRequired,
+      lastReplayReason: current.lastReplayReason || "",
     },
     acceptedFrames,
     changed: true,
+  };
+}
+
+export function applyTelemetrySnapshotMetadata(store, payload) {
+  const current = store || createTelemetryStore();
+  const replay = payload?.replay || {};
+  return {
+    ...current,
+    latestSequence: Math.max(
+      Number(current.latestSequence || 0),
+      Number(payload?.latest_sequence || replay?.latest_sequence || 0),
+    ),
+    droppedFramesTotal: Math.max(
+      Number(current.droppedFramesTotal || 0),
+      Number(payload?.dropped_frames_total || replay?.dropped_frames_total || 0),
+    ),
+    overloaded: Boolean(current.overloaded) || payload?.telemetry_overloaded === true,
+    lastReplayRequired: replay?.required === true,
+    lastReplayReason: replay?.reason || current.lastReplayReason || "",
   };
 }
 


### PR DESCRIPTION
## Summary
- add versioned host telemetry stream fields and source/node/plane aliases
- make telemetry SSE streaming-first with since_sequence replay and snapshot fallback on gaps
- expose telemetry health, latency breakdown, downsampled history, and plane aggregates
- add hostd plane-local runtime summary fields and WebUI pipeline display

## Checks
- cmake --build build/telemetry-debug --target naim-controller naim-node naim-hostd naim-telemetry-live-store-tests naim-hostd-reporting-support-tests naim-hostd-http-tests
- ./build/telemetry-debug/naim-telemetry-live-store-tests
- ./build/telemetry-debug/naim-hostd-reporting-support-tests
- ./build/telemetry-debug/naim-hostd-http-tests
- npm run build
- npm test
- hpc1 sandbox C++/UI checks
- hpc1 hostd smoke