### PR TITLE
Add durable telemetry health stream

### DIFF
--- a/controller/include/http/controller_http_server.h
+++ b/controller/include/http/controller_http_server.h
@@ -68,6 +68,12 @@ class ControllerHttpServer {
       SocketHandle client_fd,
       const HttpRequest& request,
       std::shared_ptr<SharedState> state);
+  static void StreamLiveSse(
+      SocketHandle client_fd,
+      const std::string& db_path,
+      const HttpRequest& request,
+      BuildEventPayloadItemFn build_event_payload_item,
+      std::shared_ptr<SharedState> state);
 
   Deps deps_;
 };

--- a/controller/include/telemetry/telemetry_live_store.h
+++ b/controller/include/telemetry/telemetry_live_store.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <deque>
 #include <mutex>
 #include <optional>
@@ -26,10 +27,17 @@ class TelemetryLiveStore final {
 
   static TelemetryLiveStore& Instance();
 
+  void ConfigurePersistence(
+      const std::string& db_path,
+      std::size_t retention_capacity = 9600);
+  void ResetForTests();
+
   bool Upsert(naim::HostTelemetryFrame frame);
   nlohmann::json BuildSnapshot(
       const std::optional<std::string>& plane_name,
       int history_seconds) const;
+  nlohmann::json BuildHealth(
+      const std::optional<std::string>& plane_name) const;
   std::vector<naim::HostTelemetryFrame> LoadFramesAfter(
       std::uint64_t sequence,
       const std::optional<std::string>& plane_name) const;
@@ -46,9 +54,34 @@ class TelemetryLiveStore final {
     std::uint64_t last_pruned_sequence = 0;
   };
 
+  struct PersistenceState {
+    bool enabled = false;
+    std::string db_path;
+    std::size_t retention_capacity = 0;
+    std::uint64_t loaded_frames_total = 0;
+    std::uint64_t persisted_frames_total = 0;
+    std::uint64_t pruned_frames_total = 0;
+    std::uint64_t error_count = 0;
+    std::string last_error;
+  };
+
   static bool MatchesPlane(
       const naim::HostTelemetryFrame& frame,
       const std::optional<std::string>& plane_name);
+  bool UpsertInMemoryLocked(naim::HostTelemetryFrame frame);
+  void ConfigurePersistenceLocked(
+      const std::string& db_path,
+      std::size_t retention_capacity);
+  void PersistFrameLocked(const naim::HostTelemetryFrame& frame);
+  std::vector<naim::HostTelemetryFrame> LoadPersistedFramesLocked(
+      const std::string& db_path,
+      std::size_t retention_capacity);
+  nlohmann::json BuildPersistenceStatusLocked() const;
+  static nlohmann::json BuildAlerts(
+      const std::vector<const NodeBuffer*>& buffers,
+      const PersistenceState& persistence,
+      std::uint64_t dropped_frames_total,
+      std::uint64_t now_ms);
   static nlohmann::json FrameToJson(const naim::HostTelemetryFrame& frame);
   static nlohmann::json BuildLatencyBreakdown(
       const naim::HostTelemetryFrame& frame,
@@ -69,11 +102,13 @@ class TelemetryLiveStore final {
   static constexpr std::size_t StreamBatchLimit();
   static constexpr std::uint64_t WarmBucketMs();
   static constexpr std::uint64_t ColdBucketMs();
+  static constexpr std::size_t DurableHistoryCapacity();
 
   mutable std::mutex mutex_;
   std::vector<NodeBuffer> nodes_;
   std::uint64_t latest_sequence_ = 0;
   std::uint64_t dropped_frames_total_ = 0;
+  PersistenceState persistence_;
 };
 
 }  // namespace naim::controller

--- a/controller/src/app/controller_route_summary_builder.cpp
+++ b/controller/src/app/controller_route_summary_builder.cpp
@@ -93,6 +93,8 @@ std::string ControllerRouteSummaryBuilder::BuildControllerRoutesSummary(
       "/api/v1/rebalance-plan",
       "/api/v1/events",
       "/api/v1/events/stream",
+      "/api/v1/live/stream",
+      "/api/v1/telemetry/health",
       "/api/v1/telemetry/snapshot",
       "/api/v1/telemetry/stream",
   });

--- a/controller/src/http/controller_http_router.cpp
+++ b/controller/src/http/controller_http_router.cpp
@@ -794,6 +794,12 @@ HttpResponse ControllerHttpRouter::HandleRequest(
         json{{"status", "method_not_allowed"}},
         {});
   }
