### PR TITLE
Add telemetry operational health gates

### DIFF
--- a/controller/include/app/controller_service_interfaces.h
+++ b/controller/include/app/controller_service_interfaces.h
@@ -89,6 +89,9 @@ class IReadModelCliService {
       const std::string& db_path,
       const std::optional<std::string>& node_name,
       int stale_after_seconds) const = 0;
+  virtual int ShowTelemetryHealth(
+      const std::string& db_path,
+      const std::optional<std::string>& plane_name) const = 0;
   virtual int ShowEvents(
       const std::string& db_path,
       const std::optional<std::string>& plane_name,

--- a/controller/include/read_model/read_model_cli_service.h
+++ b/controller/include/read_model/read_model_cli_service.h
@@ -43,6 +43,10 @@ class ReadModelCliService : public IReadModelCliService {
       const std::optional<std::string>& node_name,
       int stale_after_seconds) const override;
 
+  int ShowTelemetryHealth(
+      const std::string& db_path,
+      const std::optional<std::string>& plane_name) const override;
+
   int ShowEvents(
       const std::string& db_path,
       const std::optional<std::string>& plane_name,

--- a/controller/include/telemetry/telemetry_live_store.h
+++ b/controller/include/telemetry/telemetry_live_store.h
@@ -15,6 +15,22 @@ namespace naim::controller {
 
 class TelemetryLiveStore final {
  public:
+  struct RetentionConfig {
+    std::size_t hot_history_capacity = 300;
+    std::size_t stream_batch_limit = 128;
+    std::size_t durable_history_capacity = 9600;
+    std::uint64_t warm_bucket_ms = 10000;
+    std::uint64_t cold_bucket_ms = 60000;
+  };
+
+  struct AlertThresholds {
+    std::uint64_t stale_warning_ms = 15000;
+    std::uint64_t stale_critical_ms = 60000;
+    std::uint64_t ingest_warning_ms = 3000;
+    std::uint64_t queue_warning_ms = 1000;
+    std::uint64_t browser_apply_warning_ms = 250;
+  };
+
   struct StreamDelta {
     std::vector<naim::HostTelemetryFrame> frames;
     bool replay_required = false;
@@ -30,6 +46,10 @@ class TelemetryLiveStore final {
   void ConfigurePersistence(
       const std::string& db_path,
       std::size_t retention_capacity = 9600);
+  void ConfigureFromEnvironment(const std::string& db_path);
+  void ConfigureOperationalPolicy(
+      RetentionConfig retention,
+      AlertThresholds thresholds);
   void ResetForTests();
 
   bool Upsert(naim::HostTelemetryFrame frame);
@@ -38,6 +58,8 @@ class TelemetryLiveStore final {
       int history_seconds) const;
   nlohmann::json BuildHealth(
       const std::optional<std::string>& plane_name) const;
+  std::string BuildOpenMetrics(
+      const std::optional<std::string>& plane_name) const;
   std::vector<naim::HostTelemetryFrame> LoadFramesAfter(
       std::uint64_t sequence,
       const std::optional<std::string>& plane_name) const;
@@ -45,6 +67,10 @@ class TelemetryLiveStore final {
       std::uint64_t sequence,
       const std::optional<std::string>& plane_name) const;
   std::uint64_t LatestSequence() const;
+  void RecordStreamOpened(const std::string& stream_name);
+  void RecordStreamClosed(const std::string& stream_name);
+  void RecordStreamReplayRequired(const std::string& stream_name);
+  void RecordStreamSendFailure(const std::string& stream_name);
 
  private:
   struct NodeBuffer {
@@ -65,6 +91,20 @@ class TelemetryLiveStore final {
     std::string last_error;
   };
 
+  struct StreamState {
+    std::uint64_t active_clients = 0;
+    std::uint64_t opened_total = 0;
+    std::uint64_t closed_total = 0;
+    std::uint64_t replay_required_total = 0;
+    std::uint64_t send_failure_total = 0;
+    std::uint64_t reconnect_total = 0;
+  };
+
+  struct StreamMetrics {
+    StreamState telemetry;
+    StreamState live;
+  };
+
   static bool MatchesPlane(
       const naim::HostTelemetryFrame& frame,
       const std::optional<std::string>& plane_name);
@@ -77,9 +117,12 @@ class TelemetryLiveStore final {
       const std::string& db_path,
       std::size_t retention_capacity);
   nlohmann::json BuildPersistenceStatusLocked() const;
+  nlohmann::json BuildStreamStatusLocked() const;
   static nlohmann::json BuildAlerts(
       const std::vector<const NodeBuffer*>& buffers,
       const PersistenceState& persistence,
+      const StreamMetrics& streams,
+      const AlertThresholds& thresholds,
       std::uint64_t dropped_frames_total,
       std::uint64_t now_ms);
   static nlohmann::json FrameToJson(const naim::HostTelemetryFrame& frame);
@@ -94,21 +137,23 @@ class TelemetryLiveStore final {
   static nlohmann::json BuildDownsampledHistory(
       const std::vector<const NodeBuffer*>& buffers,
       int history_seconds,
-      std::uint64_t now_ms);
+      std::uint64_t now_ms,
+      std::uint64_t warm_bucket_ms,
+      std::uint64_t cold_bucket_ms);
   static nlohmann::json BuildPlaneAggregates(
       const std::vector<const NodeBuffer*>& buffers,
       std::uint64_t now_ms);
-  static constexpr std::size_t HistoryCapacity();
-  static constexpr std::size_t StreamBatchLimit();
-  static constexpr std::uint64_t WarmBucketMs();
-  static constexpr std::uint64_t ColdBucketMs();
-  static constexpr std::size_t DurableHistoryCapacity();
+  void RecordStreamOpenedLocked(const std::string& stream_name);
+  StreamState& MutableStreamStateLocked(const std::string& stream_name);
 
   mutable std::mutex mutex_;
   std::vector<NodeBuffer> nodes_;
   std::uint64_t latest_sequence_ = 0;
   std::uint64_t dropped_frames_total_ = 0;
+  RetentionConfig retention_;
+  AlertThresholds thresholds_;
   PersistenceState persistence_;
+  StreamMetrics streams_;
 };
 
 }  // namespace naim::controller

--- a/controller/src/app/controller_cli.cpp
+++ b/controller/src/app/controller_cli.cpp
@@ -103,6 +103,12 @@ std::optional<int> ControllerCli::TryRun() const {
         command_line_.stale_after().value_or(300));
   }
 
+  if (command == "show-telemetry-health") {
+    return read_model_cli_service_.ShowTelemetryHealth(
+        command_line_.db().value_or("var/controller.sqlite"),
+        command_line_.plane());
+  }
+
   if (command == "show-disk-state") {
     return read_model_cli_service_.ShowDiskState(
         command_line_.db().value_or("var/controller.sqlite"),

--- a/controller/src/app/controller_command_line.cpp
+++ b/controller/src/app/controller_command_line.cpp
@@ -49,6 +49,7 @@ void ControllerCommandLine::PrintUsage(std::ostream& output) const {
       << "  naim-controller show-host-assignments [--db <path>] [--node <node-name>]\n"
       << "  naim-controller show-host-observations [--db <path>] [--plane <plane-name>] [--node <node-name>] [--stale-after <seconds>]\n"
       << "  naim-controller show-host-health [--db <path>] [--node <node-name>] [--stale-after <seconds>]\n"
+      << "  naim-controller show-telemetry-health [--db <path>] [--plane <plane-name>]\n"
       << "  naim-controller show-disk-state [--db <path>] [--plane <plane-name>] [--node <node-name>]\n"
       << "  naim-controller show-rollout-actions [--db <path>] [--plane <plane-name>] [--node <node-name>]\n"
       << "  naim-controller show-rebalance-plan [--db <path>] [--plane <plane-name>] [--node <node-name>]\n"
@@ -86,6 +87,7 @@ void ControllerCommandLine::PrintUsage(std::ostream& output) const {
       << "Remote operator CLI:\n"
       << "  most inspection and mutation commands also accept --controller <http://host:port>\n"
       << "  target resolution order: --controller, NAIM_CONTROLLER, ~/.config/naim/controller\n"
+      << "  auth token order: NAIM_CONTROLLER_SESSION_TOKEN, NAIM_CONTROLLER_TOKEN, NAIM_CONTROLLER_BEARER_TOKEN, NAIM_CONTROLLER_COOKIE\n"
       << "  explicit --db keeps the command local\n";
 }
 

--- a/controller/src/app/controller_route_summary_builder.cpp
+++ b/controller/src/app/controller_route_summary_builder.cpp
@@ -95,6 +95,7 @@ std::string ControllerRouteSummaryBuilder::BuildControllerRoutesSummary(
       "/api/v1/events/stream",
       "/api/v1/live/stream",
       "/api/v1/telemetry/health",
+      "/api/v1/telemetry/metrics",
       "/api/v1/telemetry/snapshot",
       "/api/v1/telemetry/stream",
   });

--- a/controller/src/app/remote_controller_cli_service.cpp
+++ b/controller/src/app/remote_controller_cli_service.cpp
@@ -199,6 +199,13 @@ int RemoteControllerCliService::ExecuteCommand(
         {{"node", node_name.value_or("")},
          {"stale_after", stale_after.has_value() ? std::to_string(*stale_after) : ""}}));
   }
+  if (command == "show-telemetry-health") {
+    return EmitRemoteJsonPayload(SendControllerJsonRequest(
+        target,
+        "GET",
+        "/api/v1/telemetry/health",
+        {{"plane", plane_name.value_or("")}}));
+  }
   if (command == "show-disk-state") {
     return EmitRemoteJsonPayload(SendControllerJsonRequest(
         target,

--- a/controller/src/http/controller_http_server.cpp
+++ b/controller/src/http/controller_http_server.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <thread>
+#include <utility>
 
 #include "http/controller_http_server_support.h"
 #include "infra/controller_network_manager.h"
@@ -38,6 +39,29 @@ struct SseStreamRequest {
 struct TelemetryStreamRequest {
   std::optional<std::string> plane_name;
   std::uint64_t last_sequence = 0;
+};
+
+class TelemetryStreamScope final {
+ public:
+  explicit TelemetryStreamScope(std::string stream_name)
+      : stream_name_(std::move(stream_name)) {
+    TelemetryLiveStore::Instance().RecordStreamOpened(stream_name_);
+  }
+
+  ~TelemetryStreamScope() {
+    TelemetryLiveStore::Instance().RecordStreamClosed(stream_name_);
+  }
+
+  void RecordSendFailure() const {
+    TelemetryLiveStore::Instance().RecordStreamSendFailure(stream_name_);
+  }
+
+  void RecordReplayRequired() const {
+    TelemetryLiveStore::Instance().RecordStreamReplayRequired(stream_name_);
+  }
+
+ private:
+  std::string stream_name_;
 };
 
 std::optional<std::string> FindQueryString(
@@ -204,13 +228,16 @@ void ControllerHttpServer::StreamTelemetrySse(
     const SocketHandle client_fd,
     const HttpRequest& request,
     std::shared_ptr<SharedState> state) {
+  const TelemetryStreamScope stream_scope("telemetry");
   const TelemetryStreamRequest stream_request = ParseTelemetryStreamRequest(request);
   std::uint64_t last_sequence = stream_request.last_sequence;
   if (!ControllerNetworkManager::SendSseHeaders(client_fd)) {
+    stream_scope.RecordSendFailure();
     ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
     return;
   }
   if (!ControllerNetworkManager::SendSseCommentFrame(client_fd, " telemetry connected")) {
+    stream_scope.RecordSendFailure();
     ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
     return;
   }
@@ -219,6 +246,9 @@ void ControllerHttpServer::StreamTelemetrySse(
       last_sequence,
       stream_request.plane_name);
   if (last_sequence == 0 || initial_delta.replay_required) {
+    if (initial_delta.replay_required) {
+      stream_scope.RecordReplayRequired();
+    }
     auto snapshot = TelemetryLiveStore::Instance().BuildSnapshot(
         stream_request.plane_name,
         0);
@@ -235,6 +265,7 @@ void ControllerHttpServer::StreamTelemetrySse(
             static_cast<int>(TelemetryLiveStore::Instance().LatestSequence() % 2147483647ULL),
             "telemetry.snapshot",
             snapshot.dump())) {
+      stream_scope.RecordSendFailure();
       ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
       return;
     }
@@ -246,6 +277,7 @@ void ControllerHttpServer::StreamTelemetrySse(
     auto delta =
         TelemetryLiveStore::Instance().LoadStreamDeltaAfter(last_sequence, stream_request.plane_name);
     if (delta.replay_required) {
+      stream_scope.RecordReplayRequired();
       auto snapshot = TelemetryLiveStore::Instance().BuildSnapshot(
           stream_request.plane_name,
           0);
@@ -262,6 +294,7 @@ void ControllerHttpServer::StreamTelemetrySse(
               static_cast<int>(delta.latest_sequence % 2147483647ULL),
               "telemetry.snapshot",
               snapshot.dump())) {
+        stream_scope.RecordSendFailure();
         ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
         return;
       }
@@ -276,6 +309,7 @@ void ControllerHttpServer::StreamTelemetrySse(
               static_cast<int>(frame.sequence % 2147483647ULL),
               "telemetry.node",
               payload)) {
+        stream_scope.RecordSendFailure();
         ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
         return;
       }
@@ -288,6 +322,7 @@ void ControllerHttpServer::StreamTelemetrySse(
       if (!ControllerNetworkManager::SendSseCommentFrame(
               client_fd,
               " telemetry keepalive")) {
+        stream_scope.RecordSendFailure();
         ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
         return;
       }
@@ -328,15 +363,18 @@ void ControllerHttpServer::StreamLiveSse(
     const HttpRequest& request,
     const BuildEventPayloadItemFn build_event_payload_item,
     std::shared_ptr<SharedState> state) {
+  const TelemetryStreamScope stream_scope("live");
   const SseStreamRequest event_request = ParseSseStreamRequest(request);
   const TelemetryStreamRequest telemetry_request = ParseTelemetryStreamRequest(request);
   int last_event_id = event_request.last_event_id.value_or(0);
   std::uint64_t last_sequence = telemetry_request.last_sequence;
   if (!ControllerNetworkManager::SendSseHeaders(client_fd)) {
+    stream_scope.RecordSendFailure();
     ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
     return;
   }
   if (!ControllerNetworkManager::SendSseCommentFrame(client_fd, " live connected")) {
+    stream_scope.RecordSendFailure();
     ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
     return;
   }
@@ -345,6 +383,9 @@ void ControllerHttpServer::StreamLiveSse(
       last_sequence,
       telemetry_request.plane_name);
   if (last_sequence == 0 || initial_delta.replay_required) {
+    if (initial_delta.replay_required) {
+      stream_scope.RecordReplayRequired();
+    }
     auto snapshot = TelemetryLiveStore::Instance().BuildSnapshot(
         telemetry_request.plane_name,
         0);
@@ -362,6 +403,7 @@ void ControllerHttpServer::StreamLiveSse(
             static_cast<int>(TelemetryLiveStore::Instance().LatestSequence() % 2147483647ULL),
             "telemetry.snapshot",
             snapshot.dump())) {
+      stream_scope.RecordSendFailure();
       ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
       return;
     }
@@ -388,6 +430,7 @@ void ControllerHttpServer::StreamLiveSse(
               event.id,
               "events." + BuildSseEventName(event),
               payload.dump())) {
+        stream_scope.RecordSendFailure();
         ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
         return;
       }
@@ -399,6 +442,7 @@ void ControllerHttpServer::StreamLiveSse(
         last_sequence,
         telemetry_request.plane_name);
     if (delta.replay_required) {
+      stream_scope.RecordReplayRequired();
       auto snapshot = TelemetryLiveStore::Instance().BuildSnapshot(
           telemetry_request.plane_name,
           0);
@@ -416,6 +460,7 @@ void ControllerHttpServer::StreamLiveSse(
               static_cast<int>(delta.latest_sequence % 2147483647ULL),
               "telemetry.snapshot",
               snapshot.dump())) {
+        stream_scope.RecordSendFailure();
         ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
         return;
       }
@@ -430,6 +475,7 @@ void ControllerHttpServer::StreamLiveSse(
               static_cast<int>(frame.sequence % 2147483647ULL),
               "telemetry.node",
               payload.dump())) {
+        stream_scope.RecordSendFailure();
         ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
         return;
       }
@@ -440,6 +486,7 @@ void ControllerHttpServer::StreamLiveSse(
     const auto now = std::chrono::steady_clock::now();
     if (now - last_keepalive >= std::chrono::seconds(5)) {
       if (!ControllerNetworkManager::SendSseCommentFrame(client_fd, " live keepalive")) {
+        stream_scope.RecordSendFailure();
         ControllerNetworkManager::ShutdownAndCloseSocket(client_fd);
         return;
       }
@@ -481,7 +528,7 @@ int ControllerHttpServer::Serve(const Config& config) {
 
   naim::ControllerStore store(config.db_path);
   store.Initialize();
-  TelemetryLiveStore::Instance().ConfigurePersistence(config.db_path);
+  TelemetryLiveStore::Instance().ConfigureFromEnvironment(config.db_path);
 
   const SocketHandle listen_fd = ControllerNetworkManager::CreateListenSocket(
       config.listen_host,

--- a/controller/src/infra/controller_remote_client.cpp
+++ b/controller/src/infra/controller_remote_client.cpp
@@ -62,6 +62,30 @@ std::optional<std::string> LoadControllerTargetConfig() {
   return value;
 }
 
+std::vector<std::pair<std::string, std::string>> ControllerAuthHeadersFromEnv() {
+  std::vector<std::pair<std::string, std::string>> headers;
+  if (const char* token = std::getenv("NAIM_CONTROLLER_SESSION_TOKEN");
+      token != nullptr && token[0] != '\0') {
+    headers.emplace_back("X-NAIM-Session-Token", token);
+    return headers;
+  }
+  if (const char* token = std::getenv("NAIM_CONTROLLER_TOKEN");
+      token != nullptr && token[0] != '\0') {
+    headers.emplace_back("X-NAIM-Session-Token", token);
+    return headers;
+  }
+  if (const char* token = std::getenv("NAIM_CONTROLLER_BEARER_TOKEN");
+      token != nullptr && token[0] != '\0') {
+    headers.emplace_back("Authorization", std::string("Bearer ") + token);
+    return headers;
+  }
+  if (const char* cookie = std::getenv("NAIM_CONTROLLER_COOKIE");
+      cookie != nullptr && cookie[0] != '\0') {
+    headers.emplace_back("Cookie", cookie);
+  }
+  return headers;
+}
+
 }  // namespace
 
 std::optional<std::string> ResolveControllerTarget(
@@ -86,7 +110,11 @@ nlohmann::json SendControllerJsonRequest(
     const std::string& path,
     const std::vector<std::pair<std::string, std::string>>& params) {
   const HttpResponse response = SendControllerHttpRequest(
-      target, method, path + BuildQueryString(params));
+      target,
+      method,
+      path + BuildQueryString(params),
+      "",
+      ControllerAuthHeadersFromEnv());
   nlohmann::json payload =
       response.body.empty() ? nlohmann::json::object()
                             : nlohmann::json::parse(response.body);

--- a/controller/src/read_model/read_model_cli_service.cpp
+++ b/controller/src/read_model/read_model_cli_service.cpp
@@ -4,6 +4,8 @@
 #include <stdexcept>
 #include <utility>
 
+#include "telemetry/telemetry_live_store.h"
+
 namespace naim::controller {
 
 namespace {
@@ -143,6 +145,16 @@ int ReadModelCliService::ShowHostHealth(
       view.availability_overrides,
       view.node_name,
       view.stale_after_seconds);
+  return 0;
+}
+
+int ReadModelCliService::ShowTelemetryHealth(
+    const std::string& db_path,
+    const std::optional<std::string>& plane_name) const {
+  auto& store = TelemetryLiveStore::Instance();
+  store.ResetForTests();
+  store.ConfigureFromEnvironment(db_path);
+  std::cout << store.BuildHealth(plane_name).dump(2) << "\n";
   return 0;
 }
 

--- a/controller/src/read_model/read_model_http_service.cpp
+++ b/controller/src/read_model/read_model_http_service.cpp
@@ -109,6 +109,29 @@ std::optional<HttpResponse> ReadModelHttpService::HandleRequest(
     }
   }
 
+  if (request.path == "/api/v1/telemetry/metrics") {
+    if (request.method != "GET") {
+      return support_.build_json_response(
+          405, json{{"status", "method_not_allowed"}}, {});
+    }
+    try {
+      HttpResponse response;
+      response.status_code = 200;
+      response.content_type = "text/plain; version=0.0.4; charset=utf-8";
+      response.body =
+          naim::controller::TelemetryLiveStore::Instance().BuildOpenMetrics(
+              support_.find_query_string(request, "plane"));
+      return response;
+    } catch (const std::exception& error) {
+      return support_.build_json_response(
+          500,
+          json{{"status", "internal_error"},
+               {"message", error.what()},
+               {"path", request.path}},
+          {});
+    }
+  }
+
   if (request.path == "/api/v1/host-health") {
     if (request.method != "GET") {
       return support_.build_json_response(

--- a/controller/src/telemetry/telemetry_live_store.cpp
+++ b/controller/src/telemetry/telemetry_live_store.cpp
@@ -4,8 +4,10 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <limits>
 #include <map>
+#include <sstream>
 #include <stdexcept>
 
 #include <sqlite3.h>
@@ -106,6 +108,34 @@ std::int64_t SafeSequenceForSqlite(std::uint64_t sequence) {
       static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())));
 }
 
+std::optional<std::uint64_t> EnvUint64(const char* key) {
+  const char* value = std::getenv(key);
+  if (value == nullptr || value[0] == '\0') {
+    return std::nullopt;
+  }
+  return static_cast<std::uint64_t>(std::stoull(value));
+}
+
+std::optional<std::size_t> EnvSize(const char* key) {
+  const auto value = EnvUint64(key);
+  if (!value.has_value()) {
+    return std::nullopt;
+  }
+  return static_cast<std::size_t>(*value);
+}
+
+std::string SanitizeMetricLabel(std::string value) {
+  for (char& ch : value) {
+    const bool ok =
+        (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
+        (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' || ch == '.';
+    if (!ok) {
+      ch = '_';
+    }
+  }
+  return value;
+}
+
 }  // namespace
 
 TelemetryLiveStore& TelemetryLiveStore::Instance() {
@@ -120,12 +150,78 @@ void TelemetryLiveStore::ConfigurePersistence(
   ConfigurePersistenceLocked(db_path, retention_capacity);
 }
 
+void TelemetryLiveStore::ConfigureFromEnvironment(const std::string& db_path) {
+  RetentionConfig retention = retention_;
+  retention.hot_history_capacity =
+      EnvSize("NAIM_TELEMETRY_HOT_HISTORY_CAPACITY")
+          .value_or(retention.hot_history_capacity);
+  retention.stream_batch_limit =
+      EnvSize("NAIM_TELEMETRY_STREAM_BATCH_LIMIT")
+          .value_or(retention.stream_batch_limit);
+  retention.durable_history_capacity =
+      EnvSize("NAIM_TELEMETRY_DURABLE_HISTORY_CAPACITY")
+          .value_or(retention.durable_history_capacity);
+  retention.warm_bucket_ms =
+      EnvUint64("NAIM_TELEMETRY_WARM_BUCKET_MS")
+          .value_or(retention.warm_bucket_ms);
+  retention.cold_bucket_ms =
+      EnvUint64("NAIM_TELEMETRY_COLD_BUCKET_MS")
+          .value_or(retention.cold_bucket_ms);
+
+  AlertThresholds thresholds = thresholds_;
+  thresholds.stale_warning_ms =
+      EnvUint64("NAIM_TELEMETRY_STALE_WARNING_MS")
+          .value_or(thresholds.stale_warning_ms);
+  thresholds.stale_critical_ms =
+      EnvUint64("NAIM_TELEMETRY_STALE_CRITICAL_MS")
+          .value_or(thresholds.stale_critical_ms);
+  thresholds.ingest_warning_ms =
+      EnvUint64("NAIM_TELEMETRY_INGEST_WARNING_MS")
+          .value_or(thresholds.ingest_warning_ms);
+  thresholds.queue_warning_ms =
+      EnvUint64("NAIM_TELEMETRY_QUEUE_WARNING_MS")
+          .value_or(thresholds.queue_warning_ms);
+  thresholds.browser_apply_warning_ms =
+      EnvUint64("NAIM_TELEMETRY_BROWSER_APPLY_WARNING_MS")
+          .value_or(thresholds.browser_apply_warning_ms);
+
+  ConfigureOperationalPolicy(retention, thresholds);
+  ConfigurePersistence(db_path, retention.durable_history_capacity);
+}
+
+void TelemetryLiveStore::ConfigureOperationalPolicy(
+    RetentionConfig retention,
+    AlertThresholds thresholds) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  retention.hot_history_capacity = std::max<std::size_t>(1, retention.hot_history_capacity);
+  retention.stream_batch_limit = std::max<std::size_t>(1, retention.stream_batch_limit);
+  retention.durable_history_capacity =
+      std::max<std::size_t>(1, retention.durable_history_capacity);
+  retention.warm_bucket_ms = std::max<std::uint64_t>(1, retention.warm_bucket_ms);
+  retention.cold_bucket_ms = std::max<std::uint64_t>(
+      retention.warm_bucket_ms,
+      retention.cold_bucket_ms);
+  retention_ = retention;
+  thresholds_ = thresholds;
+  for (auto& node : nodes_) {
+    while (node.history.size() > retention_.hot_history_capacity) {
+      node.last_pruned_sequence = node.history.front().sequence;
+      node.history.pop_front();
+      ++node.dropped_frames_total;
+      ++dropped_frames_total_;
+    }
+  }
+}
+
 void TelemetryLiveStore::ResetForTests() {
   std::lock_guard<std::mutex> lock(mutex_);
   nodes_.clear();
   latest_sequence_ = 0;
   dropped_frames_total_ = 0;
+  retention_ = RetentionConfig{};
+  thresholds_ = AlertThresholds{};
   persistence_ = PersistenceState{};
+  streams_ = StreamMetrics{};
 }
 
 bool TelemetryLiveStore::Upsert(naim::HostTelemetryFrame frame) {
@@ -177,7 +273,7 @@ bool TelemetryLiveStore::UpsertInMemoryLocked(naim::HostTelemetryFrame frame) {
   } else {
     it->latest = frame;
     it->history.push_back(std::move(frame));
-    while (it->history.size() > HistoryCapacity()) {
+    while (it->history.size() > retention_.hot_history_capacity) {
       it->last_pruned_sequence = it->history.front().sequence;
       it->history.pop_front();
       ++it->dropped_frames_total;
@@ -316,8 +412,13 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
     }
   }
   const bool overloaded = dropped_frames_total_ > 0;
-  const auto alerts =
-      BuildAlerts(matched_buffers, persistence_, dropped_frames_total_, now_ms);
+  const auto alerts = BuildAlerts(
+      matched_buffers,
+      persistence_,
+      streams_,
+      thresholds_,
+      dropped_frames_total_,
+      now_ms);
   const std::string status =
       !alerts.empty() ? "degraded" : overloaded ? "overloaded" : "ok";
   return nlohmann::json{
@@ -329,16 +430,18 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
       {"latest_sequence", latest_sequence_},
       {"telemetry_overloaded", overloaded},
       {"dropped_frames_total", dropped_frames_total_},
-      {"history_capacity", HistoryCapacity()},
-      {"stream_batch_limit", StreamBatchLimit()},
+      {"history_capacity", retention_.hot_history_capacity},
+      {"stream_batch_limit", retention_.stream_batch_limit},
       {"persistence", BuildPersistenceStatusLocked()},
+      {"streams", BuildStreamStatusLocked()},
       {"alerts", alerts},
       {"retention",
        nlohmann::json{
-           {"hot_history_capacity", HistoryCapacity()},
+           {"hot_history_capacity", retention_.hot_history_capacity},
            {"durable_history_capacity", persistence_.retention_capacity},
-           {"warm_bucket_ms", WarmBucketMs()},
-           {"cold_bucket_ms", ColdBucketMs()},
+           {"stream_batch_limit", retention_.stream_batch_limit},
+           {"warm_bucket_ms", retention_.warm_bucket_ms},
+           {"cold_bucket_ms", retention_.cold_bucket_ms},
        }},
       {"telemetry_health",
        nlohmann::json{
@@ -346,13 +449,18 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
            {"last_frame_age_ms",
             latest_sequence_ > 0 && now_ms >= latest_sequence_ ? now_ms - latest_sequence_ : 0},
            {"dropped_frames_total", dropped_frames_total_},
-           {"stream_batch_limit", StreamBatchLimit()},
+           {"stream_batch_limit", retention_.stream_batch_limit},
        }},
       {"planes", BuildPlaneAggregates(matched_buffers, now_ms)},
       {"nodes", std::move(nodes)},
       {"history", std::move(history)},
       {"downsampled_history",
-       BuildDownsampledHistory(matched_buffers, history_seconds, now_ms)},
+       BuildDownsampledHistory(
+           matched_buffers,
+           history_seconds,
+           now_ms,
+           retention_.warm_bucket_ms,
+           retention_.cold_bucket_ms)},
   };
 }
 
@@ -366,8 +474,13 @@ nlohmann::json TelemetryLiveStore::BuildHealth(
       matched_buffers.push_back(&buffer);
     }
   }
-  const auto alerts =
-      BuildAlerts(matched_buffers, persistence_, dropped_frames_total_, now_ms);
+  const auto alerts = BuildAlerts(
+      matched_buffers,
+      persistence_,
+      streams_,
+      thresholds_,
+      dropped_frames_total_,
+      now_ms);
   std::string status = "ok";
   if (!alerts.empty()) {
     status = "degraded";
@@ -388,18 +501,88 @@ nlohmann::json TelemetryLiveStore::BuildHealth(
       {"last_frame_age_ms",
        latest_sequence_ > 0 && now_ms >= latest_sequence_ ? now_ms - latest_sequence_ : 0},
       {"dropped_frames_total", dropped_frames_total_},
-      {"stream_batch_limit", StreamBatchLimit()},
+      {"stream_batch_limit", retention_.stream_batch_limit},
       {"retention",
        nlohmann::json{
-           {"hot_history_capacity", HistoryCapacity()},
+           {"hot_history_capacity", retention_.hot_history_capacity},
            {"durable_history_capacity", persistence_.retention_capacity},
-           {"warm_bucket_ms", WarmBucketMs()},
-           {"cold_bucket_ms", ColdBucketMs()},
+           {"stream_batch_limit", retention_.stream_batch_limit},
+           {"warm_bucket_ms", retention_.warm_bucket_ms},
+           {"cold_bucket_ms", retention_.cold_bucket_ms},
        }},
       {"persistence", BuildPersistenceStatusLocked()},
+      {"streams", BuildStreamStatusLocked()},
+      {"thresholds",
+       nlohmann::json{
+           {"stale_warning_ms", thresholds_.stale_warning_ms},
+           {"stale_critical_ms", thresholds_.stale_critical_ms},
+           {"ingest_warning_ms", thresholds_.ingest_warning_ms},
+           {"queue_warning_ms", thresholds_.queue_warning_ms},
+           {"browser_apply_warning_ms", thresholds_.browser_apply_warning_ms},
+       }},
       {"planes", BuildPlaneAggregates(matched_buffers, now_ms)},
       {"alerts", alerts},
   };
+}
+
+std::string TelemetryLiveStore::BuildOpenMetrics(
+    const std::optional<std::string>& plane_name) const {
+  const auto health = BuildHealth(plane_name);
+  std::ostringstream out;
+  const auto status = health.value("status", std::string{"ok"});
+  const int status_value = status == "critical" ? 2 : status == "degraded" ? 1 : 0;
+  out << "# TYPE naim_telemetry_health_status gauge\n";
+  out << "naim_telemetry_health_status " << status_value << "\n";
+  out << "# TYPE naim_telemetry_latest_sequence gauge\n";
+  out << "naim_telemetry_latest_sequence "
+      << health.value("latest_sequence", std::uint64_t{0}) << "\n";
+  out << "# TYPE naim_telemetry_last_frame_age_ms gauge\n";
+  out << "naim_telemetry_last_frame_age_ms "
+      << health.value("last_frame_age_ms", std::uint64_t{0}) << "\n";
+  out << "# TYPE naim_telemetry_dropped_frames_total counter\n";
+  out << "naim_telemetry_dropped_frames_total "
+      << health.value("dropped_frames_total", std::uint64_t{0}) << "\n";
+  const auto persistence = health.value("persistence", nlohmann::json::object());
+  out << "# TYPE naim_telemetry_persistence_enabled gauge\n";
+  out << "naim_telemetry_persistence_enabled "
+      << (persistence.value("enabled", false) ? 1 : 0) << "\n";
+  out << "# TYPE naim_telemetry_persistence_errors_total counter\n";
+  out << "naim_telemetry_persistence_errors_total "
+      << persistence.value("error_count", std::uint64_t{0}) << "\n";
+  out << "# TYPE naim_telemetry_persistence_persisted_frames_total counter\n";
+  out << "naim_telemetry_persistence_persisted_frames_total "
+      << persistence.value("persisted_frames_total", std::uint64_t{0}) << "\n";
+  out << "# TYPE naim_telemetry_stream_active_clients gauge\n";
+  out << "# TYPE naim_telemetry_stream_replay_required_total counter\n";
+  out << "# TYPE naim_telemetry_stream_send_failures_total counter\n";
+  const auto streams = health.value("streams", nlohmann::json::object());
+  for (const auto& name : {std::string{"telemetry"}, std::string{"live"}}) {
+    const auto stream = streams.value(name, nlohmann::json::object());
+    out << "naim_telemetry_stream_active_clients{stream=\""
+        << SanitizeMetricLabel(name) << "\"} "
+        << stream.value("active_clients", std::uint64_t{0}) << "\n";
+    out << "naim_telemetry_stream_replay_required_total{stream=\""
+        << SanitizeMetricLabel(name) << "\"} "
+        << stream.value("replay_required_total", std::uint64_t{0}) << "\n";
+    out << "naim_telemetry_stream_send_failures_total{stream=\""
+        << SanitizeMetricLabel(name) << "\"} "
+        << stream.value("send_failure_total", std::uint64_t{0}) << "\n";
+  }
+  out << "# TYPE naim_telemetry_plane_nodes gauge\n";
+  out << "# TYPE naim_telemetry_plane_stale_nodes gauge\n";
+  out << "# TYPE naim_telemetry_plane_max_ingest_ms gauge\n";
+  for (const auto& plane : health.value("planes", nlohmann::json::array())) {
+    const std::string plane_name_label =
+        SanitizeMetricLabel(plane.value("plane_name", std::string{"unassigned"}));
+    out << "naim_telemetry_plane_nodes{plane=\"" << plane_name_label << "\"} "
+        << plane.value("node_count", std::uint64_t{0}) << "\n";
+    out << "naim_telemetry_plane_stale_nodes{plane=\"" << plane_name_label << "\"} "
+        << plane.value("stale_nodes", std::uint64_t{0}) << "\n";
+    const auto latency = plane.value("latency", nlohmann::json::object());
+    out << "naim_telemetry_plane_max_ingest_ms{plane=\"" << plane_name_label << "\"} "
+        << latency.value("max_controller_ingest_ms", std::uint64_t{0}) << "\n";
+  }
+  return out.str();
 }
 
 std::vector<naim::HostTelemetryFrame> TelemetryLiveStore::LoadFramesAfter(
@@ -420,8 +603,9 @@ std::vector<naim::HostTelemetryFrame> TelemetryLiveStore::LoadFramesAfter(
       [](const auto& left, const auto& right) {
         return left.sequence < right.sequence;
       });
-  if (frames.size() > StreamBatchLimit()) {
-    const auto erase_count = static_cast<std::ptrdiff_t>(frames.size() - StreamBatchLimit());
+  if (frames.size() > retention_.stream_batch_limit) {
+    const auto erase_count =
+        static_cast<std::ptrdiff_t>(frames.size() - retention_.stream_batch_limit);
     frames.erase(frames.begin(), frames.begin() + erase_count);
   }
   return frames;
@@ -462,12 +646,13 @@ TelemetryLiveStore::StreamDelta TelemetryLiveStore::LoadStreamDeltaAfter(
       [](const auto& left, const auto& right) {
         return left.sequence < right.sequence;
       });
-  if (frames.size() > StreamBatchLimit()) {
+  if (frames.size() > retention_.stream_batch_limit) {
     delta.replay_required = true;
     if (delta.replay_reason.empty()) {
       delta.replay_reason = "stream-batch-truncated";
     }
-    const auto erase_count = static_cast<std::ptrdiff_t>(frames.size() - StreamBatchLimit());
+    const auto erase_count =
+        static_cast<std::ptrdiff_t>(frames.size() - retention_.stream_batch_limit);
     frames.erase(frames.begin(), frames.begin() + erase_count);
   }
   delta.frames = std::move(frames);
@@ -477,6 +662,47 @@ TelemetryLiveStore::StreamDelta TelemetryLiveStore::LoadStreamDeltaAfter(
 std::uint64_t TelemetryLiveStore::LatestSequence() const {
   std::lock_guard<std::mutex> lock(mutex_);
   return latest_sequence_;
+}
+
+void TelemetryLiveStore::RecordStreamOpened(const std::string& stream_name) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  RecordStreamOpenedLocked(stream_name);
+}
+
+void TelemetryLiveStore::RecordStreamClosed(const std::string& stream_name) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto& state = MutableStreamStateLocked(stream_name);
+  if (state.active_clients > 0) {
+    --state.active_clients;
+  }
+  ++state.closed_total;
+}
+
+void TelemetryLiveStore::RecordStreamReplayRequired(const std::string& stream_name) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  ++MutableStreamStateLocked(stream_name).replay_required_total;
+}
+
+void TelemetryLiveStore::RecordStreamSendFailure(const std::string& stream_name) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  ++MutableStreamStateLocked(stream_name).send_failure_total;
+}
+
+void TelemetryLiveStore::RecordStreamOpenedLocked(const std::string& stream_name) {
+  auto& state = MutableStreamStateLocked(stream_name);
+  if (state.opened_total > 0) {
+    ++state.reconnect_total;
+  }
+  ++state.opened_total;
+  ++state.active_clients;
+}
+
+TelemetryLiveStore::StreamState& TelemetryLiveStore::MutableStreamStateLocked(
+    const std::string& stream_name) {
+  if (stream_name == "live") {
+    return streams_.live;
+  }
+  return streams_.telemetry;
 }
 
 bool TelemetryLiveStore::MatchesPlane(
@@ -510,16 +736,31 @@ nlohmann::json TelemetryLiveStore::BuildPersistenceStatusLocked() const {
   };
 }
 
+nlohmann::json TelemetryLiveStore::BuildStreamStatusLocked() const {
+  const auto encode = [](const StreamState& state) {
+    return nlohmann::json{
+        {"active_clients", state.active_clients},
+        {"opened_total", state.opened_total},
+        {"closed_total", state.closed_total},
+        {"reconnect_total", state.reconnect_total},
+        {"replay_required_total", state.replay_required_total},
+        {"send_failure_total", state.send_failure_total},
+    };
+  };
+  return nlohmann::json{
+      {"telemetry", encode(streams_.telemetry)},
+      {"live", encode(streams_.live)},
+  };
+}
+
 nlohmann::json TelemetryLiveStore::BuildAlerts(
     const std::vector<const NodeBuffer*>& buffers,
     const PersistenceState& persistence,
+    const StreamMetrics& streams,
+    const AlertThresholds& thresholds,
     const std::uint64_t dropped_frames_total,
     const std::uint64_t now_ms) {
   nlohmann::json alerts = nlohmann::json::array();
-  constexpr std::uint64_t stale_warn_ms = 15000;
-  constexpr std::uint64_t stale_critical_ms = 60000;
-  constexpr std::uint64_t ingest_warn_ms = 3000;
-  constexpr std::uint64_t queue_warn_ms = 1000;
   if (!persistence.enabled) {
     alerts.push_back(nlohmann::json{
         {"code", "telemetry.persistence.disabled"},
@@ -544,13 +785,31 @@ nlohmann::json TelemetryLiveStore::BuildAlerts(
         {"count", dropped_frames_total},
     });
   }
+  if (streams.telemetry.send_failure_total > 0 || streams.live.send_failure_total > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.stream.send_failures"},
+        {"severity", "warning"},
+        {"message", "telemetry stream clients observed send failures"},
+        {"telemetry_failures", streams.telemetry.send_failure_total},
+        {"live_failures", streams.live.send_failure_total},
+    });
+  }
+  if (streams.telemetry.replay_required_total > 0 || streams.live.replay_required_total > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.stream.replay_required"},
+        {"severity", "warning"},
+        {"message", "telemetry stream replay was required"},
+        {"telemetry_replay_required_total", streams.telemetry.replay_required_total},
+        {"live_replay_required_total", streams.live.replay_required_total},
+    });
+  }
   for (const auto* buffer : buffers) {
     if (buffer == nullptr) {
       continue;
     }
     const auto& frame = buffer->latest;
     const auto ingest_ms = ControllerIngestDelayMs(frame, now_ms);
-    if (ingest_ms >= stale_critical_ms) {
+    if (ingest_ms >= thresholds.stale_critical_ms) {
       alerts.push_back(nlohmann::json{
           {"code", "telemetry.node.stale"},
           {"severity", "critical"},
@@ -558,7 +817,7 @@ nlohmann::json TelemetryLiveStore::BuildAlerts(
           {"plane_name", PlaneKeyForFrame(frame)},
           {"age_ms", ingest_ms},
       });
-    } else if (ingest_ms >= stale_warn_ms) {
+    } else if (ingest_ms >= thresholds.stale_warning_ms) {
       alerts.push_back(nlohmann::json{
           {"code", "telemetry.node.slow"},
           {"severity", "warning"},
@@ -567,7 +826,7 @@ nlohmann::json TelemetryLiveStore::BuildAlerts(
           {"age_ms", ingest_ms},
       });
     }
-    if (ingest_ms >= ingest_warn_ms) {
+    if (ingest_ms >= thresholds.ingest_warning_ms) {
       alerts.push_back(nlohmann::json{
           {"code", "telemetry.controller.ingest_delay"},
           {"severity", "warning"},
@@ -576,7 +835,7 @@ nlohmann::json TelemetryLiveStore::BuildAlerts(
           {"delay_ms", ingest_ms},
       });
     }
-    if (frame.publisher_queue_delay_ms >= queue_warn_ms) {
+    if (frame.publisher_queue_delay_ms >= thresholds.queue_warning_ms) {
       alerts.push_back(nlohmann::json{
           {"code", "telemetry.publisher.queue_delay"},
           {"severity", "warning"},
@@ -692,7 +951,9 @@ struct BucketAccumulator {
 nlohmann::json TelemetryLiveStore::BuildDownsampledHistory(
     const std::vector<const NodeBuffer*>& buffers,
     const int history_seconds,
-    const std::uint64_t now_ms) {
+    const std::uint64_t now_ms,
+    const std::uint64_t warm_bucket_ms,
+    const std::uint64_t cold_bucket_ms) {
   if (history_seconds <= 0) {
     return nlohmann::json::array();
   }
@@ -708,7 +969,8 @@ nlohmann::json TelemetryLiveStore::BuildDownsampledHistory(
         continue;
       }
       const std::uint64_t age_ms = now_ms >= frame.sequence ? now_ms - frame.sequence : 0;
-      const std::uint64_t bucket_ms = age_ms <= WarmBucketMs() ? WarmBucketMs() : ColdBucketMs();
+      const std::uint64_t bucket_ms =
+          age_ms <= warm_bucket_ms ? warm_bucket_ms : cold_bucket_ms;
       const std::uint64_t bucket_start_ms = (frame.sequence / bucket_ms) * bucket_ms;
       const auto key =
           frame.node_name + "|" + PlaneKeyForFrame(frame) + "|" +
@@ -843,26 +1105,6 @@ nlohmann::json TelemetryLiveStore::BuildPlaneAggregates(
     });
   }
   return result;
-}
-
-constexpr std::size_t TelemetryLiveStore::HistoryCapacity() {
-  return 300;
-}
-
-constexpr std::size_t TelemetryLiveStore::StreamBatchLimit() {
-  return 128;
-}
-
-constexpr std::uint64_t TelemetryLiveStore::WarmBucketMs() {
-  return 10000;
-}
-
-constexpr std::uint64_t TelemetryLiveStore::ColdBucketMs() {
-  return 60000;
-}
-
-constexpr std::size_t TelemetryLiveStore::DurableHistoryCapacity() {
-  return 9600;
 }
 
 }  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -274,6 +274,62 @@ void TestSqlitePersistenceReplayAndHealth() {
   std::cout << "ok: telemetry-live-store-sqlite-persistence-health\n";
 }
 
+void TestConfigurableRetentionAndMetrics() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  store.ResetForTests();
+  naim::controller::TelemetryLiveStore::RetentionConfig retention;
+  retention.hot_history_capacity = 3;
+  retention.stream_batch_limit = 2;
+  retention.durable_history_capacity = 5;
+  retention.warm_bucket_ms = 1000;
+  retention.cold_bucket_ms = 2000;
+  naim::controller::TelemetryLiveStore::AlertThresholds thresholds;
+  thresholds.queue_warning_ms = 1;
+  store.ConfigureOperationalPolicy(retention, thresholds);
+  for (std::uint64_t index = 0; index < 6; ++index) {
+    Expect(
+        store.Upsert(MakeFrame("node-config", "plane-config", 5000 + index)),
+        "config frame should update");
+  }
+  const auto snapshot = store.BuildSnapshot(std::string("plane-config"), 30);
+  Expect(snapshot.at("history_capacity").get<std::size_t>() == 3, "hot capacity should be configurable");
+  Expect(snapshot.at("stream_batch_limit").get<std::size_t>() == 2, "stream cap should be configurable");
+  Expect(
+      snapshot.at("dropped_frames_total").get<std::uint64_t>() >= 3,
+      "custom hot capacity should prune frames");
+  const auto delta = store.LoadStreamDeltaAfter(0, std::string("plane-config"));
+  Expect(delta.frames.size() == 2, "custom stream batch limit should cap deltas");
+  Expect(delta.replay_required, "custom stream batch limit should require replay");
+  Expect(!snapshot.at("alerts").empty(), "custom thresholds should produce alert candidates");
+  std::cout << "ok: telemetry-live-store-configurable-retention\n";
+}
+
+void TestStreamMetricsAndOpenMetrics() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  store.ResetForTests();
+  Expect(store.Upsert(MakeFrame("node-metrics", "plane-metrics", CurrentMillis())), "metrics frame");
+  store.RecordStreamOpened("live");
+  store.RecordStreamOpened("live");
+  store.RecordStreamClosed("live");
+  store.RecordStreamReplayRequired("live");
+  store.RecordStreamSendFailure("live");
+  const auto health = store.BuildHealth(std::string("plane-metrics"));
+  const auto live = health.at("streams").at("live");
+  Expect(live.at("active_clients").get<std::uint64_t>() == 1, "live active clients");
+  Expect(live.at("reconnect_total").get<std::uint64_t>() == 1, "live reconnect count");
+  Expect(live.at("replay_required_total").get<std::uint64_t>() == 1, "live replay count");
+  Expect(live.at("send_failure_total").get<std::uint64_t>() == 1, "live send failure count");
+  const auto metrics = store.BuildOpenMetrics(std::string("plane-metrics"));
+  Expect(
+      metrics.find("naim_telemetry_health_status") != std::string::npos,
+      "openmetrics should expose health status");
+  Expect(
+      metrics.find("naim_telemetry_stream_active_clients") != std::string::npos,
+      "openmetrics should expose stream clients");
+  store.ResetForTests();
+  std::cout << "ok: telemetry-live-store-stream-openmetrics\n";
+}
+
 }  // namespace
 
 int main() {
@@ -284,6 +340,8 @@ int main() {
     TestBackpressureProjection();
     TestPlaneAggregatesAndDownsampling();
     TestSqlitePersistenceReplayAndHealth();
+    TestConfigurableRetentionAndMetrics();
+    TestStreamMetricsAndOpenMetrics();
     return 0;
   } catch (const std::exception& error) {
     std::cerr << "telemetry_live_store_tests failed: " << error.what() << "\n";

--- a/scripts/ci/main-bootstrap-controller-update.sh
+++ b/scripts/ci/main-bootstrap-controller-update.sh
@@ -203,9 +203,47 @@ wait_for_container_http_contains() {
   return 1
 }
 
+check_telemetry_health() {
+  local phase="$1"
+  local output_path
+  output_path="$(mktemp)"
+  docker run --rm \
+    -v "${main_root}/state:/naim/state" \
+    "${controller_image}" \
+    show-telemetry-health \
+      --db /naim/state/controller.sqlite > "${output_path}"
+  python3 - "${output_path}" "${phase}" <<'PY'
+import json
+import sys
+
+path, phase = sys.argv[1:3]
+payload = json.load(open(path, encoding="utf-8"))
+status = payload.get("status", "unknown")
+persistence = payload.get("persistence") or {}
+if status == "critical":
+    raise SystemExit(f"telemetry health is critical during {phase}: {json.dumps(payload, sort_keys=True)}")
+if not persistence.get("enabled"):
+    raise SystemExit(f"telemetry SQLite persistence is disabled during {phase}: {json.dumps(payload, sort_keys=True)}")
+if persistence.get("error_count", 0):
+    raise SystemExit(f"telemetry SQLite persistence has errors during {phase}: {json.dumps(payload, sort_keys=True)}")
+print("telemetry health", phase, json.dumps({
+    "status": status,
+    "latest_sequence": payload.get("latest_sequence", 0),
+    "observed_nodes": payload.get("observed_nodes", 0),
+    "persistence": {
+        "enabled": persistence.get("enabled", False),
+        "retention_capacity": persistence.get("retention_capacity", 0),
+        "error_count": persistence.get("error_count", 0),
+    },
+}, sort_keys=True))
+PY
+  rm -f "${output_path}"
+}
+
 docker compose -f "${compose_path}" pull naim-controller >/dev/null
 docker compose -f "${compose_path}" up -d --remove-orphans naim-controller >/dev/null
 wait_for_http "http://127.0.0.1:${controller_port}/health" 90
+check_telemetry_health "controller-update"
 
 docker compose -f "${compose_path}" pull naim-skills-factory naim-web-ui >/dev/null
 docker compose -f "${compose_path}" up -d --remove-orphans naim-skills-factory naim-web-ui >/dev/null
@@ -350,6 +388,7 @@ raise SystemExit(
     + json.dumps(last, sort_keys=True)
 )
 PY
+check_telemetry_health "managed-rollout"
 
 plane_refresh_root="$(mktemp -d)"
 plane_refresh_plan="${plane_refresh_root}/planes.tsv"

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -2136,6 +2136,9 @@ function App() {
   const [hostObservations, setHostObservations] = useState(null);
   const [globalHostObservations, setGlobalHostObservations] = useState(null);
   const [telemetryHealthy, setTelemetryHealthy] = useState(false);
+  const [telemetryBrowserLatency, setTelemetryBrowserLatency] = useState(
+    createTelemetryStore().browserLatency,
+  );
   const [hostdHosts, setHostdHosts] = useState([]);
   const [protocolRegistry, setProtocolRegistry] = useState({ items: [], summary: {} });
   const [selectedHostNodeName, setSelectedHostNodeName] = useState("");
@@ -3979,35 +3982,38 @@ function App() {
             selectedPlaneRef.current,
           ),
         );
-        planeTelemetryStoreRef.current = updateTelemetryBrowserLatency(
-          planeTelemetryStoreRef.current,
-          {
-            receivedAtMs,
-            receiveDelayMs: Math.max(
-              0,
-              ...validFrames.map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
-            ),
-            parseMs,
-            reduceMs: planeReduceMs,
-            applyMs: performance.now() - applyStartedAt,
-            acceptedFrames: planeResult.acceptedFrames.length,
-          },
-        );
-      }
-      globalTelemetryStoreRef.current = updateTelemetryBrowserLatency(
-        globalTelemetryStoreRef.current,
-        {
+        const nextPlaneLatency = {
           receivedAtMs,
           receiveDelayMs: Math.max(
             0,
             ...validFrames.map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
           ),
           parseMs,
-          reduceMs,
+          reduceMs: planeReduceMs,
           applyMs: performance.now() - applyStartedAt,
-          acceptedFrames: globalResult.acceptedFrames.length,
-        },
+          acceptedFrames: planeResult.acceptedFrames.length,
+        };
+        planeTelemetryStoreRef.current = updateTelemetryBrowserLatency(
+          planeTelemetryStoreRef.current,
+          nextPlaneLatency,
+        );
+      }
+      const nextGlobalLatency = {
+        receivedAtMs,
+        receiveDelayMs: Math.max(
+          0,
+          ...validFrames.map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
+        ),
+        parseMs,
+        reduceMs,
+        applyMs: performance.now() - applyStartedAt,
+        acceptedFrames: globalResult.acceptedFrames.length,
+      };
+      globalTelemetryStoreRef.current = updateTelemetryBrowserLatency(
+        globalTelemetryStoreRef.current,
+        nextGlobalLatency,
       );
+      setTelemetryBrowserLatency(nextGlobalLatency);
       if (!globalChanged) {
         return;
       }
@@ -4141,20 +4147,22 @@ function App() {
             globalHostObservationsRef.current = mergedGlobal;
             setGlobalHostObservations(mergedGlobal);
           }
+          const nextGlobalLatency = {
+            receivedAtMs: Date.now(),
+            receiveDelayMs: Math.max(
+              0,
+              ...frames.map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
+            ),
+            parseMs: 0,
+            reduceMs: 0,
+            applyMs: 0,
+            acceptedFrames: globalResult.acceptedFrames.length,
+          };
           globalTelemetryStoreRef.current = updateTelemetryBrowserLatency(
             globalTelemetryStoreRef.current,
-            {
-              receivedAtMs: Date.now(),
-              receiveDelayMs: Math.max(
-                0,
-                ...frames.map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
-              ),
-              parseMs: 0,
-              reduceMs: 0,
-              applyMs: 0,
-              acceptedFrames: globalResult.acceptedFrames.length,
-            },
+            nextGlobalLatency,
           );
+          setTelemetryBrowserLatency(nextGlobalLatency);
           if (selectedPlaneRef.current) {
             planeTelemetryStoreRef.current = applyTelemetrySnapshotMetadata(
               planeTelemetryStoreRef.current,
@@ -8235,6 +8243,12 @@ function App() {
                   <span className="subpanel-meta">
                     Host-level CPU, GPU, temperature, network, disk, and runtime posture across all observed nodes
                   </span>
+                </div>
+                <div className="telemetry-latency-strip">
+                  <span>Receive <strong>{Math.round(telemetryBrowserLatency.receiveDelayMs || 0)} ms</strong></span>
+                  <span>Parse <strong>{Number(telemetryBrowserLatency.parseMs || 0).toFixed(1)} ms</strong></span>
+                  <span>Reduce <strong>{Number(telemetryBrowserLatency.reduceMs || 0).toFixed(1)} ms</strong></span>
+                  <span>Apply <strong>{Number(telemetryBrowserLatency.applyMs || 0).toFixed(1)} ms</strong></span>
                 </div>
                 <div className="summary-grid server-summary-grid">
                   <SummaryCard

--- a/ui/operator-react/src/styles.css
+++ b/ui/operator-react/src/styles.css
@@ -429,6 +429,25 @@ body {
   gap: 16px;
 }
 
+.telemetry-latency-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.telemetry-latency-strip span {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-dim);
+  font-size: 12px;
+  padding: 6px 8px;
+}
+
+.telemetry-latency-strip strong {
+  color: var(--text);
+  font-weight: 700;
+}
+
 .page-panel {
   min-width: 0;
 }


### PR DESCRIPTION
## Summary
- add telemetry health CLI, auth-aware remote CLI token headers, and OpenMetrics endpoint
- add configurable telemetry retention and alert thresholds via controller environment variables
- track live/telemetry stream client, reconnect, replay, and send-failure metrics
- add release telemetry health checks after controller bootstrap and managed rollout
- surface browser receive/parse/reduce/apply latency in the operator UI

## Validation
- cmake --build build/telemetry-debug --target naim-telemetry-live-store-tests
- ./build/telemetry-debug/naim-telemetry-live-store-tests
- cmake --build build/telemetry-debug --target naim-controller
- cmake --build build/telemetry-debug --target naim-hostd-http-tests
- ./build/telemetry-debug/naim-hostd-http-tests
- npm test -- --run src/telemetryStore.test.js
- npm run build
- bash -n scripts/ci/main-bootstrap-controller-update.sh
- naim-controller show-telemetry-health env override smoke test