### PR TITLE
Refactor telemetry boundary cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,21 +558,33 @@ target_include_directories(
 target_link_libraries(naim-plane-observation-matcher-tests PRIVATE naim-common)
 naim_enable_strict_warnings(naim-plane-observation-matcher-tests)
 
-add_executable(
-  naim-telemetry-live-store-tests
+set(
+  NAIM_CONTROLLER_TELEMETRY_SOURCES
+  controller/src/telemetry/telemetry_alert_builder.cpp
   controller/src/telemetry/telemetry_clock.cpp
   controller/src/telemetry/telemetry_environment_reader.cpp
+  controller/src/telemetry/telemetry_frame_json_builder.cpp
   controller/src/telemetry/telemetry_frame_matcher.cpp
   controller/src/telemetry/telemetry_frame_normalizer.cpp
   controller/src/telemetry/telemetry_frame_ring_buffer.cpp
+  controller/src/telemetry/telemetry_frame_sequence_less.cpp
   controller/src/telemetry/telemetry_health_builder.cpp
+  controller/src/telemetry/telemetry_history_downsampler.cpp
   controller/src/telemetry/telemetry_live_store.cpp
+  controller/src/telemetry/telemetry_live_store_state.cpp
+  controller/src/telemetry/telemetry_node_health_builder.cpp
   controller/src/telemetry/telemetry_open_metrics_exporter.cpp
   controller/src/telemetry/telemetry_operational_config.cpp
   controller/src/telemetry/telemetry_persistence_repository.cpp
+  controller/src/telemetry/telemetry_plane_aggregate_builder.cpp
   controller/src/telemetry/telemetry_snapshot_builder.cpp
   controller/src/telemetry/telemetry_sqlite_connection.cpp
   controller/src/telemetry/telemetry_stream_metrics_service.cpp
+)
+
+add_executable(
+  naim-telemetry-live-store-tests
+  ${NAIM_CONTROLLER_TELEMETRY_SOURCES}
   controller/src/telemetry/telemetry_live_store_tests.cpp
 )
 target_include_directories(
@@ -638,19 +650,7 @@ add_executable(
   controller/src/infra/controller_network_manager.cpp
   controller/src/knowledge/knowledge_vault_service_repository.cpp
   controller/src/observation/plane_observation_matcher.cpp
-  controller/src/telemetry/telemetry_clock.cpp
-  controller/src/telemetry/telemetry_environment_reader.cpp
-  controller/src/telemetry/telemetry_frame_matcher.cpp
-  controller/src/telemetry/telemetry_frame_normalizer.cpp
-  controller/src/telemetry/telemetry_frame_ring_buffer.cpp
-  controller/src/telemetry/telemetry_health_builder.cpp
-  controller/src/telemetry/telemetry_live_store.cpp
-  controller/src/telemetry/telemetry_open_metrics_exporter.cpp
-  controller/src/telemetry/telemetry_operational_config.cpp
-  controller/src/telemetry/telemetry_persistence_repository.cpp
-  controller/src/telemetry/telemetry_snapshot_builder.cpp
-  controller/src/telemetry/telemetry_sqlite_connection.cpp
-  controller/src/telemetry/telemetry_stream_metrics_service.cpp
+  ${NAIM_CONTROLLER_TELEMETRY_SOURCES}
 )
 target_include_directories(
   naim-hostd-http-tests PRIVATE common/include controller/include)
@@ -1460,19 +1460,7 @@ add_executable(
   controller/src/skills/skills_factory_service.cpp
   controller/src/scheduler/scheduler_service.cpp
   controller/src/read_model/state_aggregate_loader.cpp
-  controller/src/telemetry/telemetry_clock.cpp
-  controller/src/telemetry/telemetry_environment_reader.cpp
-  controller/src/telemetry/telemetry_frame_matcher.cpp
-  controller/src/telemetry/telemetry_frame_normalizer.cpp
-  controller/src/telemetry/telemetry_frame_ring_buffer.cpp
-  controller/src/telemetry/telemetry_health_builder.cpp
-  controller/src/telemetry/telemetry_live_store.cpp
-  controller/src/telemetry/telemetry_open_metrics_exporter.cpp
-  controller/src/telemetry/telemetry_operational_config.cpp
-  controller/src/telemetry/telemetry_persistence_repository.cpp
-  controller/src/telemetry/telemetry_snapshot_builder.cpp
-  controller/src/telemetry/telemetry_sqlite_connection.cpp
-  controller/src/telemetry/telemetry_stream_metrics_service.cpp
+  ${NAIM_CONTROLLER_TELEMETRY_SOURCES}
   controller/src/web/web_ui_service.cpp
   controller/src/app/controller_app.cpp
   controller/src/app/controller_composition_root.cpp

--- a/controller/include/telemetry/telemetry_aggregate_types.h
+++ b/controller/include/telemetry/telemetry_aggregate_types.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace naim::controller {
+
+struct TelemetryHistoryBucketAccumulator {
+  std::string node_name;
+  std::string plane_name;
+  std::uint64_t bucket_start_ms = 0;
+  std::uint64_t bucket_ms = 0;
+  std::uint64_t first_sequence = 0;
+  std::uint64_t last_sequence = 0;
+  std::uint64_t sample_count = 0;
+  double cpu_utilization_sum = 0.0;
+  double gpu_utilization_sum = 0.0;
+  double max_gpu_utilization_pct = 0.0;
+  std::uint64_t max_queue_delay_ms = 0;
+  std::uint64_t max_publish_ms = 0;
+  std::uint64_t max_controller_ingest_ms = 0;
+};
+
+struct TelemetryPlaneAccumulator {
+  std::string plane_name;
+  std::uint64_t node_count = 0;
+  std::uint64_t stale_nodes = 0;
+  std::uint64_t degraded_nodes = 0;
+  std::uint64_t dropped_frames_total = 0;
+  std::uint64_t latest_sequence = 0;
+  std::uint64_t max_last_frame_age_ms = 0;
+  std::uint64_t max_queue_delay_ms = 0;
+  std::uint64_t max_publish_ms = 0;
+  std::uint64_t max_controller_ingest_ms = 0;
+  std::uint64_t gpu_count = 0;
+  std::uint64_t plane_instance_count = 0;
+  std::uint64_t plane_ready_instance_count = 0;
+  std::uint64_t plane_not_ready_instance_count = 0;
+  double gpu_utilization_sum = 0.0;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_alert_builder.h
+++ b/controller/include/telemetry/telemetry_alert_builder.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "telemetry/telemetry_frame_matcher.h"
+#include "telemetry/telemetry_live_store_types.h"
+#include "telemetry/telemetry_state_types.h"
+
+namespace naim::controller {
+
+class TelemetryAlertBuilder final {
+ public:
+  nlohmann::json Build(
+      const std::vector<const TelemetryNodeBuffer*>& buffers,
+      const TelemetryPersistenceState& persistence,
+      const TelemetryStreamMetrics& streams,
+      const TelemetryAlertThresholds& thresholds,
+      std::uint64_t dropped_frames_total,
+      std::uint64_t now_ms) const;
+
+ private:
+  TelemetryFrameMatcher matcher_;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_frame_json_builder.h
+++ b/controller/include/telemetry/telemetry_frame_json_builder.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+#include <nlohmann/json.hpp>
+
+#include "naim/runtime/runtime_status.h"
+#include "telemetry/telemetry_frame_matcher.h"
+
+namespace naim::controller {
+
+class TelemetryFrameJsonBuilder final {
+ public:
+  nlohmann::json Build(
+      const naim::HostTelemetryFrame& frame,
+      std::uint64_t now_ms) const;
+  nlohmann::json BuildLatencyBreakdown(
+      const naim::HostTelemetryFrame& frame,
+      std::uint64_t controller_ingest_delay_ms) const;
+
+ private:
+  TelemetryFrameMatcher matcher_;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_frame_ring_buffer.h
+++ b/controller/include/telemetry/telemetry_frame_ring_buffer.h
@@ -6,6 +6,7 @@
 
 #include "telemetry/telemetry_frame_matcher.h"
 #include "telemetry/telemetry_live_store_types.h"
+#include "telemetry/telemetry_state_types.h"
 
 namespace naim::controller {
 

--- a/controller/include/telemetry/telemetry_frame_sequence_less.h
+++ b/controller/include/telemetry/telemetry_frame_sequence_less.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "naim/runtime/runtime_status.h"
+
+namespace naim::controller {
+
+class TelemetryFrameSequenceLess final {
+ public:
+  bool operator()(
+      const naim::HostTelemetryFrame& left,
+      const naim::HostTelemetryFrame& right) const;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_health_builder.h
+++ b/controller/include/telemetry/telemetry_health_builder.h
@@ -6,9 +6,12 @@
 
 #include <nlohmann/json.hpp>
 
+#include "telemetry/telemetry_alert_builder.h"
 #include "telemetry/telemetry_frame_matcher.h"
 #include "telemetry/telemetry_live_store_types.h"
+#include "telemetry/telemetry_plane_aggregate_builder.h"
 #include "telemetry/telemetry_persistence_repository.h"
+#include "telemetry/telemetry_state_types.h"
 #include "telemetry/telemetry_stream_metrics_service.h"
 
 namespace naim::controller {
@@ -25,25 +28,12 @@ class TelemetryHealthBuilder final {
       std::uint64_t dropped_frames_total,
       const std::optional<std::string>& plane_name,
       std::uint64_t now_ms) const;
-  nlohmann::json BuildAlerts(
-      const std::vector<const TelemetryNodeBuffer*>& buffers,
-      const TelemetryPersistenceState& persistence,
-      const TelemetryStreamMetrics& streams,
-      const TelemetryAlertThresholds& thresholds,
-      std::uint64_t dropped_frames_total,
-      std::uint64_t now_ms) const;
-  nlohmann::json BuildTelemetryHealth(
-      const naim::HostTelemetryFrame& frame,
-      const TelemetryNodeBuffer& buffer,
-      std::uint64_t now_ms,
-      std::uint64_t controller_ingest_delay_ms) const;
-  nlohmann::json BuildPlaneAggregates(
-      const std::vector<const TelemetryNodeBuffer*>& buffers,
-      std::uint64_t now_ms) const;
 
  private:
   TelemetryFrameMatcher matcher_;
+  TelemetryAlertBuilder alert_builder_;
   TelemetryPersistenceRepository persistence_repository_;
+  TelemetryPlaneAggregateBuilder plane_aggregate_builder_;
   TelemetryStreamMetricsService stream_metrics_service_;
 };
 

--- a/controller/include/telemetry/telemetry_history_downsampler.h
+++ b/controller/include/telemetry/telemetry_history_downsampler.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "telemetry/telemetry_frame_matcher.h"
+#include "telemetry/telemetry_state_types.h"
+
+namespace naim::controller {
+
+class TelemetryHistoryDownsampler final {
+ public:
+  nlohmann::json Build(
+      const std::vector<const TelemetryNodeBuffer*>& buffers,
+      int history_seconds,
+      std::uint64_t now_ms,
+      std::uint64_t warm_bucket_ms,
+      std::uint64_t cold_bucket_ms) const;
+
+ private:
+  TelemetryFrameMatcher matcher_;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_live_store.h
+++ b/controller/include/telemetry/telemetry_live_store.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -9,24 +10,20 @@
 #include <nlohmann/json.hpp>
 
 #include "naim/runtime/runtime_status.h"
-#include "telemetry/telemetry_clock.h"
-#include "telemetry/telemetry_frame_normalizer.h"
-#include "telemetry/telemetry_frame_ring_buffer.h"
-#include "telemetry/telemetry_health_builder.h"
 #include "telemetry/telemetry_live_store_types.h"
-#include "telemetry/telemetry_open_metrics_exporter.h"
-#include "telemetry/telemetry_operational_config.h"
-#include "telemetry/telemetry_persistence_repository.h"
-#include "telemetry/telemetry_snapshot_builder.h"
-#include "telemetry/telemetry_stream_metrics_service.h"
 
 namespace naim::controller {
+
+class TelemetryLiveStoreState;
 
 class TelemetryLiveStore final {
  public:
   using RetentionConfig = TelemetryRetentionConfig;
   using AlertThresholds = TelemetryAlertThresholds;
   using StreamDelta = TelemetryStreamDelta;
+
+  TelemetryLiveStore();
+  ~TelemetryLiveStore();
 
   static TelemetryLiveStore& Instance();
 
@@ -66,22 +63,7 @@ class TelemetryLiveStore final {
       std::size_t retention_capacity);
 
   mutable std::mutex mutex_;
-  std::vector<TelemetryNodeBuffer> nodes_;
-  std::uint64_t latest_sequence_ = 0;
-  std::uint64_t dropped_frames_total_ = 0;
-  RetentionConfig retention_;
-  AlertThresholds thresholds_;
-  TelemetryPersistenceState persistence_;
-  TelemetryStreamMetrics streams_;
-  TelemetryClock clock_;
-  TelemetryFrameNormalizer frame_normalizer_;
-  TelemetryOperationalConfig operational_config_;
-  TelemetryFrameRingBuffer ring_buffer_;
-  TelemetryPersistenceRepository persistence_repository_;
-  TelemetryStreamMetricsService stream_metrics_service_;
-  TelemetryHealthBuilder health_builder_;
-  TelemetrySnapshotBuilder snapshot_builder_;
-  TelemetryOpenMetricsExporter open_metrics_exporter_;
+  std::unique_ptr<TelemetryLiveStoreState> state_;
 };
 
 }  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_live_store_state.h
+++ b/controller/include/telemetry/telemetry_live_store_state.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "telemetry/telemetry_clock.h"
+#include "telemetry/telemetry_frame_normalizer.h"
+#include "telemetry/telemetry_frame_ring_buffer.h"
+#include "telemetry/telemetry_health_builder.h"
+#include "telemetry/telemetry_live_store_types.h"
+#include "telemetry/telemetry_open_metrics_exporter.h"
+#include "telemetry/telemetry_operational_config.h"
+#include "telemetry/telemetry_persistence_repository.h"
+#include "telemetry/telemetry_snapshot_builder.h"
+#include "telemetry/telemetry_state_types.h"
+#include "telemetry/telemetry_stream_metrics_service.h"
+
+namespace naim::controller {
+
+class TelemetryLiveStoreState final {
+ public:
+  TelemetryLiveStoreState();
+
+  std::vector<TelemetryNodeBuffer> nodes;
+  std::uint64_t latest_sequence = 0;
+  std::uint64_t dropped_frames_total = 0;
+  TelemetryRetentionConfig retention;
+  TelemetryAlertThresholds thresholds;
+  TelemetryPersistenceState persistence;
+  TelemetryStreamMetrics streams;
+  TelemetryClock clock;
+  TelemetryFrameNormalizer frame_normalizer;
+  TelemetryOperationalConfig operational_config;
+  TelemetryFrameRingBuffer ring_buffer;
+  TelemetryPersistenceRepository persistence_repository;
+  TelemetryStreamMetricsService stream_metrics_service;
+  TelemetryHealthBuilder health_builder;
+  TelemetrySnapshotBuilder snapshot_builder;
+  TelemetryOpenMetricsExporter open_metrics_exporter;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_live_store_types.h
+++ b/controller/include/telemetry/telemetry_live_store_types.h
@@ -2,7 +2,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <deque>
 #include <string>
 #include <vector>
 
@@ -34,72 +33,6 @@ struct TelemetryStreamDelta {
   std::uint64_t first_available_sequence = 0;
   std::uint64_t latest_sequence = 0;
   std::uint64_t dropped_frames_total = 0;
-};
-
-struct TelemetryNodeBuffer {
-  naim::HostTelemetryFrame latest;
-  std::deque<naim::HostTelemetryFrame> history;
-  std::uint64_t dropped_frames_total = 0;
-  std::uint64_t last_pruned_sequence = 0;
-};
-
-struct TelemetryPersistenceState {
-  bool enabled = false;
-  std::string db_path;
-  std::size_t retention_capacity = 0;
-  std::uint64_t loaded_frames_total = 0;
-  std::uint64_t persisted_frames_total = 0;
-  std::uint64_t pruned_frames_total = 0;
-  std::uint64_t error_count = 0;
-  std::string last_error;
-};
-
-struct TelemetryStreamState {
-  std::uint64_t active_clients = 0;
-  std::uint64_t opened_total = 0;
-  std::uint64_t closed_total = 0;
-  std::uint64_t replay_required_total = 0;
-  std::uint64_t send_failure_total = 0;
-  std::uint64_t reconnect_total = 0;
-};
-
-struct TelemetryStreamMetrics {
-  TelemetryStreamState telemetry;
-  TelemetryStreamState live;
-};
-
-struct TelemetryHistoryBucketAccumulator {
-  std::string node_name;
-  std::string plane_name;
-  std::uint64_t bucket_start_ms = 0;
-  std::uint64_t bucket_ms = 0;
-  std::uint64_t first_sequence = 0;
-  std::uint64_t last_sequence = 0;
-  std::uint64_t sample_count = 0;
-  double cpu_utilization_sum = 0.0;
-  double gpu_utilization_sum = 0.0;
-  double max_gpu_utilization_pct = 0.0;
-  std::uint64_t max_queue_delay_ms = 0;
-  std::uint64_t max_publish_ms = 0;
-  std::uint64_t max_controller_ingest_ms = 0;
-};
-
-struct TelemetryPlaneAccumulator {
-  std::string plane_name;
-  std::uint64_t node_count = 0;
-  std::uint64_t stale_nodes = 0;
-  std::uint64_t degraded_nodes = 0;
-  std::uint64_t dropped_frames_total = 0;
-  std::uint64_t latest_sequence = 0;
-  std::uint64_t max_last_frame_age_ms = 0;
-  std::uint64_t max_queue_delay_ms = 0;
-  std::uint64_t max_publish_ms = 0;
-  std::uint64_t max_controller_ingest_ms = 0;
-  std::uint64_t gpu_count = 0;
-  std::uint64_t plane_instance_count = 0;
-  std::uint64_t plane_ready_instance_count = 0;
-  std::uint64_t plane_not_ready_instance_count = 0;
-  double gpu_utilization_sum = 0.0;
 };
 
 }  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_node_health_builder.h
+++ b/controller/include/telemetry/telemetry_node_health_builder.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+#include <nlohmann/json.hpp>
+
+#include "naim/runtime/runtime_status.h"
+#include "telemetry/telemetry_state_types.h"
+
+namespace naim::controller {
+
+class TelemetryNodeHealthBuilder final {
+ public:
+  nlohmann::json Build(
+      const naim::HostTelemetryFrame& frame,
+      const TelemetryNodeBuffer& buffer,
+      std::uint64_t now_ms,
+      std::uint64_t controller_ingest_delay_ms) const;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_persistence_repository.h
+++ b/controller/include/telemetry/telemetry_persistence_repository.h
@@ -8,7 +8,7 @@
 #include <sqlite3.h>
 
 #include "naim/runtime/runtime_status.h"
-#include "telemetry/telemetry_live_store_types.h"
+#include "telemetry/telemetry_state_types.h"
 
 namespace naim::controller {
 

--- a/controller/include/telemetry/telemetry_plane_aggregate_builder.h
+++ b/controller/include/telemetry/telemetry_plane_aggregate_builder.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "telemetry/telemetry_frame_matcher.h"
+#include "telemetry/telemetry_node_health_builder.h"
+#include "telemetry/telemetry_state_types.h"
+
+namespace naim::controller {
+
+class TelemetryPlaneAggregateBuilder final {
+ public:
+  nlohmann::json Build(
+      const std::vector<const TelemetryNodeBuffer*>& buffers,
+      std::uint64_t now_ms) const;
+
+ private:
+  TelemetryFrameMatcher matcher_;
+  TelemetryNodeHealthBuilder node_health_builder_;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_snapshot_builder.h
+++ b/controller/include/telemetry/telemetry_snapshot_builder.h
@@ -6,10 +6,15 @@
 
 #include <nlohmann/json.hpp>
 
+#include "telemetry/telemetry_alert_builder.h"
 #include "telemetry/telemetry_frame_matcher.h"
-#include "telemetry/telemetry_health_builder.h"
+#include "telemetry/telemetry_frame_json_builder.h"
+#include "telemetry/telemetry_history_downsampler.h"
 #include "telemetry/telemetry_live_store_types.h"
+#include "telemetry/telemetry_node_health_builder.h"
+#include "telemetry/telemetry_plane_aggregate_builder.h"
 #include "telemetry/telemetry_persistence_repository.h"
+#include "telemetry/telemetry_state_types.h"
 #include "telemetry/telemetry_stream_metrics_service.h"
 
 namespace naim::controller {
@@ -27,22 +32,14 @@ class TelemetrySnapshotBuilder final {
       const std::optional<std::string>& plane_name,
       int history_seconds,
       std::uint64_t now_ms) const;
-  nlohmann::json FrameToJson(
-      const naim::HostTelemetryFrame& frame,
-      std::uint64_t now_ms) const;
-  nlohmann::json BuildLatencyBreakdown(
-      const naim::HostTelemetryFrame& frame,
-      std::uint64_t controller_ingest_delay_ms) const;
-  nlohmann::json BuildDownsampledHistory(
-      const std::vector<const TelemetryNodeBuffer*>& buffers,
-      int history_seconds,
-      std::uint64_t now_ms,
-      std::uint64_t warm_bucket_ms,
-      std::uint64_t cold_bucket_ms) const;
 
  private:
+  TelemetryAlertBuilder alert_builder_;
   TelemetryFrameMatcher matcher_;
-  TelemetryHealthBuilder health_builder_;
+  TelemetryFrameJsonBuilder frame_json_builder_;
+  TelemetryHistoryDownsampler history_downsampler_;
+  TelemetryNodeHealthBuilder node_health_builder_;
+  TelemetryPlaneAggregateBuilder plane_aggregate_builder_;
   TelemetryPersistenceRepository persistence_repository_;
   TelemetryStreamMetricsService stream_metrics_service_;
 };

--- a/controller/include/telemetry/telemetry_state_types.h
+++ b/controller/include/telemetry/telemetry_state_types.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <string>
+
+#include "naim/runtime/runtime_status.h"
+
+namespace naim::controller {
+
+struct TelemetryNodeBuffer {
+  naim::HostTelemetryFrame latest;
+  std::deque<naim::HostTelemetryFrame> history;
+  std::uint64_t dropped_frames_total = 0;
+  std::uint64_t last_pruned_sequence = 0;
+};
+
+struct TelemetryPersistenceState {
+  bool enabled = false;
+  std::string db_path;
+  std::size_t retention_capacity = 0;
+  std::uint64_t loaded_frames_total = 0;
+  std::uint64_t persisted_frames_total = 0;
+  std::uint64_t pruned_frames_total = 0;
+  std::uint64_t error_count = 0;
+  std::string last_error;
+};
+
+struct TelemetryStreamState {
+  std::uint64_t active_clients = 0;
+  std::uint64_t opened_total = 0;
+  std::uint64_t closed_total = 0;
+  std::uint64_t replay_required_total = 0;
+  std::uint64_t send_failure_total = 0;
+  std::uint64_t reconnect_total = 0;
+};
+
+struct TelemetryStreamMetrics {
+  TelemetryStreamState telemetry;
+  TelemetryStreamState live;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_stream_metrics_service.h
+++ b/controller/include/telemetry/telemetry_stream_metrics_service.h
@@ -4,7 +4,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include "telemetry/telemetry_live_store_types.h"
+#include "telemetry/telemetry_state_types.h"
 
 namespace naim::controller {
 

--- a/controller/src/telemetry/telemetry_alert_builder.cpp
+++ b/controller/src/telemetry/telemetry_alert_builder.cpp
@@ -1,0 +1,110 @@
+#include "telemetry/telemetry_alert_builder.h"
+
+namespace naim::controller {
+
+nlohmann::json TelemetryAlertBuilder::Build(
+    const std::vector<const TelemetryNodeBuffer*>& buffers,
+    const TelemetryPersistenceState& persistence,
+    const TelemetryStreamMetrics& streams,
+    const TelemetryAlertThresholds& thresholds,
+    const std::uint64_t dropped_frames_total,
+    const std::uint64_t now_ms) const {
+  nlohmann::json alerts = nlohmann::json::array();
+  if (!persistence.enabled) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.persistence.disabled"},
+        {"severity", "warning"},
+        {"message", "sqlite telemetry ring buffer is disabled"},
+    });
+  }
+  if (persistence.error_count > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.persistence.errors"},
+        {"severity", "warning"},
+        {"message", "sqlite telemetry ring buffer reported errors"},
+        {"count", persistence.error_count},
+        {"last_error", persistence.last_error},
+    });
+  }
+  if (dropped_frames_total > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.controller.dropped_frames"},
+        {"severity", "warning"},
+        {"message", "controller telemetry ring buffer pruned live frames"},
+        {"count", dropped_frames_total},
+    });
+  }
+  if (streams.telemetry.send_failure_total > 0 || streams.live.send_failure_total > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.stream.send_failures"},
+        {"severity", "warning"},
+        {"message", "telemetry stream clients observed send failures"},
+        {"telemetry_failures", streams.telemetry.send_failure_total},
+        {"live_failures", streams.live.send_failure_total},
+    });
+  }
+  if (streams.telemetry.replay_required_total > 0 || streams.live.replay_required_total > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.stream.replay_required"},
+        {"severity", "warning"},
+        {"message", "telemetry stream replay was required"},
+        {"telemetry_replay_required_total", streams.telemetry.replay_required_total},
+        {"live_replay_required_total", streams.live.replay_required_total},
+    });
+  }
+  for (const auto* buffer : buffers) {
+    if (buffer == nullptr) {
+      continue;
+    }
+    const auto& frame = buffer->latest;
+    const auto ingest_ms = matcher_.ControllerIngestDelayMs(frame, now_ms);
+    if (ingest_ms >= thresholds.stale_critical_ms) {
+      alerts.push_back(nlohmann::json{
+          {"code", "telemetry.node.stale"},
+          {"severity", "critical"},
+          {"node_name", frame.node_name},
+          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
+          {"age_ms", ingest_ms},
+      });
+    } else if (ingest_ms >= thresholds.stale_warning_ms) {
+      alerts.push_back(nlohmann::json{
+          {"code", "telemetry.node.slow"},
+          {"severity", "warning"},
+          {"node_name", frame.node_name},
+          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
+          {"age_ms", ingest_ms},
+      });
+    }
+    if (ingest_ms >= thresholds.ingest_warning_ms) {
+      alerts.push_back(nlohmann::json{
+          {"code", "telemetry.controller.ingest_delay"},
+          {"severity", "warning"},
+          {"node_name", frame.node_name},
+          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
+          {"delay_ms", ingest_ms},
+      });
+    }
+    if (frame.publisher_queue_delay_ms >= thresholds.queue_warning_ms) {
+      alerts.push_back(nlohmann::json{
+          {"code", "telemetry.publisher.queue_delay"},
+          {"severity", "warning"},
+          {"node_name", frame.node_name},
+          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
+          {"delay_ms", frame.publisher_queue_delay_ms},
+      });
+    }
+    if (frame.publish_error_count > 0) {
+      alerts.push_back(nlohmann::json{
+          {"code", "telemetry.publisher.errors"},
+          {"severity", "warning"},
+          {"node_name", frame.node_name},
+          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
+          {"count", frame.publish_error_count},
+          {"last_error", frame.last_publish_error},
+      });
+    }
+  }
+  return alerts;
+}
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_frame_json_builder.cpp
+++ b/controller/src/telemetry/telemetry_frame_json_builder.cpp
@@ -1,0 +1,50 @@
+#include "telemetry/telemetry_frame_json_builder.h"
+
+#include <string>
+
+namespace naim::controller {
+
+nlohmann::json TelemetryFrameJsonBuilder::Build(
+    const naim::HostTelemetryFrame& frame,
+    const std::uint64_t now_ms) const {
+  auto payload = nlohmann::json::parse(naim::SerializeHostTelemetryFrameJson(frame));
+  const std::uint64_t ttl_ms =
+      frame.ttl_ms > 0 ? static_cast<std::uint64_t>(frame.ttl_ms) : 0;
+  const std::uint64_t expires_at_ms = frame.sequence + ttl_ms;
+  const bool stale = frame.sequence == 0 || ttl_ms == 0 || expires_at_ms <= now_ms;
+  payload["stale"] = stale;
+  payload["expires_in_ms"] = stale ? 0 : expires_at_ms - now_ms;
+  const auto controller_ingest_delay_ms = matcher_.ControllerIngestDelayMs(frame, now_ms);
+  payload["controller_ingest_delay_ms"] = controller_ingest_delay_ms;
+  payload["last_frame_age_ms"] = controller_ingest_delay_ms;
+  payload["telemetry_health_status"] =
+      stale ? "stale"
+            : frame.telemetry_dropped_frames > 0 || frame.publish_error_count > 0
+                ? "degraded"
+                : "ok";
+  payload["latency_breakdown"] = BuildLatencyBreakdown(frame, controller_ingest_delay_ms);
+  payload["transport"] = nlohmann::json{
+      {"primary", "sse"},
+      {"fallback", "snapshot-poll"},
+      {"sequence", frame.sequence},
+      {"schema_version", frame.schema_version},
+  };
+  return payload;
+}
+
+nlohmann::json TelemetryFrameJsonBuilder::BuildLatencyBreakdown(
+    const naim::HostTelemetryFrame& frame,
+    const std::uint64_t controller_ingest_delay_ms) const {
+  const std::uint64_t total_observed_ms =
+      frame.collector_duration_ms + frame.publisher_queue_delay_ms +
+      frame.publish_duration_ms + controller_ingest_delay_ms;
+  return nlohmann::json{
+      {"collect_ms", frame.collector_duration_ms},
+      {"queue_ms", frame.publisher_queue_delay_ms},
+      {"publish_ms", frame.publish_duration_ms},
+      {"controller_ingest_ms", controller_ingest_delay_ms},
+      {"total_observed_ms", total_observed_ms},
+  };
+}
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_frame_ring_buffer.cpp
+++ b/controller/src/telemetry/telemetry_frame_ring_buffer.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <cstddef>
 
+#include "telemetry/telemetry_frame_sequence_less.h"
+
 namespace naim::controller {
 
 bool TelemetryFrameRingBuffer::Upsert(
@@ -61,12 +63,7 @@ std::vector<naim::HostTelemetryFrame> TelemetryFrameRingBuffer::LoadFramesAfter(
       }
     }
   }
-  std::sort(
-      frames.begin(),
-      frames.end(),
-      [](const auto& left, const auto& right) {
-        return left.sequence < right.sequence;
-      });
+  std::sort(frames.begin(), frames.end(), TelemetryFrameSequenceLess{});
   if (frames.size() > retention.stream_batch_limit) {
     const auto erase_count =
         static_cast<std::ptrdiff_t>(frames.size() - retention.stream_batch_limit);
@@ -107,12 +104,7 @@ TelemetryStreamDelta TelemetryFrameRingBuffer::LoadStreamDeltaAfter(
     }
   }
   delta.first_available_sequence = first_available;
-  std::sort(
-      frames.begin(),
-      frames.end(),
-      [](const auto& left, const auto& right) {
-        return left.sequence < right.sequence;
-      });
+  std::sort(frames.begin(), frames.end(), TelemetryFrameSequenceLess{});
   if (frames.size() > retention.stream_batch_limit) {
     delta.replay_required = true;
     if (delta.replay_reason.empty()) {

--- a/controller/src/telemetry/telemetry_frame_sequence_less.cpp
+++ b/controller/src/telemetry/telemetry_frame_sequence_less.cpp
@@ -1,0 +1,11 @@
+#include "telemetry/telemetry_frame_sequence_less.h"
+
+namespace naim::controller {
+
+bool TelemetryFrameSequenceLess::operator()(
+    const naim::HostTelemetryFrame& left,
+    const naim::HostTelemetryFrame& right) const {
+  return left.sequence < right.sequence;
+}
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_health_builder.cpp
+++ b/controller/src/telemetry/telemetry_health_builder.cpp
@@ -1,7 +1,6 @@
 #include "telemetry/telemetry_health_builder.h"
 
-#include <algorithm>
-#include <map>
+#include <string>
 
 namespace naim::controller {
 
@@ -21,7 +20,7 @@ nlohmann::json TelemetryHealthBuilder::BuildHealth(
       matched_buffers.push_back(&buffer);
     }
   }
-  const auto alerts = BuildAlerts(
+  const auto alerts = alert_builder_.Build(
       matched_buffers,
       persistence,
       streams,
@@ -67,212 +66,9 @@ nlohmann::json TelemetryHealthBuilder::BuildHealth(
            {"queue_warning_ms", thresholds.queue_warning_ms},
            {"browser_apply_warning_ms", thresholds.browser_apply_warning_ms},
        }},
-      {"planes", BuildPlaneAggregates(matched_buffers, now_ms)},
+      {"planes", plane_aggregate_builder_.Build(matched_buffers, now_ms)},
       {"alerts", alerts},
   };
-}
-
-nlohmann::json TelemetryHealthBuilder::BuildAlerts(
-    const std::vector<const TelemetryNodeBuffer*>& buffers,
-    const TelemetryPersistenceState& persistence,
-    const TelemetryStreamMetrics& streams,
-    const TelemetryAlertThresholds& thresholds,
-    const std::uint64_t dropped_frames_total,
-    const std::uint64_t now_ms) const {
-  nlohmann::json alerts = nlohmann::json::array();
-  if (!persistence.enabled) {
-    alerts.push_back(nlohmann::json{
-        {"code", "telemetry.persistence.disabled"},
-        {"severity", "warning"},
-        {"message", "sqlite telemetry ring buffer is disabled"},
-    });
-  }
-  if (persistence.error_count > 0) {
-    alerts.push_back(nlohmann::json{
-        {"code", "telemetry.persistence.errors"},
-        {"severity", "warning"},
-        {"message", "sqlite telemetry ring buffer reported errors"},
-        {"count", persistence.error_count},
-        {"last_error", persistence.last_error},
-    });
-  }
-  if (dropped_frames_total > 0) {
-    alerts.push_back(nlohmann::json{
-        {"code", "telemetry.controller.dropped_frames"},
-        {"severity", "warning"},
-        {"message", "controller telemetry ring buffer pruned live frames"},
-        {"count", dropped_frames_total},
-    });
-  }
-  if (streams.telemetry.send_failure_total > 0 || streams.live.send_failure_total > 0) {
-    alerts.push_back(nlohmann::json{
-        {"code", "telemetry.stream.send_failures"},
-        {"severity", "warning"},
-        {"message", "telemetry stream clients observed send failures"},
-        {"telemetry_failures", streams.telemetry.send_failure_total},
-        {"live_failures", streams.live.send_failure_total},
-    });
-  }
-  if (streams.telemetry.replay_required_total > 0 || streams.live.replay_required_total > 0) {
-    alerts.push_back(nlohmann::json{
-        {"code", "telemetry.stream.replay_required"},
-        {"severity", "warning"},
-        {"message", "telemetry stream replay was required"},
-        {"telemetry_replay_required_total", streams.telemetry.replay_required_total},
-        {"live_replay_required_total", streams.live.replay_required_total},
-    });
-  }
-  for (const auto* buffer : buffers) {
-    if (buffer == nullptr) {
-      continue;
-    }
-    const auto& frame = buffer->latest;
-    const auto ingest_ms = matcher_.ControllerIngestDelayMs(frame, now_ms);
-    if (ingest_ms >= thresholds.stale_critical_ms) {
-      alerts.push_back(nlohmann::json{
-          {"code", "telemetry.node.stale"},
-          {"severity", "critical"},
-          {"node_name", frame.node_name},
-          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
-          {"age_ms", ingest_ms},
-      });
-    } else if (ingest_ms >= thresholds.stale_warning_ms) {
-      alerts.push_back(nlohmann::json{
-          {"code", "telemetry.node.slow"},
-          {"severity", "warning"},
-          {"node_name", frame.node_name},
-          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
-          {"age_ms", ingest_ms},
-      });
-    }
-    if (ingest_ms >= thresholds.ingest_warning_ms) {
-      alerts.push_back(nlohmann::json{
-          {"code", "telemetry.controller.ingest_delay"},
-          {"severity", "warning"},
-          {"node_name", frame.node_name},
-          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
-          {"delay_ms", ingest_ms},
-      });
-    }
-    if (frame.publisher_queue_delay_ms >= thresholds.queue_warning_ms) {
-      alerts.push_back(nlohmann::json{
-          {"code", "telemetry.publisher.queue_delay"},
-          {"severity", "warning"},
-          {"node_name", frame.node_name},
-          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
-          {"delay_ms", frame.publisher_queue_delay_ms},
-      });
-    }
-    if (frame.publish_error_count > 0) {
-      alerts.push_back(nlohmann::json{
-          {"code", "telemetry.publisher.errors"},
-          {"severity", "warning"},
-          {"node_name", frame.node_name},
-          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
-          {"count", frame.publish_error_count},
-          {"last_error", frame.last_publish_error},
-      });
-    }
-  }
-  return alerts;
-}
-
-nlohmann::json TelemetryHealthBuilder::BuildTelemetryHealth(
-    const naim::HostTelemetryFrame& frame,
-    const TelemetryNodeBuffer& buffer,
-    const std::uint64_t now_ms,
-    const std::uint64_t controller_ingest_delay_ms) const {
-  const std::uint64_t ttl_ms =
-      frame.ttl_ms > 0 ? static_cast<std::uint64_t>(frame.ttl_ms) : 0;
-  const bool stale =
-      frame.sequence == 0 || ttl_ms == 0 || frame.sequence + ttl_ms <= now_ms;
-  std::string status = "ok";
-  if (stale) {
-    status = "stale";
-  } else if (
-      buffer.dropped_frames_total > 0 || frame.telemetry_dropped_frames > 0 ||
-      frame.publish_error_count > 0 || !frame.degraded_reason.empty()) {
-    status = "degraded";
-  }
-  return nlohmann::json{
-      {"status", status},
-      {"last_frame_age_ms", controller_ingest_delay_ms},
-      {"dropped_frames_total", buffer.dropped_frames_total},
-      {"publish_error_count", frame.publish_error_count},
-      {"publish_error", frame.last_publish_error},
-      {"degraded_reason", frame.degraded_reason},
-  };
-}
-
-nlohmann::json TelemetryHealthBuilder::BuildPlaneAggregates(
-    const std::vector<const TelemetryNodeBuffer*>& buffers,
-    const std::uint64_t now_ms) const {
-  std::map<std::string, TelemetryPlaneAccumulator> planes;
-  for (const auto* buffer : buffers) {
-    if (buffer == nullptr) {
-      continue;
-    }
-    const auto& frame = buffer->latest;
-    auto& plane = planes[matcher_.PlaneKeyForFrame(frame)];
-    if (plane.plane_name.empty()) {
-      plane.plane_name = matcher_.PlaneKeyForFrame(frame);
-    }
-    const auto ingest_ms = matcher_.ControllerIngestDelayMs(frame, now_ms);
-    const auto health = BuildTelemetryHealth(frame, *buffer, now_ms, ingest_ms);
-    plane.node_count += 1;
-    plane.latest_sequence = std::max(plane.latest_sequence, frame.sequence);
-    plane.dropped_frames_total += buffer->dropped_frames_total;
-    plane.max_last_frame_age_ms = std::max(plane.max_last_frame_age_ms, ingest_ms);
-    plane.max_queue_delay_ms = std::max(plane.max_queue_delay_ms, frame.publisher_queue_delay_ms);
-    plane.max_publish_ms = std::max(plane.max_publish_ms, frame.publish_duration_ms);
-    plane.max_controller_ingest_ms = std::max(plane.max_controller_ingest_ms, ingest_ms);
-    plane.gpu_count += frame.gpu.devices.size();
-    plane.plane_instance_count += frame.plane_instance_count;
-    plane.plane_ready_instance_count += frame.plane_ready_instance_count;
-    plane.plane_not_ready_instance_count += frame.plane_not_ready_instance_count;
-    plane.gpu_utilization_sum += matcher_.GpuUtilizationAverage(frame);
-    if (health.value("status", std::string{"ok"}) == "stale") {
-      plane.stale_nodes += 1;
-    } else if (health.value("status", std::string{"ok"}) == "degraded") {
-      plane.degraded_nodes += 1;
-    }
-  }
-  nlohmann::json result = nlohmann::json::array();
-  for (const auto& [_, plane] : planes) {
-    const bool overloaded = plane.dropped_frames_total > 0;
-    std::string status = "ok";
-    if (plane.stale_nodes > 0) {
-      status = "stale";
-    } else if (plane.degraded_nodes > 0 || overloaded) {
-      status = "degraded";
-    }
-    const double node_count = static_cast<double>(std::max<std::uint64_t>(1, plane.node_count));
-    result.push_back(nlohmann::json{
-        {"plane_name", plane.plane_name},
-        {"status", status},
-        {"node_count", plane.node_count},
-        {"stale_nodes", plane.stale_nodes},
-        {"degraded_nodes", plane.degraded_nodes},
-        {"dropped_frames_total", plane.dropped_frames_total},
-        {"latest_sequence", plane.latest_sequence},
-        {"max_last_frame_age_ms", plane.max_last_frame_age_ms},
-        {"latency",
-         nlohmann::json{
-             {"max_queue_delay_ms", plane.max_queue_delay_ms},
-             {"max_publish_ms", plane.max_publish_ms},
-             {"max_controller_ingest_ms", plane.max_controller_ingest_ms},
-         }},
-        {"gpu_count", plane.gpu_count},
-        {"runtime",
-         nlohmann::json{
-             {"instance_count", plane.plane_instance_count},
-             {"ready_instance_count", plane.plane_ready_instance_count},
-             {"not_ready_instance_count", plane.plane_not_ready_instance_count},
-         }},
-        {"avg_gpu_utilization_pct", plane.gpu_utilization_sum / node_count},
-    });
-  }
-  return result;
 }
 
 }  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_history_downsampler.cpp
+++ b/controller/src/telemetry/telemetry_history_downsampler.cpp
@@ -1,0 +1,82 @@
+#include "telemetry/telemetry_history_downsampler.h"
+
+#include <algorithm>
+#include <map>
+#include <string>
+
+#include "telemetry/telemetry_aggregate_types.h"
+
+namespace naim::controller {
+
+nlohmann::json TelemetryHistoryDownsampler::Build(
+    const std::vector<const TelemetryNodeBuffer*>& buffers,
+    const int history_seconds,
+    const std::uint64_t now_ms,
+    const std::uint64_t warm_bucket_ms,
+    const std::uint64_t cold_bucket_ms) const {
+  if (history_seconds <= 0) {
+    return nlohmann::json::array();
+  }
+  std::map<std::string, TelemetryHistoryBucketAccumulator> buckets;
+  const std::uint64_t horizon_ms =
+      static_cast<std::uint64_t>(std::max(1, history_seconds)) * 1000ULL;
+  for (const auto* buffer : buffers) {
+    if (buffer == nullptr) {
+      continue;
+    }
+    for (const auto& frame : buffer->history) {
+      if (frame.sequence == 0 || now_ms > frame.sequence + horizon_ms) {
+        continue;
+      }
+      const std::uint64_t age_ms = now_ms >= frame.sequence ? now_ms - frame.sequence : 0;
+      const std::uint64_t bucket_ms =
+          age_ms <= warm_bucket_ms ? warm_bucket_ms : cold_bucket_ms;
+      const std::uint64_t bucket_start_ms = (frame.sequence / bucket_ms) * bucket_ms;
+      const auto key =
+          frame.node_name + "|" + matcher_.PlaneKeyForFrame(frame) + "|" +
+          std::to_string(bucket_ms) + "|" + std::to_string(bucket_start_ms);
+      auto& bucket = buckets[key];
+      if (bucket.sample_count == 0) {
+        bucket.node_name = frame.node_name;
+        bucket.plane_name = matcher_.PlaneKeyForFrame(frame);
+        bucket.bucket_start_ms = bucket_start_ms;
+        bucket.bucket_ms = bucket_ms;
+        bucket.first_sequence = frame.sequence;
+      }
+      bucket.last_sequence = std::max(bucket.last_sequence, frame.sequence);
+      bucket.sample_count += 1;
+      bucket.cpu_utilization_sum += frame.cpu.utilization_pct;
+      const double gpu_util = matcher_.GpuUtilizationAverage(frame);
+      bucket.gpu_utilization_sum += gpu_util;
+      bucket.max_gpu_utilization_pct = std::max(bucket.max_gpu_utilization_pct, gpu_util);
+      bucket.max_queue_delay_ms =
+          std::max(bucket.max_queue_delay_ms, frame.publisher_queue_delay_ms);
+      bucket.max_publish_ms = std::max(bucket.max_publish_ms, frame.publish_duration_ms);
+      bucket.max_controller_ingest_ms = std::max(
+          bucket.max_controller_ingest_ms,
+          matcher_.ControllerIngestDelayMs(frame, now_ms));
+    }
+  }
+  nlohmann::json result = nlohmann::json::array();
+  for (const auto& [_, bucket] : buckets) {
+    const double count = static_cast<double>(std::max<std::uint64_t>(1, bucket.sample_count));
+    result.push_back(nlohmann::json{
+        {"node_name", bucket.node_name},
+        {"plane_name", bucket.plane_name},
+        {"bucket_start_ms", bucket.bucket_start_ms},
+        {"bucket_ms", bucket.bucket_ms},
+        {"sample_count", bucket.sample_count},
+        {"first_sequence", bucket.first_sequence},
+        {"last_sequence", bucket.last_sequence},
+        {"avg_cpu_utilization_pct", bucket.cpu_utilization_sum / count},
+        {"avg_gpu_utilization_pct", bucket.gpu_utilization_sum / count},
+        {"max_gpu_utilization_pct", bucket.max_gpu_utilization_pct},
+        {"max_queue_delay_ms", bucket.max_queue_delay_ms},
+        {"max_publish_ms", bucket.max_publish_ms},
+        {"max_controller_ingest_ms", bucket.max_controller_ingest_ms},
+    });
+  }
+  return result;
+}
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_live_store.cpp
+++ b/controller/src/telemetry/telemetry_live_store.cpp
@@ -1,8 +1,16 @@
 #include "telemetry/telemetry_live_store.h"
 
-#include <algorithm>
+#include <utility>
+
+#include "telemetry/telemetry_live_store_state.h"
+#include "telemetry/telemetry_state_types.h"
 
 namespace naim::controller {
+
+TelemetryLiveStore::TelemetryLiveStore()
+    : state_(std::make_unique<TelemetryLiveStoreState>()) {}
+
+TelemetryLiveStore::~TelemetryLiveStore() = default;
 
 TelemetryLiveStore& TelemetryLiveStore::Instance() {
   static TelemetryLiveStore store;
@@ -18,9 +26,9 @@ void TelemetryLiveStore::ConfigurePersistence(
 
 void TelemetryLiveStore::ConfigureFromEnvironment(const std::string& db_path) {
   const auto retention =
-      operational_config_.RetentionFromEnvironment(retention_);
+      state_->operational_config.RetentionFromEnvironment(state_->retention);
   const auto thresholds =
-      operational_config_.ThresholdsFromEnvironment(thresholds_);
+      state_->operational_config.ThresholdsFromEnvironment(state_->thresholds);
   ConfigureOperationalPolicy(retention, thresholds);
   ConfigurePersistence(db_path, retention.durable_history_capacity);
 }
@@ -29,31 +37,34 @@ void TelemetryLiveStore::ConfigureOperationalPolicy(
     RetentionConfig retention,
     AlertThresholds thresholds) {
   std::lock_guard<std::mutex> lock(mutex_);
-  retention_ = operational_config_.NormalizeRetention(retention);
-  thresholds_ = thresholds;
-  ring_buffer_.ApplyHotRetention(nodes_, dropped_frames_total_, retention_);
+  state_->retention = state_->operational_config.NormalizeRetention(retention);
+  state_->thresholds = thresholds;
+  state_->ring_buffer.ApplyHotRetention(
+      state_->nodes,
+      state_->dropped_frames_total,
+      state_->retention);
 }
 
 void TelemetryLiveStore::ResetForTests() {
   std::lock_guard<std::mutex> lock(mutex_);
-  nodes_.clear();
-  latest_sequence_ = 0;
-  dropped_frames_total_ = 0;
-  retention_ = RetentionConfig{};
-  thresholds_ = AlertThresholds{};
-  persistence_ = TelemetryPersistenceState{};
-  streams_ = TelemetryStreamMetrics{};
+  state_->nodes.clear();
+  state_->latest_sequence = 0;
+  state_->dropped_frames_total = 0;
+  state_->retention = RetentionConfig{};
+  state_->thresholds = AlertThresholds{};
+  state_->persistence = TelemetryPersistenceState{};
+  state_->streams = TelemetryStreamMetrics{};
 }
 
 bool TelemetryLiveStore::Upsert(naim::HostTelemetryFrame frame) {
   if (frame.node_name.empty()) {
     return false;
   }
-  frame = frame_normalizer_.Normalize(std::move(frame));
+  frame = state_->frame_normalizer.Normalize(std::move(frame));
   std::lock_guard<std::mutex> lock(mutex_);
   const bool updated = UpsertInMemoryLocked(frame);
   if (updated) {
-    persistence_repository_.PersistFrame(persistence_, frame);
+    state_->persistence_repository.PersistFrame(state_->persistence, frame);
   }
   return updated;
 }
@@ -62,90 +73,94 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
     const std::optional<std::string>& plane_name,
     const int history_seconds) const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return snapshot_builder_.BuildSnapshot(
-      nodes_,
-      retention_,
-      thresholds_,
-      persistence_,
-      streams_,
-      latest_sequence_,
-      dropped_frames_total_,
+  return state_->snapshot_builder.BuildSnapshot(
+      state_->nodes,
+      state_->retention,
+      state_->thresholds,
+      state_->persistence,
+      state_->streams,
+      state_->latest_sequence,
+      state_->dropped_frames_total,
       plane_name,
       history_seconds,
-      clock_.CurrentUnixMillis());
+      state_->clock.CurrentUnixMillis());
 }
 
 nlohmann::json TelemetryLiveStore::BuildHealth(
     const std::optional<std::string>& plane_name) const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return health_builder_.BuildHealth(
-      nodes_,
-      retention_,
-      thresholds_,
-      persistence_,
-      streams_,
-      latest_sequence_,
-      dropped_frames_total_,
+  return state_->health_builder.BuildHealth(
+      state_->nodes,
+      state_->retention,
+      state_->thresholds,
+      state_->persistence,
+      state_->streams,
+      state_->latest_sequence,
+      state_->dropped_frames_total,
       plane_name,
-      clock_.CurrentUnixMillis());
+      state_->clock.CurrentUnixMillis());
 }
 
 std::string TelemetryLiveStore::BuildOpenMetrics(
     const std::optional<std::string>& plane_name) const {
-  return open_metrics_exporter_.Build(BuildHealth(plane_name), plane_name);
+  return state_->open_metrics_exporter.Build(BuildHealth(plane_name), plane_name);
 }
 
 std::vector<naim::HostTelemetryFrame> TelemetryLiveStore::LoadFramesAfter(
     const std::uint64_t sequence,
     const std::optional<std::string>& plane_name) const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return ring_buffer_.LoadFramesAfter(nodes_, retention_, sequence, plane_name);
+  return state_->ring_buffer.LoadFramesAfter(
+      state_->nodes,
+      state_->retention,
+      sequence,
+      plane_name);
 }
 
 TelemetryLiveStore::StreamDelta TelemetryLiveStore::LoadStreamDeltaAfter(
     const std::uint64_t sequence,
     const std::optional<std::string>& plane_name) const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return ring_buffer_.LoadStreamDeltaAfter(
-      nodes_,
-      retention_,
-      latest_sequence_,
-      dropped_frames_total_,
+  return state_->ring_buffer.LoadStreamDeltaAfter(
+      state_->nodes,
+      state_->retention,
+      state_->latest_sequence,
+      state_->dropped_frames_total,
       sequence,
       plane_name);
 }
 
 std::uint64_t TelemetryLiveStore::LatestSequence() const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return latest_sequence_;
+  return state_->latest_sequence;
 }
 
 void TelemetryLiveStore::RecordStreamOpened(const std::string& stream_name) {
   std::lock_guard<std::mutex> lock(mutex_);
-  stream_metrics_service_.RecordOpened(streams_, stream_name);
+  state_->stream_metrics_service.RecordOpened(state_->streams, stream_name);
 }
 
 void TelemetryLiveStore::RecordStreamClosed(const std::string& stream_name) {
   std::lock_guard<std::mutex> lock(mutex_);
-  stream_metrics_service_.RecordClosed(streams_, stream_name);
+  state_->stream_metrics_service.RecordClosed(state_->streams, stream_name);
 }
 
 void TelemetryLiveStore::RecordStreamReplayRequired(const std::string& stream_name) {
   std::lock_guard<std::mutex> lock(mutex_);
-  stream_metrics_service_.RecordReplayRequired(streams_, stream_name);
+  state_->stream_metrics_service.RecordReplayRequired(state_->streams, stream_name);
 }
 
 void TelemetryLiveStore::RecordStreamSendFailure(const std::string& stream_name) {
   std::lock_guard<std::mutex> lock(mutex_);
-  stream_metrics_service_.RecordSendFailure(streams_, stream_name);
+  state_->stream_metrics_service.RecordSendFailure(state_->streams, stream_name);
 }
 
 bool TelemetryLiveStore::UpsertInMemoryLocked(naim::HostTelemetryFrame frame) {
-  return ring_buffer_.Upsert(
-      nodes_,
-      latest_sequence_,
-      dropped_frames_total_,
-      retention_,
+  return state_->ring_buffer.Upsert(
+      state_->nodes,
+      state_->latest_sequence,
+      state_->dropped_frames_total,
+      state_->retention,
       std::move(frame));
 }
 
@@ -153,9 +168,12 @@ void TelemetryLiveStore::ConfigurePersistenceLocked(
     const std::string& db_path,
     const std::size_t retention_capacity) {
   const auto frames =
-      persistence_repository_.Configure(persistence_, db_path, retention_capacity);
+      state_->persistence_repository.Configure(
+          state_->persistence,
+          db_path,
+          retention_capacity);
   for (auto frame : frames) {
-    frame = frame_normalizer_.Normalize(std::move(frame));
+    frame = state_->frame_normalizer.Normalize(std::move(frame));
     UpsertInMemoryLocked(std::move(frame));
   }
 }

--- a/controller/src/telemetry/telemetry_live_store_state.cpp
+++ b/controller/src/telemetry/telemetry_live_store_state.cpp
@@ -1,0 +1,7 @@
+#include "telemetry/telemetry_live_store_state.h"
+
+namespace naim::controller {
+
+TelemetryLiveStoreState::TelemetryLiveStoreState() = default;
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_node_health_builder.cpp
+++ b/controller/src/telemetry/telemetry_node_health_builder.cpp
@@ -1,0 +1,34 @@
+#include "telemetry/telemetry_node_health_builder.h"
+
+#include <string>
+
+namespace naim::controller {
+
+nlohmann::json TelemetryNodeHealthBuilder::Build(
+    const naim::HostTelemetryFrame& frame,
+    const TelemetryNodeBuffer& buffer,
+    const std::uint64_t now_ms,
+    const std::uint64_t controller_ingest_delay_ms) const {
+  const std::uint64_t ttl_ms =
+      frame.ttl_ms > 0 ? static_cast<std::uint64_t>(frame.ttl_ms) : 0;
+  const bool stale =
+      frame.sequence == 0 || ttl_ms == 0 || frame.sequence + ttl_ms <= now_ms;
+  std::string status = "ok";
+  if (stale) {
+    status = "stale";
+  } else if (
+      buffer.dropped_frames_total > 0 || frame.telemetry_dropped_frames > 0 ||
+      frame.publish_error_count > 0 || !frame.degraded_reason.empty()) {
+    status = "degraded";
+  }
+  return nlohmann::json{
+      {"status", status},
+      {"last_frame_age_ms", controller_ingest_delay_ms},
+      {"dropped_frames_total", buffer.dropped_frames_total},
+      {"publish_error_count", frame.publish_error_count},
+      {"publish_error", frame.last_publish_error},
+      {"degraded_reason", frame.degraded_reason},
+  };
+}
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_plane_aggregate_builder.cpp
+++ b/controller/src/telemetry/telemetry_plane_aggregate_builder.cpp
@@ -1,0 +1,82 @@
+#include "telemetry/telemetry_plane_aggregate_builder.h"
+
+#include <algorithm>
+#include <map>
+#include <string>
+
+#include "telemetry/telemetry_aggregate_types.h"
+
+namespace naim::controller {
+
+nlohmann::json TelemetryPlaneAggregateBuilder::Build(
+    const std::vector<const TelemetryNodeBuffer*>& buffers,
+    const std::uint64_t now_ms) const {
+  std::map<std::string, TelemetryPlaneAccumulator> planes;
+  for (const auto* buffer : buffers) {
+    if (buffer == nullptr) {
+      continue;
+    }
+    const auto& frame = buffer->latest;
+    auto& plane = planes[matcher_.PlaneKeyForFrame(frame)];
+    if (plane.plane_name.empty()) {
+      plane.plane_name = matcher_.PlaneKeyForFrame(frame);
+    }
+    const auto ingest_ms = matcher_.ControllerIngestDelayMs(frame, now_ms);
+    const auto health = node_health_builder_.Build(frame, *buffer, now_ms, ingest_ms);
+    plane.node_count += 1;
+    plane.latest_sequence = std::max(plane.latest_sequence, frame.sequence);
+    plane.dropped_frames_total += buffer->dropped_frames_total;
+    plane.max_last_frame_age_ms = std::max(plane.max_last_frame_age_ms, ingest_ms);
+    plane.max_queue_delay_ms = std::max(plane.max_queue_delay_ms, frame.publisher_queue_delay_ms);
+    plane.max_publish_ms = std::max(plane.max_publish_ms, frame.publish_duration_ms);
+    plane.max_controller_ingest_ms = std::max(plane.max_controller_ingest_ms, ingest_ms);
+    plane.gpu_count += frame.gpu.devices.size();
+    plane.plane_instance_count += frame.plane_instance_count;
+    plane.plane_ready_instance_count += frame.plane_ready_instance_count;
+    plane.plane_not_ready_instance_count += frame.plane_not_ready_instance_count;
+    plane.gpu_utilization_sum += matcher_.GpuUtilizationAverage(frame);
+    if (health.value("status", std::string{"ok"}) == "stale") {
+      plane.stale_nodes += 1;
+    } else if (health.value("status", std::string{"ok"}) == "degraded") {
+      plane.degraded_nodes += 1;
+    }
+  }
+  nlohmann::json result = nlohmann::json::array();
+  for (const auto& [_, plane] : planes) {
+    const bool overloaded = plane.dropped_frames_total > 0;
+    std::string status = "ok";
+    if (plane.stale_nodes > 0) {
+      status = "stale";
+    } else if (plane.degraded_nodes > 0 || overloaded) {
+      status = "degraded";
+    }
+    const double node_count = static_cast<double>(std::max<std::uint64_t>(1, plane.node_count));
+    result.push_back(nlohmann::json{
+        {"plane_name", plane.plane_name},
+        {"status", status},
+        {"node_count", plane.node_count},
+        {"stale_nodes", plane.stale_nodes},
+        {"degraded_nodes", plane.degraded_nodes},
+        {"dropped_frames_total", plane.dropped_frames_total},
+        {"latest_sequence", plane.latest_sequence},
+        {"max_last_frame_age_ms", plane.max_last_frame_age_ms},
+        {"latency",
+         nlohmann::json{
+             {"max_queue_delay_ms", plane.max_queue_delay_ms},
+             {"max_publish_ms", plane.max_publish_ms},
+             {"max_controller_ingest_ms", plane.max_controller_ingest_ms},
+         }},
+        {"gpu_count", plane.gpu_count},
+        {"runtime",
+         nlohmann::json{
+             {"instance_count", plane.plane_instance_count},
+             {"ready_instance_count", plane.plane_ready_instance_count},
+             {"not_ready_instance_count", plane.plane_not_ready_instance_count},
+         }},
+        {"avg_gpu_utilization_pct", plane.gpu_utilization_sum / node_count},
+    });
+  }
+  return result;
+}
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_snapshot_builder.cpp
+++ b/controller/src/telemetry/telemetry_snapshot_builder.cpp
@@ -1,7 +1,7 @@
 #include "telemetry/telemetry_snapshot_builder.h"
 
 #include <algorithm>
-#include <map>
+#include <string>
 
 namespace naim::controller {
 
@@ -24,10 +24,10 @@ nlohmann::json TelemetrySnapshotBuilder::BuildSnapshot(
       continue;
     }
     matched_buffers.push_back(&buffer);
-    auto node = FrameToJson(buffer.latest, now_ms);
+    auto node = frame_json_builder_.Build(buffer.latest, now_ms);
     const auto controller_ingest_delay_ms =
         matcher_.ControllerIngestDelayMs(buffer.latest, now_ms);
-    node["telemetry_health"] = health_builder_.BuildTelemetryHealth(
+    node["telemetry_health"] = node_health_builder_.Build(
         buffer.latest,
         buffer,
         now_ms,
@@ -43,11 +43,11 @@ nlohmann::json TelemetrySnapshotBuilder::BuildSnapshot(
     const std::size_t begin =
         buffer.history.size() > max_samples ? buffer.history.size() - max_samples : 0;
     for (std::size_t index = begin; index < buffer.history.size(); ++index) {
-      history.push_back(FrameToJson(buffer.history[index], now_ms));
+      history.push_back(frame_json_builder_.Build(buffer.history[index], now_ms));
     }
   }
   const bool overloaded = dropped_frames_total > 0;
-  const auto alerts = health_builder_.BuildAlerts(
+  const auto alerts = alert_builder_.Build(
       matched_buffers,
       persistence,
       streams,
@@ -86,131 +86,17 @@ nlohmann::json TelemetrySnapshotBuilder::BuildSnapshot(
            {"dropped_frames_total", dropped_frames_total},
            {"stream_batch_limit", retention.stream_batch_limit},
        }},
-      {"planes", health_builder_.BuildPlaneAggregates(matched_buffers, now_ms)},
+      {"planes", plane_aggregate_builder_.Build(matched_buffers, now_ms)},
       {"nodes", std::move(node_payloads)},
       {"history", std::move(history)},
       {"downsampled_history",
-       BuildDownsampledHistory(
+       history_downsampler_.Build(
            matched_buffers,
            history_seconds,
            now_ms,
            retention.warm_bucket_ms,
            retention.cold_bucket_ms)},
   };
-}
-
-nlohmann::json TelemetrySnapshotBuilder::FrameToJson(
-    const naim::HostTelemetryFrame& frame,
-    const std::uint64_t now_ms) const {
-  auto payload = nlohmann::json::parse(naim::SerializeHostTelemetryFrameJson(frame));
-  const std::uint64_t ttl_ms =
-      frame.ttl_ms > 0 ? static_cast<std::uint64_t>(frame.ttl_ms) : 0;
-  const std::uint64_t expires_at_ms = frame.sequence + ttl_ms;
-  const bool stale = frame.sequence == 0 || ttl_ms == 0 || expires_at_ms <= now_ms;
-  payload["stale"] = stale;
-  payload["expires_in_ms"] = stale ? 0 : expires_at_ms - now_ms;
-  const auto controller_ingest_delay_ms = matcher_.ControllerIngestDelayMs(frame, now_ms);
-  payload["controller_ingest_delay_ms"] = controller_ingest_delay_ms;
-  payload["last_frame_age_ms"] = controller_ingest_delay_ms;
-  payload["telemetry_health_status"] =
-      stale ? "stale"
-            : frame.telemetry_dropped_frames > 0 || frame.publish_error_count > 0
-                ? "degraded"
-                : "ok";
-  payload["latency_breakdown"] = BuildLatencyBreakdown(frame, controller_ingest_delay_ms);
-  payload["transport"] = nlohmann::json{
-      {"primary", "sse"},
-      {"fallback", "snapshot-poll"},
-      {"sequence", frame.sequence},
-      {"schema_version", frame.schema_version},
-  };
-  return payload;
-}
-
-nlohmann::json TelemetrySnapshotBuilder::BuildLatencyBreakdown(
-    const naim::HostTelemetryFrame& frame,
-    const std::uint64_t controller_ingest_delay_ms) const {
-  const std::uint64_t total_observed_ms =
-      frame.collector_duration_ms + frame.publisher_queue_delay_ms +
-      frame.publish_duration_ms + controller_ingest_delay_ms;
-  return nlohmann::json{
-      {"collect_ms", frame.collector_duration_ms},
-      {"queue_ms", frame.publisher_queue_delay_ms},
-      {"publish_ms", frame.publish_duration_ms},
-      {"controller_ingest_ms", controller_ingest_delay_ms},
-      {"total_observed_ms", total_observed_ms},
-  };
-}
-
-nlohmann::json TelemetrySnapshotBuilder::BuildDownsampledHistory(
-    const std::vector<const TelemetryNodeBuffer*>& buffers,
-    const int history_seconds,
-    const std::uint64_t now_ms,
-    const std::uint64_t warm_bucket_ms,
-    const std::uint64_t cold_bucket_ms) const {
-  if (history_seconds <= 0) {
-    return nlohmann::json::array();
-  }
-  std::map<std::string, TelemetryHistoryBucketAccumulator> buckets;
-  const std::uint64_t horizon_ms =
-      static_cast<std::uint64_t>(std::max(1, history_seconds)) * 1000ULL;
-  for (const auto* buffer : buffers) {
-    if (buffer == nullptr) {
-      continue;
-    }
-    for (const auto& frame : buffer->history) {
-      if (frame.sequence == 0 || now_ms > frame.sequence + horizon_ms) {
-        continue;
-      }
-      const std::uint64_t age_ms = now_ms >= frame.sequence ? now_ms - frame.sequence : 0;
-      const std::uint64_t bucket_ms =
-          age_ms <= warm_bucket_ms ? warm_bucket_ms : cold_bucket_ms;
-      const std::uint64_t bucket_start_ms = (frame.sequence / bucket_ms) * bucket_ms;
-      const auto key =
-          frame.node_name + "|" + matcher_.PlaneKeyForFrame(frame) + "|" +
-          std::to_string(bucket_ms) + "|" + std::to_string(bucket_start_ms);
-      auto& bucket = buckets[key];
-      if (bucket.sample_count == 0) {
-        bucket.node_name = frame.node_name;
-        bucket.plane_name = matcher_.PlaneKeyForFrame(frame);
-        bucket.bucket_start_ms = bucket_start_ms;
-        bucket.bucket_ms = bucket_ms;
-        bucket.first_sequence = frame.sequence;
-      }
-      bucket.last_sequence = std::max(bucket.last_sequence, frame.sequence);
-      bucket.sample_count += 1;
-      bucket.cpu_utilization_sum += frame.cpu.utilization_pct;
-      const double gpu_util = matcher_.GpuUtilizationAverage(frame);
-      bucket.gpu_utilization_sum += gpu_util;
-      bucket.max_gpu_utilization_pct = std::max(bucket.max_gpu_utilization_pct, gpu_util);
-      bucket.max_queue_delay_ms =
-          std::max(bucket.max_queue_delay_ms, frame.publisher_queue_delay_ms);
-      bucket.max_publish_ms = std::max(bucket.max_publish_ms, frame.publish_duration_ms);
-      bucket.max_controller_ingest_ms = std::max(
-          bucket.max_controller_ingest_ms,
-          matcher_.ControllerIngestDelayMs(frame, now_ms));
-    }
-  }
-  nlohmann::json result = nlohmann::json::array();
-  for (const auto& [_, bucket] : buckets) {
-    const double count = static_cast<double>(std::max<std::uint64_t>(1, bucket.sample_count));
-    result.push_back(nlohmann::json{
-        {"node_name", bucket.node_name},
-        {"plane_name", bucket.plane_name},
-        {"bucket_start_ms", bucket.bucket_start_ms},
-        {"bucket_ms", bucket.bucket_ms},
-        {"sample_count", bucket.sample_count},
-        {"first_sequence", bucket.first_sequence},
-        {"last_sequence", bucket.last_sequence},
-        {"avg_cpu_utilization_pct", bucket.cpu_utilization_sum / count},
-        {"avg_gpu_utilization_pct", bucket.gpu_utilization_sum / count},
-        {"max_gpu_utilization_pct", bucket.max_gpu_utilization_pct},
-        {"max_queue_delay_ms", bucket.max_queue_delay_ms},
-        {"max_publish_ms", bucket.max_publish_ms},
-        {"max_controller_ingest_ms", bucket.max_controller_ingest_ms},
-    });
-  }
-  return result;
 }
 
 }  // namespace naim::controller


### PR DESCRIPTION
## Summary
- Narrow TelemetryLiveStore public header by moving concrete state and services behind TelemetryLiveStoreState.
- Split telemetry public contract types, internal state types, and aggregate accumulator types.
- Move alerts, node health, frame JSON projection, plane aggregates, history downsampling, and frame sequence sorting into named classes.
- Replace duplicated telemetry source lists in CMake with one shared source list.

## Validation
- cmake --build build/telemetry-debug --target naim-telemetry-live-store-tests naim-controller naim-hostd-http-tests
- ./build/telemetry-debug/naim-telemetry-live-store-tests
- ./build/telemetry-debug/naim-hostd-http-tests
- npm test -- --run src/telemetryStore.test.js
- npm run build
- bash -n scripts/ci/main-bootstrap-controller-update.sh
- telemetry health CLI env retention smoke test
- git diff --check