+  if (request.path == "/api/v1/live/stream") {
+    return deps_.build_json_response(
+        405,
+        json{{"status", "method_not_allowed"}},
+        {});
+  }
   if (request.path == "/api/v1/telemetry/stream") {
     return deps_.build_json_response(
         405,

--- a/controller/src/http/controller_http_server.cpp
+++ b/controller/src/http/controller_http_server.cpp
@@ -322,6 +322,158 @@ void ControllerHttpServer::StreamTelemetrySse(
   ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
 }
 
+void ControllerHttpServer::StreamLiveSse(
+    const SocketHandle client_fd,
+    const std::string& db_path,
+    const HttpRequest& request,
+    const BuildEventPayloadItemFn build_event_payload_item,
+    std::shared_ptr<SharedState> state) {
+  const SseStreamRequest event_request = ParseSseStreamRequest(request);
+  const TelemetryStreamRequest telemetry_request = ParseTelemetryStreamRequest(request);
+  int last_event_id = event_request.last_event_id.value_or(0);
+  std::uint64_t last_sequence = telemetry_request.last_sequence;
+  if (!ControllerNetworkManager::SendSseHeaders(client_fd)) {
+    ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+    return;
+  }
+  if (!ControllerNetworkManager::SendSseCommentFrame(client_fd, " live connected")) {
+    ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+    return;
+  }
+
+  auto initial_delta = TelemetryLiveStore::Instance().LoadStreamDeltaAfter(
+      last_sequence,
+      telemetry_request.plane_name);
+  if (last_sequence == 0 || initial_delta.replay_required) {
+    auto snapshot = TelemetryLiveStore::Instance().BuildSnapshot(
+        telemetry_request.plane_name,
+        0);
+    snapshot["topic"] = "telemetry";
+    snapshot["replay"] = nlohmann::json{
+        {"required", initial_delta.replay_required},
+        {"reason", initial_delta.replay_reason},
+        {"requested_sequence", initial_delta.requested_sequence},
+        {"first_available_sequence", initial_delta.first_available_sequence},
+        {"latest_sequence", initial_delta.latest_sequence},
+        {"dropped_frames_total", initial_delta.dropped_frames_total},
+    };
+    if (!ControllerNetworkManager::SendSseEventFrame(
+            client_fd,
+            static_cast<int>(TelemetryLiveStore::Instance().LatestSequence() % 2147483647ULL),
+            "telemetry.snapshot",
+            snapshot.dump())) {
+      ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+      return;
+    }
+    last_sequence = std::max(last_sequence, TelemetryLiveStore::Instance().LatestSequence());
+  }
+
+  auto last_keepalive = std::chrono::steady_clock::now();
+  while (!state->stop_requested.load()) {
+    naim::ControllerStore store(db_path);
+    store.Initialize();
+    const auto events = store.LoadEvents(
+        event_request.plane_name,
+        event_request.node_name,
+        event_request.worker_name,
+        event_request.category,
+        event_request.limit,
+        last_event_id > 0 ? std::optional<int>(last_event_id) : std::nullopt,
+        true);
+    for (const auto& event : events) {
+      auto payload = build_event_payload_item(event);
+      payload["topic"] = "events";
+      if (!ControllerNetworkManager::SendSseEventFrame(
+              client_fd,
+              event.id,
+              "events." + BuildSseEventName(event),
+              payload.dump())) {
+        ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+        return;
+      }
+      last_event_id = std::max(last_event_id, event.id);
+      last_keepalive = std::chrono::steady_clock::now();
+    }
+
+    auto delta = TelemetryLiveStore::Instance().LoadStreamDeltaAfter(
+        last_sequence,
+        telemetry_request.plane_name);
+    if (delta.replay_required) {
+      auto snapshot = TelemetryLiveStore::Instance().BuildSnapshot(
+          telemetry_request.plane_name,
+          0);
+      snapshot["topic"] = "telemetry";
+      snapshot["replay"] = nlohmann::json{
+          {"required", true},
+          {"reason", delta.replay_reason},
+          {"requested_sequence", delta.requested_sequence},
+          {"first_available_sequence", delta.first_available_sequence},
+          {"latest_sequence", delta.latest_sequence},
+          {"dropped_frames_total", delta.dropped_frames_total},
+      };
+      if (!ControllerNetworkManager::SendSseEventFrame(
+              client_fd,
+              static_cast<int>(delta.latest_sequence % 2147483647ULL),
+              "telemetry.snapshot",
+              snapshot.dump())) {
+        ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+        return;
+      }
+      last_sequence = std::max(last_sequence, delta.latest_sequence);
+      last_keepalive = std::chrono::steady_clock::now();
+    }
+    for (const auto& frame : delta.frames) {
+      auto payload = nlohmann::json::parse(naim::SerializeHostTelemetryFrameJson(frame));
+      payload["topic"] = "telemetry";
+      if (!ControllerNetworkManager::SendSseEventFrame(
+              client_fd,
+              static_cast<int>(frame.sequence % 2147483647ULL),
+              "telemetry.node",
+              payload.dump())) {
+        ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+        return;
+      }
+      last_sequence = std::max(last_sequence, frame.sequence);
+      last_keepalive = std::chrono::steady_clock::now();
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if (now - last_keepalive >= std::chrono::seconds(5)) {
+      if (!ControllerNetworkManager::SendSseCommentFrame(client_fd, " live keepalive")) {
+        ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+        return;
+      }
+      last_keepalive = now;
+    }
+
+    naim::platform::PollFd fd_state{};
+    fd_state.fd = client_fd;
+    fd_state.events = POLLIN | POLLERR | POLLHUP;
+    const int poll_result = naim::platform::Poll(&fd_state, 1, 250);
+    if (poll_result < 0) {
+      if (naim::platform::LastSocketErrorWasInterrupted()) {
+        continue;
+      }
+      break;
+    }
+    if (poll_result == 0) {
+      continue;
+    }
+    if ((fd_state.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+      break;
+    }
+    if ((fd_state.revents & POLLIN) != 0) {
+      char scratch[1];
+      const ssize_t read_count = recv(client_fd, scratch, sizeof(scratch), MSG_PEEK);
+      if (read_count <= 0) {
+        break;
+      }
+    }
+  }
+
+  ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
+}
+
 int ControllerHttpServer::Serve(const Config& config) {
   auto state = std::make_shared<SharedState>();
   state->stop_requested.store(false);
@@ -329,6 +481,7 @@ int ControllerHttpServer::Serve(const Config& config) {
 
   naim::ControllerStore store(config.db_path);
   store.Initialize();
+  TelemetryLiveStore::Instance().ConfigurePersistence(config.db_path);
 
   const SocketHandle listen_fd = ControllerNetworkManager::CreateListenSocket(
       config.listen_host,
@@ -418,6 +571,23 @@ int ControllerHttpServer::Serve(const Config& config) {
            build_event_payload_item = deps_.build_event_payload_item,
            state]() {
             StreamEventsSse(
+                client_fd,
+                db_path,
+                request,
+                build_event_payload_item,
+                std::move(state));
+          })
+          .detach();
+      continue;
+    }
+    if (request.method == "GET" && request.path == "/api/v1/live/stream") {
+      std::thread(
+          [client_fd,
+           db_path = config.db_path,
+           request,
+           build_event_payload_item = deps_.build_event_payload_item,
+           state]() {
+            StreamLiveSse(
                 client_fd,
                 db_path,
                 request,

--- a/controller/src/read_model/read_model_http_service.cpp
+++ b/controller/src/read_model/read_model_http_service.cpp
@@ -88,6 +88,27 @@ std::optional<HttpResponse> ReadModelHttpService::HandleRequest(
     }
   }
 
+  if (request.path == "/api/v1/telemetry/health") {
+    if (request.method != "GET") {
+      return support_.build_json_response(
+          405, json{{"status", "method_not_allowed"}}, {});
+    }
+    try {
+      return support_.build_json_response(
+          200,
+          naim::controller::TelemetryLiveStore::Instance().BuildHealth(
+              support_.find_query_string(request, "plane")),
+          {});
+    } catch (const std::exception& error) {
+      return support_.build_json_response(
+          500,
+          json{{"status", "internal_error"},
+               {"message", error.what()},
+               {"path", request.path}},
+          {});
+    }
+  }
+
   if (request.path == "/api/v1/host-health") {
     if (request.method != "GET") {
       return support_.build_json_response(

--- a/controller/src/telemetry/telemetry_live_store.cpp
+++ b/controller/src/telemetry/telemetry_live_store.cpp
@@ -3,7 +3,14 @@
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <map>
+#include <stdexcept>
+
+#include <sqlite3.h>
+
+#include "naim/state/sqlite_statement.h"
 
 namespace naim::controller {
 namespace {
@@ -35,11 +42,90 @@ double GpuUtilizationAverage(const naim::HostTelemetryFrame& frame) {
   return sum / static_cast<double>(frame.gpu.devices.size());
 }
 
+void ExecuteSqlite(sqlite3* db, const std::string& sql) {
+  char* error_message = nullptr;
+  const int rc = sqlite3_exec(db, sql.c_str(), nullptr, nullptr, &error_message);
+  if (rc != SQLITE_OK) {
+    std::string message = error_message != nullptr ? error_message : sqlite3_errmsg(db);
+    sqlite3_free(error_message);
+    throw std::runtime_error("sqlite exec failed: " + message);
+  }
+}
+
+class SqliteConnection final {
+ public:
+  explicit SqliteConnection(const std::string& db_path) {
+    if (sqlite3_open_v2(
+            db_path.c_str(),
+            &db_,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
+            nullptr) != SQLITE_OK) {
+      std::string message = db_ != nullptr ? sqlite3_errmsg(db_) : "unknown";
+      if (db_ != nullptr) {
+        sqlite3_close(db_);
+      }
+      throw std::runtime_error("sqlite open failed: " + message);
+    }
+    sqlite3_busy_timeout(db_, 1000);
+  }
+
+  ~SqliteConnection() {
+    if (db_ != nullptr) {
+      sqlite3_close(db_);
+    }
+  }
+
+  sqlite3* get() const {
+    return db_;
+  }
+
+ private:
+  sqlite3* db_ = nullptr;
+};
+
+void EnsureTelemetryPersistenceSchema(sqlite3* db) {
+  ExecuteSqlite(
+      db,
+      "CREATE TABLE IF NOT EXISTS telemetry_ring_buffer ("
+      "sequence INTEGER PRIMARY KEY,"
+      "node_name TEXT NOT NULL,"
+      "plane_name TEXT,"
+      "schema_version TEXT NOT NULL,"
+      "sampled_at TEXT,"
+      "frame_json TEXT NOT NULL,"
+      "created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)");
+  ExecuteSqlite(
+      db,
+      "CREATE INDEX IF NOT EXISTS idx_telemetry_ring_buffer_plane_sequence "
+      "ON telemetry_ring_buffer(plane_name, sequence)");
+}
+
+std::int64_t SafeSequenceForSqlite(std::uint64_t sequence) {
+  return static_cast<std::int64_t>(std::min<std::uint64_t>(
+      sequence,
+      static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())));
+}
+
 }  // namespace
 
 TelemetryLiveStore& TelemetryLiveStore::Instance() {
   static TelemetryLiveStore store;
   return store;
+}
+
+void TelemetryLiveStore::ConfigurePersistence(
+    const std::string& db_path,
+    const std::size_t retention_capacity) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  ConfigurePersistenceLocked(db_path, retention_capacity);
+}
+
+void TelemetryLiveStore::ResetForTests() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  nodes_.clear();
+  latest_sequence_ = 0;
+  dropped_frames_total_ = 0;
+  persistence_ = PersistenceState{};
 }
 
 bool TelemetryLiveStore::Upsert(naim::HostTelemetryFrame frame) {
@@ -65,6 +151,14 @@ bool TelemetryLiveStore::Upsert(naim::HostTelemetryFrame frame) {
     frame.monotonic_timestamp_ms = frame.monotonic_ms;
   }
   std::lock_guard<std::mutex> lock(mutex_);
+  const bool updated = UpsertInMemoryLocked(frame);
+  if (updated) {
+    PersistFrameLocked(frame);
+  }
+  return updated;
+}
+
+bool TelemetryLiveStore::UpsertInMemoryLocked(naim::HostTelemetryFrame frame) {
   auto it = std::find_if(
       nodes_.begin(),
       nodes_.end(),
@@ -91,6 +185,99 @@ bool TelemetryLiveStore::Upsert(naim::HostTelemetryFrame frame) {
     }
   }
   return true;
+}
+
+void TelemetryLiveStore::ConfigurePersistenceLocked(
+    const std::string& db_path,
+    const std::size_t retention_capacity) {
+  persistence_.enabled = false;
+  persistence_.db_path = db_path;
+  persistence_.retention_capacity = std::max<std::size_t>(1, retention_capacity);
+  try {
+    const auto frames = LoadPersistedFramesLocked(db_path, persistence_.retention_capacity);
+    for (auto frame : frames) {
+      UpsertInMemoryLocked(std::move(frame));
+    }
+    persistence_.loaded_frames_total += frames.size();
+    persistence_.enabled = true;
+    persistence_.last_error.clear();
+  } catch (const std::exception& error) {
+    persistence_.error_count += 1;
+    persistence_.last_error = error.what();
+  }
+}
+
+void TelemetryLiveStore::PersistFrameLocked(const naim::HostTelemetryFrame& frame) {
+  if (!persistence_.enabled || persistence_.db_path.empty()) {
+    return;
+  }
+  try {
+    SqliteConnection connection(persistence_.db_path);
+    EnsureTelemetryPersistenceSchema(connection.get());
+    {
+      naim::SqliteStatement statement(
+          connection.get(),
+          "INSERT INTO telemetry_ring_buffer("
+          "sequence, node_name, plane_name, schema_version, sampled_at, frame_json) "
+          "VALUES(?, ?, ?, ?, ?, ?) "
+          "ON CONFLICT(sequence) DO UPDATE SET "
+          "node_name=excluded.node_name,"
+          "plane_name=excluded.plane_name,"
+          "schema_version=excluded.schema_version,"
+          "sampled_at=excluded.sampled_at,"
+          "frame_json=excluded.frame_json");
+      statement.BindInt64(1, SafeSequenceForSqlite(frame.sequence));
+      statement.BindText(2, frame.node_name);
+      statement.BindText(3, frame.plane_name);
+      statement.BindText(4, frame.schema_version);
+      statement.BindText(5, frame.sampled_at);
+      statement.BindText(6, naim::SerializeHostTelemetryFrameJson(frame));
+      statement.StepDone();
+    }
+    {
+      naim::SqliteStatement prune(
+          connection.get(),
+          "DELETE FROM telemetry_ring_buffer "
+          "WHERE sequence NOT IN ("
+          "SELECT sequence FROM telemetry_ring_buffer "
+          "ORDER BY sequence DESC LIMIT ?)");
+      prune.BindInt64(1, static_cast<std::int64_t>(persistence_.retention_capacity));
+      prune.StepDone();
+      const int changed = sqlite3_changes(connection.get());
+      if (changed > 0) {
+        persistence_.pruned_frames_total += static_cast<std::uint64_t>(changed);
+      }
+    }
+    persistence_.persisted_frames_total += 1;
+    persistence_.last_error.clear();
+  } catch (const std::exception& error) {
+    persistence_.error_count += 1;
+    persistence_.last_error = error.what();
+  }
+}
+
+std::vector<naim::HostTelemetryFrame> TelemetryLiveStore::LoadPersistedFramesLocked(
+    const std::string& db_path,
+    const std::size_t retention_capacity) {
+  SqliteConnection connection(db_path);
+  EnsureTelemetryPersistenceSchema(connection.get());
+  naim::SqliteStatement statement(
+      connection.get(),
+      "SELECT frame_json FROM telemetry_ring_buffer "
+      "ORDER BY sequence DESC LIMIT ?");
+  statement.BindInt64(1, static_cast<std::int64_t>(retention_capacity));
+  std::vector<std::string> payloads;
+  while (statement.StepRow()) {
+    const unsigned char* text = sqlite3_column_text(statement.raw(), 0);
+    if (text != nullptr) {
+      payloads.emplace_back(reinterpret_cast<const char*>(text));
+    }
+  }
+  std::vector<naim::HostTelemetryFrame> frames;
+  for (auto it = payloads.rbegin(); it != payloads.rend(); ++it) {
+    frames.push_back(naim::DeserializeHostTelemetryFrameJson(*it));
+  }
+  return frames;
 }
 
 nlohmann::json TelemetryLiveStore::BuildSnapshot(
@@ -129,6 +316,10 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
     }
   }
   const bool overloaded = dropped_frames_total_ > 0;
+  const auto alerts =
+      BuildAlerts(matched_buffers, persistence_, dropped_frames_total_, now_ms);
+  const std::string status =
+      !alerts.empty() ? "degraded" : overloaded ? "overloaded" : "ok";
   return nlohmann::json{
       {"schema_version", "telemetry.snapshot.v2"},
       {"service", "naim-controller"},
@@ -140,15 +331,18 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
       {"dropped_frames_total", dropped_frames_total_},
       {"history_capacity", HistoryCapacity()},
       {"stream_batch_limit", StreamBatchLimit()},
+      {"persistence", BuildPersistenceStatusLocked()},
+      {"alerts", alerts},
       {"retention",
        nlohmann::json{
            {"hot_history_capacity", HistoryCapacity()},
+           {"durable_history_capacity", persistence_.retention_capacity},
            {"warm_bucket_ms", WarmBucketMs()},
            {"cold_bucket_ms", ColdBucketMs()},
        }},
       {"telemetry_health",
        nlohmann::json{
-           {"status", overloaded ? "overloaded" : "ok"},
+           {"status", status},
            {"last_frame_age_ms",
             latest_sequence_ > 0 && now_ms >= latest_sequence_ ? now_ms - latest_sequence_ : 0},
            {"dropped_frames_total", dropped_frames_total_},
@@ -159,6 +353,52 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
       {"history", std::move(history)},
       {"downsampled_history",
        BuildDownsampledHistory(matched_buffers, history_seconds, now_ms)},
+  };
+}
+
+nlohmann::json TelemetryLiveStore::BuildHealth(
+    const std::optional<std::string>& plane_name) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto now_ms = CurrentUnixMillis();
+  std::vector<const NodeBuffer*> matched_buffers;
+  for (const auto& buffer : nodes_) {
+    if (MatchesPlane(buffer.latest, plane_name)) {
+      matched_buffers.push_back(&buffer);
+    }
+  }
+  const auto alerts =
+      BuildAlerts(matched_buffers, persistence_, dropped_frames_total_, now_ms);
+  std::string status = "ok";
+  if (!alerts.empty()) {
+    status = "degraded";
+    for (const auto& alert : alerts) {
+      if (alert.value("severity", std::string{}) == "critical") {
+        status = "critical";
+        break;
+      }
+    }
+  }
+  return nlohmann::json{
+      {"schema_version", "telemetry.health.v1"},
+      {"service", "naim-controller"},
+      {"plane_name", plane_name.has_value() ? nlohmann::json(*plane_name) : nlohmann::json(nullptr)},
+      {"status", status},
+      {"observed_nodes", matched_buffers.size()},
+      {"latest_sequence", latest_sequence_},
+      {"last_frame_age_ms",
+       latest_sequence_ > 0 && now_ms >= latest_sequence_ ? now_ms - latest_sequence_ : 0},
+      {"dropped_frames_total", dropped_frames_total_},
+      {"stream_batch_limit", StreamBatchLimit()},
+      {"retention",
+       nlohmann::json{
+           {"hot_history_capacity", HistoryCapacity()},
+           {"durable_history_capacity", persistence_.retention_capacity},
+           {"warm_bucket_ms", WarmBucketMs()},
+           {"cold_bucket_ms", ColdBucketMs()},
+       }},
+      {"persistence", BuildPersistenceStatusLocked()},
+      {"planes", BuildPlaneAggregates(matched_buffers, now_ms)},
+      {"alerts", alerts},
   };
 }
 
@@ -254,6 +494,109 @@ bool TelemetryLiveStore::MatchesPlane(
       [&](const naim::RuntimeProcessStatus& status) {
         return status.instance_name.rfind(*plane_name + "-", 0) == 0;
       });
+}
+
+nlohmann::json TelemetryLiveStore::BuildPersistenceStatusLocked() const {
+  return nlohmann::json{
+      {"enabled", persistence_.enabled},
+      {"backend", persistence_.enabled ? "sqlite" : "memory"},
+      {"db_path", persistence_.db_path},
+      {"retention_capacity", persistence_.retention_capacity},
+      {"loaded_frames_total", persistence_.loaded_frames_total},
+      {"persisted_frames_total", persistence_.persisted_frames_total},
+      {"pruned_frames_total", persistence_.pruned_frames_total},
+      {"error_count", persistence_.error_count},
+      {"last_error", persistence_.last_error},
+  };
+}
+
+nlohmann::json TelemetryLiveStore::BuildAlerts(
+    const std::vector<const NodeBuffer*>& buffers,
+    const PersistenceState& persistence,
+    const std::uint64_t dropped_frames_total,
+    const std::uint64_t now_ms) {
+  nlohmann::json alerts = nlohmann::json::array();
+  constexpr std::uint64_t stale_warn_ms = 15000;
+  constexpr std::uint64_t stale_critical_ms = 60000;
+  constexpr std::uint64_t ingest_warn_ms = 3000;
+  constexpr std::uint64_t queue_warn_ms = 1000;
+  if (!persistence.enabled) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.persistence.disabled"},
+        {"severity", "warning"},
+        {"message", "sqlite telemetry ring buffer is disabled"},
+    });
+  }
+  if (persistence.error_count > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.persistence.errors"},
+        {"severity", "warning"},
+        {"message", "sqlite telemetry ring buffer reported errors"},
+        {"count", persistence.error_count},
+        {"last_error", persistence.last_error},
+    });
+  }
+  if (dropped_frames_total > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.controller.dropped_frames"},
+        {"severity", "warning"},
+        {"message", "controller telemetry ring buffer pruned live frames"},
+        {"count", dropped_frames_total},
+    });
+  }
+  for (const auto* buffer : buffers) {
+    if (buffer == nullptr) {
+      continue;
+    }
+    const auto& frame = buffer->latest;
+    const auto ingest_ms = ControllerIngestDelayMs(frame, now_ms);
+    if (ingest_ms >= stale_critical_ms) {
+      alerts.push_back(nlohmann::json{
+          {"code", "telemetry.node.stale"},
+          {"severity", "critical"},
+          {"node_name", frame.node_name},
+          {"plane_name", PlaneKeyForFrame(frame)},
+          {"age_ms", ingest_ms},
+      });
+    } else if (ingest_ms >= stale_warn_ms) {
+      alerts.push_back(nlohmann::json{
+          {"code", "telemetry.node.slow"},
+          {"severity", "warning"},
+          {"node_name", frame.node_name},
+          {"plane_name", PlaneKeyForFrame(frame)},
+          {"age_ms", ingest_ms},
+      });
+    }
+    if (ingest_ms >= ingest_warn_ms) {
+      alerts.push_back(nlohmann::json{
+          {"code", "telemetry.controller.ingest_delay"},
+          {"severity", "warning"},
+          {"node_name", frame.node_name},
+          {"plane_name", PlaneKeyForFrame(frame)},
+          {"delay_ms", ingest_ms},
+      });
+    }
+    if (frame.publisher_queue_delay_ms >= queue_warn_ms) {
+      alerts.push_back(nlohmann::json{
+          {"code", "telemetry.publisher.queue_delay"},
+          {"severity", "warning"},
+          {"node_name", frame.node_name},
+          {"plane_name", PlaneKeyForFrame(frame)},
+          {"delay_ms", frame.publisher_queue_delay_ms},
+      });
+    }
+    if (frame.publish_error_count > 0) {
+      alerts.push_back(nlohmann::json{
+          {"code", "telemetry.publisher.errors"},
+          {"severity", "warning"},
+          {"node_name", frame.node_name},
+          {"plane_name", PlaneKeyForFrame(frame)},
+          {"count", frame.publish_error_count},
+          {"last_error", frame.last_publish_error},
+      });
+    }
+  }
+  return alerts;
 }
 
 nlohmann::json TelemetryLiveStore::FrameToJson(
@@ -516,6 +859,10 @@ constexpr std::uint64_t TelemetryLiveStore::WarmBucketMs() {
 
 constexpr std::uint64_t TelemetryLiveStore::ColdBucketMs() {
   return 60000;
+}
+
+constexpr std::size_t TelemetryLiveStore::DurableHistoryCapacity() {
+  return 9600;
 }
 
 }  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -1,6 +1,7 @@
 #include "telemetry/telemetry_live_store.h"
 
 #include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <stdexcept>
 
@@ -237,6 +238,42 @@ void TestPlaneAggregatesAndDownsampling() {
   std::cout << "ok: telemetry-live-store-plane-aggregates-downsampling\n";
 }
 
+void TestSqlitePersistenceReplayAndHealth() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  const auto db_path =
+      std::filesystem::temp_directory_path() /
+      ("naim-telemetry-live-store-" + std::to_string(CurrentMillis()) + ".sqlite");
+  store.ResetForTests();
+  store.ConfigurePersistence(db_path.string(), 4);
+  Expect(store.Upsert(MakeFrame("node-durable", "plane-durable", 4000)), "durable frame one");
+  Expect(store.Upsert(MakeFrame("node-durable", "plane-durable", 4001)), "durable frame two");
+
+  const auto before = store.BuildHealth(std::string("plane-durable"));
+  Expect(
+      before.at("persistence").at("enabled").get<bool>(),
+      "sqlite persistence should be enabled");
+  Expect(
+      before.at("persistence").at("persisted_frames_total").get<std::uint64_t>() == 2,
+      "sqlite persistence should count persisted frames");
+
+  store.ResetForTests();
+  store.ConfigurePersistence(db_path.string(), 4);
+  const auto snapshot = store.BuildSnapshot(std::string("plane-durable"), 60);
+  Expect(snapshot.at("nodes").size() == 1, "durable replay should restore latest node");
+  Expect(
+      snapshot.at("latest_sequence").get<std::uint64_t>() == 4001,
+      "durable replay should restore latest sequence");
+  Expect(
+      snapshot.at("persistence").at("loaded_frames_total").get<std::uint64_t>() == 2,
+      "durable replay should count loaded frames");
+  const auto frames = store.LoadFramesAfter(0, std::string("plane-durable"));
+  Expect(frames.size() == 2, "durable replay should restore stream history");
+
+  std::filesystem::remove(db_path);
+  store.ResetForTests();
+  std::cout << "ok: telemetry-live-store-sqlite-persistence-health\n";
+}
+
 }  // namespace
 
 int main() {
@@ -246,6 +283,7 @@ int main() {
     TestCoherenceFieldsAndStaleProjection();
     TestBackpressureProjection();
     TestPlaneAggregatesAndDownsampling();
+    TestSqlitePersistenceReplayAndHealth();
     return 0;
   } catch (const std::exception& error) {
     std::cerr << "telemetry_live_store_tests failed: " << error.what() << "\n";

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -55,8 +55,10 @@ import {
 import {
   applyTelemetrySnapshotMetadata,
   createTelemetryStore,
+  enrichTelemetryFrames,
   reduceTelemetryStore,
   selectTelemetryFrames,
+  updateTelemetryBrowserLatency,
 } from "./telemetryStore.js";
 
 const REFRESH_DEBOUNCE_MS = 350;
@@ -1102,6 +1104,8 @@ function hostObservationFromTelemetryFrame(frame) {
     telemetry_adaptive_reason: frame?.adaptive_reason || "",
     telemetry_controller_ingest_delay_ms: Number(frame?.controller_ingest_delay_ms || 0),
     telemetry_latency_total_ms: Number(frame?.latency_breakdown?.total_observed_ms || 0),
+    telemetry_browser_receive_delay_ms: Number(frame?.telemetry_browser_receive_delay_ms || 0),
+    telemetry_browser_parse_ms: Number(frame?.telemetry_browser_parse_ms || 0),
     telemetry_last_publish_error: frame?.last_publish_error || "",
     telemetry_plane_instance_count: Number(frame?.plane_instance_count || 0),
     telemetry_plane_ready_instance_count: Number(frame?.plane_ready_instance_count || 0),
@@ -3914,48 +3918,13 @@ function App() {
   }, [authState.authenticated, hasActiveModelJobsForPolling, selectedPage]);
 
   useEffect(() => {
-    if (!authState.authenticated) {
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
-        eventSourceRef.current = null;
-      }
-      setStreamHealthy(false);
-      return;
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
     }
-
-    const source = new EventSource(
-      queryPath("/api/v1/events/stream", {
-        limit: EVENT_LIMIT,
-      }),
-    );
-    eventSourceRef.current = source;
     setStreamHealthy(false);
-
-    source.onopen = () => {
-      setStreamHealthy(true);
-    };
-    source.onerror = () => {
-      setStreamHealthy(false);
-    };
-    const handleRefreshEvent = (event) => {
-      setLastEventName(event.type || "message");
-      scheduleRefresh(selectedPlane);
-    };
-    source.onmessage = handleRefreshEvent;
-    for (const eventName of REFRESH_EVENT_NAMES) {
-      source.addEventListener(eventName, handleRefreshEvent);
-    }
-
-    return () => {
-      for (const eventName of REFRESH_EVENT_NAMES) {
-        source.removeEventListener(eventName, handleRefreshEvent);
-      }
-      source.close();
-      if (eventSourceRef.current === source) {
-        eventSourceRef.current = null;
-      }
-    };
-  }, [authState.authenticated, selectedPlane]);
+    return undefined;
+  }, [authState.authenticated]);
 
   useEffect(() => {
     if (!authState.authenticated) {
@@ -3968,12 +3937,16 @@ function App() {
     }
 
     let stopped = false;
-    const applyFrames = (frames) => {
-      const validFrames = (frames || []).filter((frame) => frame?.node_name);
+    const applyFrames = (frames, parseMs = 0) => {
+      const applyStartedAt = performance.now();
+      const receivedAtMs = Date.now();
+      const validFrames = enrichTelemetryFrames(frames, receivedAtMs, parseMs);
       if (validFrames.length === 0) {
         return;
       }
+      const reduceStartedAt = performance.now();
       const globalResult = reduceTelemetryStore(globalTelemetryStoreRef.current, validFrames);
+      const reduceMs = performance.now() - reduceStartedAt;
       if (globalResult.changed) {
         globalTelemetryStoreRef.current = globalResult.store;
       }
@@ -3989,11 +3962,13 @@ function App() {
         setGlobalHostObservations(mergedGlobal);
       }
       if (selectedPlaneRef.current) {
+        const planeReduceStartedAt = performance.now();
         const planeResult = reduceTelemetryStore(
           planeTelemetryStoreRef.current,
           validFrames,
           selectedPlaneRef.current,
         );
+        const planeReduceMs = performance.now() - planeReduceStartedAt;
         if (planeResult.changed) {
           planeTelemetryStoreRef.current = planeResult.store;
         }
@@ -4004,7 +3979,35 @@ function App() {
             selectedPlaneRef.current,
           ),
         );
+        planeTelemetryStoreRef.current = updateTelemetryBrowserLatency(
+          planeTelemetryStoreRef.current,
+          {
+            receivedAtMs,
+            receiveDelayMs: Math.max(
+              0,
+              ...validFrames.map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
+            ),
+            parseMs,
+            reduceMs: planeReduceMs,
+            applyMs: performance.now() - applyStartedAt,
+            acceptedFrames: planeResult.acceptedFrames.length,
+          },
+        );
       }
+      globalTelemetryStoreRef.current = updateTelemetryBrowserLatency(
+        globalTelemetryStoreRef.current,
+        {
+          receivedAtMs,
+          receiveDelayMs: Math.max(
+            0,
+            ...validFrames.map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
+          ),
+          parseMs,
+          reduceMs,
+          applyMs: performance.now() - applyStartedAt,
+          acceptedFrames: globalResult.acceptedFrames.length,
+        },
+      );
       if (!globalChanged) {
         return;
       }
@@ -4029,7 +4032,10 @@ function App() {
           payload,
         );
       }
-      applyFrames([...(payload?.history || []), ...(payload?.nodes || [])]);
+      applyFrames(
+        [...(payload?.history || []), ...(payload?.nodes || [])],
+        Number(payload?.__telemetry_browser_parse_ms || 0),
+      );
     };
 
     fetchJson(queryPath("/api/v1/telemetry/snapshot", { history_seconds: 120 }))
@@ -4046,7 +4052,8 @@ function App() {
       });
 
     const source = new EventSource(
-      queryPath("/api/v1/telemetry/stream", {
+      queryPath("/api/v1/live/stream", {
+        limit: EVENT_LIMIT,
         plane: selectedPlane || undefined,
         since_sequence: selectedPlane
           ? planeTelemetryStoreRef.current?.latestSequence || undefined
@@ -4055,16 +4062,29 @@ function App() {
     );
     telemetrySourceRef.current = source;
     setTelemetryHealthy(false);
+    setStreamHealthy(false);
 
     source.onopen = () => {
       setTelemetryHealthy(true);
+      setStreamHealthy(true);
     };
     source.onerror = () => {
       setTelemetryHealthy(false);
+      setStreamHealthy(false);
     };
+    const handleRefreshEvent = (event) => {
+      setLastEventName((event.type || "message").replace(/^events\./, ""));
+      scheduleRefresh(selectedPlaneRef.current);
+    };
+    for (const eventName of REFRESH_EVENT_NAMES) {
+      source.addEventListener(`events.${eventName}`, handleRefreshEvent);
+    }
     source.addEventListener("telemetry.snapshot", (event) => {
       try {
+        const parseStartedAt = performance.now();
         const payload = JSON.parse(event.data || "{}");
+        const parseMs = performance.now() - parseStartedAt;
+        payload.__telemetry_browser_parse_ms = parseMs;
         applySnapshotPayload(payload);
       } catch (_) {
         setTelemetryHealthy(false);
@@ -4072,13 +4092,18 @@ function App() {
     });
     source.addEventListener("telemetry.node", (event) => {
       try {
-        applyFrames([JSON.parse(event.data || "{}")]);
+        const parseStartedAt = performance.now();
+        const frame = JSON.parse(event.data || "{}");
+        applyFrames([frame], performance.now() - parseStartedAt);
       } catch (_) {
         setTelemetryHealthy(false);
       }
     });
 
     return () => {
+      for (const eventName of REFRESH_EVENT_NAMES) {
+        source.removeEventListener(`events.${eventName}`, handleRefreshEvent);
+      }
       stopped = true;
       source.close();
       if (telemetrySourceRef.current === source) {
@@ -4116,6 +4141,20 @@ function App() {
             globalHostObservationsRef.current = mergedGlobal;
             setGlobalHostObservations(mergedGlobal);
           }
+          globalTelemetryStoreRef.current = updateTelemetryBrowserLatency(
+            globalTelemetryStoreRef.current,
+            {
+              receivedAtMs: Date.now(),
+              receiveDelayMs: Math.max(
+                0,
+                ...frames.map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
+              ),
+              parseMs: 0,
+              reduceMs: 0,
+              applyMs: 0,
+              acceptedFrames: globalResult.acceptedFrames.length,
+            },
+          );
           if (selectedPlaneRef.current) {
             planeTelemetryStoreRef.current = applyTelemetrySnapshotMetadata(
               planeTelemetryStoreRef.current,
@@ -5331,6 +5370,8 @@ function App() {
               <div className="metric-row"><span>Queue delay</span><strong>{host?.telemetry_queue_delay_ms ? `${host.telemetry_queue_delay_ms} ms` : "n/a"}</strong></div>
               <div className="metric-row"><span>Controller ingest</span><strong>{host?.telemetry_controller_ingest_delay_ms ? `${host.telemetry_controller_ingest_delay_ms} ms` : "n/a"}</strong></div>
               <div className="metric-row"><span>Total observed</span><strong>{host?.telemetry_latency_total_ms ? `${host.telemetry_latency_total_ms} ms` : "n/a"}</strong></div>
+              <div className="metric-row"><span>Browser receive</span><strong>{host?.telemetry_browser_receive_delay_ms ? `${host.telemetry_browser_receive_delay_ms} ms` : "n/a"}</strong></div>
+              <div className="metric-row"><span>Browser parse</span><strong>{host?.telemetry_browser_parse_ms ? `${host.telemetry_browser_parse_ms.toFixed(1)} ms` : "n/a"}</strong></div>
               <div className="metric-row"><span>Bus depth</span><strong>{host?.telemetry_bus_depth ?? "n/a"}</strong></div>
               <div className="metric-row"><span>Dropped frames</span><strong>{host?.telemetry_dropped_frames ?? 0}</strong></div>
               <div className="metric-row"><span>Publish errors</span><strong>{host?.telemetry_publish_errors ?? 0}</strong></div>

--- a/ui/operator-react/src/telemetryStore.js
+++ b/ui/operator-react/src/telemetryStore.js
@@ -7,6 +7,14 @@ export function createTelemetryStore() {
     schemaVersion: "telemetry.store.v2",
     lastReplayRequired: false,
     lastReplayReason: "",
+    browserLatency: {
+      receivedAtMs: 0,
+      receiveDelayMs: 0,
+      parseMs: 0,
+      reduceMs: 0,
+      applyMs: 0,
+      acceptedFrames: 0,
+    },
   };
 }
 
@@ -72,9 +80,36 @@ export function reduceTelemetryStore(store, frames, planeName = "") {
       schemaVersion: "telemetry.store.v2",
       lastReplayRequired: replayRequired,
       lastReplayReason: current.lastReplayReason || "",
+      browserLatency: current.browserLatency || createTelemetryStore().browserLatency,
     },
     acceptedFrames,
     changed: true,
+  };
+}
+
+export function enrichTelemetryFrames(frames, receivedAtMs = Date.now(), parseMs = 0) {
+  return (frames || [])
+    .filter((frame) => frame?.node_name)
+    .map((frame) => {
+      const sequence = Number(frame?.sequence || 0);
+      return {
+        ...frame,
+        telemetry_browser_received_at_ms: receivedAtMs,
+        telemetry_browser_receive_delay_ms:
+          sequence > 0 && receivedAtMs >= sequence ? receivedAtMs - sequence : 0,
+        telemetry_browser_parse_ms: Number(parseMs || 0),
+      };
+    });
+}
+
+export function updateTelemetryBrowserLatency(store, latency) {
+  const current = store || createTelemetryStore();
+  return {
+    ...current,
+    browserLatency: {
+      ...(current.browserLatency || createTelemetryStore().browserLatency),
+      ...latency,
+    },
   };
 }
 
@@ -94,6 +129,7 @@ export function applyTelemetrySnapshotMetadata(store, payload) {
     overloaded: Boolean(current.overloaded) || payload?.telemetry_overloaded === true,
     lastReplayRequired: replay?.required === true,
     lastReplayReason: replay?.reason || current.lastReplayReason || "",
+    browserLatency: current.browserLatency || createTelemetryStore().browserLatency,
   };
 }
 

--- a/ui/operator-react/src/telemetryStore.test.js
+++ b/ui/operator-react/src/telemetryStore.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createTelemetryStore,
+  enrichTelemetryFrames,
+  reduceTelemetryStore,
+  updateTelemetryBrowserLatency,
+} from "./telemetryStore.js";
+
+describe("telemetryStore", () => {
+  it("enriches frames with browser-side latency fields", () => {
+    const frames = enrichTelemetryFrames(
+      [{ node_name: "node-a", plane_name: "plane-a", sequence: 1000 }],
+      1250,
+      1.5,
+    );
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].telemetry_browser_received_at_ms).toBe(1250);
+    expect(frames[0].telemetry_browser_receive_delay_ms).toBe(250);
+    expect(frames[0].telemetry_browser_parse_ms).toBe(1.5);
+  });
+
+  it("keeps browser latency state through telemetry reductions", () => {
+    const current = updateTelemetryBrowserLatency(createTelemetryStore(), {
+      receivedAtMs: 1250,
+      receiveDelayMs: 250,
+      parseMs: 1,
+      reduceMs: 2,
+      applyMs: 3,
+      acceptedFrames: 1,
+    });
+    const result = reduceTelemetryStore(current, [
+      { node_name: "node-a", plane_name: "plane-a", sequence: 1000 },
+    ]);
+
+    expect(result.changed).toBe(true);
+    expect(result.store.browserLatency.receiveDelayMs).toBe(250);
+    expect(result.store.browserLatency.applyMs).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add SQLite-backed durable telemetry ring buffer and telemetry health JSON endpoint
- add multiplexed live SSE stream for controller events and telemetry
- instrument WebUI browser-side telemetry latency and cover it with unit tests

## Validation
- cmake --build build/telemetry-debug --target naim-telemetry-live-store-tests
- ./build/telemetry-debug/naim-telemetry-live-store-tests
- cmake --build build/telemetry-debug --target naim-controller
- cmake --build build/telemetry-debug --target naim-hostd-http-tests
- ./build/telemetry-debug/naim-hostd-http-tests
- npm test -- --run src/telemetryStore.test.js
- npm run build