### PR TITLE
Refactor telemetry UI boundaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,11 +571,16 @@ set(
   controller/src/telemetry/telemetry_health_builder.cpp
   controller/src/telemetry/telemetry_history_downsampler.cpp
   controller/src/telemetry/telemetry_live_store.cpp
+  controller/src/telemetry/telemetry_live_store_services.cpp
   controller/src/telemetry/telemetry_live_store_state.cpp
+  controller/src/telemetry/telemetry_node_alert_builder.cpp
   controller/src/telemetry/telemetry_node_health_builder.cpp
   controller/src/telemetry/telemetry_open_metrics_exporter.cpp
   controller/src/telemetry/telemetry_operational_config.cpp
   controller/src/telemetry/telemetry_persistence_repository.cpp
+  controller/src/telemetry/telemetry_persistence_schema.cpp
+  controller/src/telemetry/telemetry_persistence_status_builder.cpp
+  controller/src/telemetry/telemetry_pipeline_alert_builder.cpp
   controller/src/telemetry/telemetry_plane_aggregate_builder.cpp
   controller/src/telemetry/telemetry_snapshot_builder.cpp
   controller/src/telemetry/telemetry_sqlite_connection.cpp

--- a/controller/include/telemetry/telemetry_alert_builder.h
+++ b/controller/include/telemetry/telemetry_alert_builder.h
@@ -5,8 +5,9 @@
 
 #include <nlohmann/json.hpp>
 
-#include "telemetry/telemetry_frame_matcher.h"
 #include "telemetry/telemetry_live_store_types.h"
+#include "telemetry/telemetry_node_alert_builder.h"
+#include "telemetry/telemetry_pipeline_alert_builder.h"
 #include "telemetry/telemetry_state_types.h"
 
 namespace naim::controller {
@@ -22,7 +23,8 @@ class TelemetryAlertBuilder final {
       std::uint64_t now_ms) const;
 
  private:
-  TelemetryFrameMatcher matcher_;
+  TelemetryPipelineAlertBuilder pipeline_alert_builder_;
+  TelemetryNodeAlertBuilder node_alert_builder_;
 };
 
 }  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_live_store.h
+++ b/controller/include/telemetry/telemetry_live_store.h
@@ -14,6 +14,7 @@
 
 namespace naim::controller {
 
+class TelemetryLiveStoreServices;
 class TelemetryLiveStoreState;
 
 class TelemetryLiveStore final {
@@ -64,6 +65,7 @@ class TelemetryLiveStore final {
 
   mutable std::mutex mutex_;
   std::unique_ptr<TelemetryLiveStoreState> state_;
+  std::unique_ptr<TelemetryLiveStoreServices> services_;
 };
 
 }  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_live_store_services.h
+++ b/controller/include/telemetry/telemetry_live_store_services.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "telemetry/telemetry_clock.h"
+#include "telemetry/telemetry_frame_normalizer.h"
+#include "telemetry/telemetry_frame_ring_buffer.h"
+#include "telemetry/telemetry_health_builder.h"
+#include "telemetry/telemetry_open_metrics_exporter.h"
+#include "telemetry/telemetry_operational_config.h"
+#include "telemetry/telemetry_persistence_repository.h"
+#include "telemetry/telemetry_snapshot_builder.h"
+#include "telemetry/telemetry_stream_metrics_service.h"
+
+namespace naim::controller {
+
+class TelemetryLiveStoreServices final {
+ public:
+  TelemetryLiveStoreServices();
+
+  TelemetryClock clock;
+  TelemetryFrameNormalizer frame_normalizer;
+  TelemetryOperationalConfig operational_config;
+  TelemetryFrameRingBuffer ring_buffer;
+  TelemetryPersistenceRepository persistence_repository;
+  TelemetryStreamMetricsService stream_metrics_service;
+  TelemetryHealthBuilder health_builder;
+  TelemetrySnapshotBuilder snapshot_builder;
+  TelemetryOpenMetricsExporter open_metrics_exporter;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_live_store_state.h
+++ b/controller/include/telemetry/telemetry_live_store_state.h
@@ -3,17 +3,8 @@
 #include <cstdint>
 #include <vector>
 
-#include "telemetry/telemetry_clock.h"
-#include "telemetry/telemetry_frame_normalizer.h"
-#include "telemetry/telemetry_frame_ring_buffer.h"
-#include "telemetry/telemetry_health_builder.h"
 #include "telemetry/telemetry_live_store_types.h"
-#include "telemetry/telemetry_open_metrics_exporter.h"
-#include "telemetry/telemetry_operational_config.h"
-#include "telemetry/telemetry_persistence_repository.h"
-#include "telemetry/telemetry_snapshot_builder.h"
 #include "telemetry/telemetry_state_types.h"
-#include "telemetry/telemetry_stream_metrics_service.h"
 
 namespace naim::controller {
 
@@ -28,15 +19,6 @@ class TelemetryLiveStoreState final {
   TelemetryAlertThresholds thresholds;
   TelemetryPersistenceState persistence;
   TelemetryStreamMetrics streams;
-  TelemetryClock clock;
-  TelemetryFrameNormalizer frame_normalizer;
-  TelemetryOperationalConfig operational_config;
-  TelemetryFrameRingBuffer ring_buffer;
-  TelemetryPersistenceRepository persistence_repository;
-  TelemetryStreamMetricsService stream_metrics_service;
-  TelemetryHealthBuilder health_builder;
-  TelemetrySnapshotBuilder snapshot_builder;
-  TelemetryOpenMetricsExporter open_metrics_exporter;
 };
 
 }  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_node_alert_builder.h
+++ b/controller/include/telemetry/telemetry_node_alert_builder.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+#include <nlohmann/json.hpp>
+
+#include "telemetry/telemetry_frame_matcher.h"
+#include "telemetry/telemetry_live_store_types.h"
+#include "telemetry/telemetry_state_types.h"
+
+namespace naim::controller {
+
+class TelemetryNodeAlertBuilder final {
+ public:
+  nlohmann::json Build(
+      const TelemetryNodeBuffer& buffer,
+      const TelemetryAlertThresholds& thresholds,
+      std::uint64_t now_ms) const;
+
+ private:
+  TelemetryFrameMatcher matcher_;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_persistence_repository.h
+++ b/controller/include/telemetry/telemetry_persistence_repository.h
@@ -5,9 +5,10 @@
 #include <vector>
 
 #include <nlohmann/json.hpp>
-#include <sqlite3.h>
 
 #include "naim/runtime/runtime_status.h"
+#include "telemetry/telemetry_persistence_schema.h"
+#include "telemetry/telemetry_persistence_status_builder.h"
 #include "telemetry/telemetry_state_types.h"
 
 namespace naim::controller {
@@ -27,9 +28,9 @@ class TelemetryPersistenceRepository final {
   nlohmann::json BuildStatus(const TelemetryPersistenceState& state) const;
 
  private:
-  void EnsureSchema(sqlite3* db) const;
-  void Execute(sqlite3* db, const std::string& sql) const;
   std::int64_t SafeSequenceForSqlite(std::uint64_t sequence) const;
+  TelemetryPersistenceSchema schema_;
+  TelemetryPersistenceStatusBuilder status_builder_;
 };
 
 }  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_persistence_schema.h
+++ b/controller/include/telemetry/telemetry_persistence_schema.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+#include <sqlite3.h>
+
+namespace naim::controller {
+
+class TelemetryPersistenceSchema final {
+ public:
+  void Ensure(sqlite3* db) const;
+
+ private:
+  void Execute(sqlite3* db, const std::string& sql) const;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_persistence_status_builder.h
+++ b/controller/include/telemetry/telemetry_persistence_status_builder.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "telemetry/telemetry_state_types.h"
+
+namespace naim::controller {
+
+class TelemetryPersistenceStatusBuilder final {
+ public:
+  nlohmann::json Build(const TelemetryPersistenceState& state) const;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_pipeline_alert_builder.h
+++ b/controller/include/telemetry/telemetry_pipeline_alert_builder.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+#include <nlohmann/json.hpp>
+
+#include "telemetry/telemetry_state_types.h"
+
+namespace naim::controller {
+
+class TelemetryPipelineAlertBuilder final {
+ public:
+  nlohmann::json Build(
+      const TelemetryPersistenceState& persistence,
+      const TelemetryStreamMetrics& streams,
+      std::uint64_t dropped_frames_total) const;
+};
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_alert_builder.cpp
+++ b/controller/src/telemetry/telemetry_alert_builder.cpp
@@ -10,99 +10,15 @@ nlohmann::json TelemetryAlertBuilder::Build(
     const std::uint64_t dropped_frames_total,
     const std::uint64_t now_ms) const {
   nlohmann::json alerts = nlohmann::json::array();
-  if (!persistence.enabled) {
-    alerts.push_back(nlohmann::json{
-        {"code", "telemetry.persistence.disabled"},
-        {"severity", "warning"},
-        {"message", "sqlite telemetry ring buffer is disabled"},
-    });
-  }
-  if (persistence.error_count > 0) {
-    alerts.push_back(nlohmann::json{
-        {"code", "telemetry.persistence.errors"},
-        {"severity", "warning"},
-        {"message", "sqlite telemetry ring buffer reported errors"},
-        {"count", persistence.error_count},
-        {"last_error", persistence.last_error},
-    });
-  }
-  if (dropped_frames_total > 0) {
-    alerts.push_back(nlohmann::json{
-        {"code", "telemetry.controller.dropped_frames"},
-        {"severity", "warning"},
-        {"message", "controller telemetry ring buffer pruned live frames"},
-        {"count", dropped_frames_total},
-    });
-  }
-  if (streams.telemetry.send_failure_total > 0 || streams.live.send_failure_total > 0) {
-    alerts.push_back(nlohmann::json{
-        {"code", "telemetry.stream.send_failures"},
-        {"severity", "warning"},
-        {"message", "telemetry stream clients observed send failures"},
-        {"telemetry_failures", streams.telemetry.send_failure_total},
-        {"live_failures", streams.live.send_failure_total},
-    });
-  }
-  if (streams.telemetry.replay_required_total > 0 || streams.live.replay_required_total > 0) {
-    alerts.push_back(nlohmann::json{
-        {"code", "telemetry.stream.replay_required"},
-        {"severity", "warning"},
-        {"message", "telemetry stream replay was required"},
-        {"telemetry_replay_required_total", streams.telemetry.replay_required_total},
-        {"live_replay_required_total", streams.live.replay_required_total},
-    });
-  }
+  const auto pipeline_alerts =
+      pipeline_alert_builder_.Build(persistence, streams, dropped_frames_total);
+  alerts.insert(alerts.end(), pipeline_alerts.begin(), pipeline_alerts.end());
   for (const auto* buffer : buffers) {
     if (buffer == nullptr) {
       continue;
     }
-    const auto& frame = buffer->latest;
-    const auto ingest_ms = matcher_.ControllerIngestDelayMs(frame, now_ms);
-    if (ingest_ms >= thresholds.stale_critical_ms) {
-      alerts.push_back(nlohmann::json{
-          {"code", "telemetry.node.stale"},
-          {"severity", "critical"},
-          {"node_name", frame.node_name},
-          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
-          {"age_ms", ingest_ms},
-      });
-    } else if (ingest_ms >= thresholds.stale_warning_ms) {
-      alerts.push_back(nlohmann::json{
-          {"code", "telemetry.node.slow"},
-          {"severity", "warning"},
-          {"node_name", frame.node_name},
-          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
-          {"age_ms", ingest_ms},
-      });
-    }
-    if (ingest_ms >= thresholds.ingest_warning_ms) {
-      alerts.push_back(nlohmann::json{
-          {"code", "telemetry.controller.ingest_delay"},
-          {"severity", "warning"},
-          {"node_name", frame.node_name},
-          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
-          {"delay_ms", ingest_ms},
-      });
-    }
-    if (frame.publisher_queue_delay_ms >= thresholds.queue_warning_ms) {
-      alerts.push_back(nlohmann::json{
-          {"code", "telemetry.publisher.queue_delay"},
-          {"severity", "warning"},
-          {"node_name", frame.node_name},
-          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
-          {"delay_ms", frame.publisher_queue_delay_ms},
-      });
-    }
-    if (frame.publish_error_count > 0) {
-      alerts.push_back(nlohmann::json{
-          {"code", "telemetry.publisher.errors"},
-          {"severity", "warning"},
-          {"node_name", frame.node_name},
-          {"plane_name", matcher_.PlaneKeyForFrame(frame)},
-          {"count", frame.publish_error_count},
-          {"last_error", frame.last_publish_error},
-      });
-    }
+    const auto node_alerts = node_alert_builder_.Build(*buffer, thresholds, now_ms);
+    alerts.insert(alerts.end(), node_alerts.begin(), node_alerts.end());
   }
   return alerts;
 }

--- a/controller/src/telemetry/telemetry_frame_matcher.cpp
+++ b/controller/src/telemetry/telemetry_frame_matcher.cpp
@@ -1,7 +1,5 @@
 #include "telemetry/telemetry_frame_matcher.h"
 
-#include <algorithm>
-
 namespace naim::controller {
 
 bool TelemetryFrameMatcher::MatchesPlane(
@@ -13,12 +11,13 @@ bool TelemetryFrameMatcher::MatchesPlane(
   if (frame.plane_name == *plane_name) {
     return true;
   }
-  return std::any_of(
-      frame.instance_runtime.begin(),
-      frame.instance_runtime.end(),
-      [&](const naim::RuntimeProcessStatus& status) {
-        return status.instance_name.rfind(*plane_name + "-", 0) == 0;
-      });
+  const std::string prefix = *plane_name + "-";
+  for (const auto& status : frame.instance_runtime) {
+    if (status.instance_name.rfind(prefix, 0) == 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 std::string TelemetryFrameMatcher::PlaneKeyForFrame(

--- a/controller/src/telemetry/telemetry_frame_ring_buffer.cpp
+++ b/controller/src/telemetry/telemetry_frame_ring_buffer.cpp
@@ -13,12 +13,10 @@ bool TelemetryFrameRingBuffer::Upsert(
     std::uint64_t& dropped_frames_total,
     const TelemetryRetentionConfig& retention,
     naim::HostTelemetryFrame frame) const {
-  auto it = std::find_if(
-      nodes.begin(),
-      nodes.end(),
-      [&](const TelemetryNodeBuffer& candidate) {
-        return candidate.latest.node_name == frame.node_name;
-      });
+  auto it = nodes.begin();
+  while (it != nodes.end() && it->latest.node_name != frame.node_name) {
+    ++it;
+  }
   if (it != nodes.end() && frame.sequence <= it->latest.sequence) {
     return false;
   }

--- a/controller/src/telemetry/telemetry_live_store.cpp
+++ b/controller/src/telemetry/telemetry_live_store.cpp
@@ -2,13 +2,15 @@
 
 #include <utility>
 
+#include "telemetry/telemetry_live_store_services.h"
 #include "telemetry/telemetry_live_store_state.h"
 #include "telemetry/telemetry_state_types.h"
 
 namespace naim::controller {
 
 TelemetryLiveStore::TelemetryLiveStore()
-    : state_(std::make_unique<TelemetryLiveStoreState>()) {}
+    : state_(std::make_unique<TelemetryLiveStoreState>()),
+      services_(std::make_unique<TelemetryLiveStoreServices>()) {}
 
 TelemetryLiveStore::~TelemetryLiveStore() = default;
 
@@ -26,9 +28,9 @@ void TelemetryLiveStore::ConfigurePersistence(
 
 void TelemetryLiveStore::ConfigureFromEnvironment(const std::string& db_path) {
   const auto retention =
-      state_->operational_config.RetentionFromEnvironment(state_->retention);
+      services_->operational_config.RetentionFromEnvironment(state_->retention);
   const auto thresholds =
-      state_->operational_config.ThresholdsFromEnvironment(state_->thresholds);
+      services_->operational_config.ThresholdsFromEnvironment(state_->thresholds);
   ConfigureOperationalPolicy(retention, thresholds);
   ConfigurePersistence(db_path, retention.durable_history_capacity);
 }
@@ -37,9 +39,9 @@ void TelemetryLiveStore::ConfigureOperationalPolicy(
     RetentionConfig retention,
     AlertThresholds thresholds) {
   std::lock_guard<std::mutex> lock(mutex_);
-  state_->retention = state_->operational_config.NormalizeRetention(retention);
+  state_->retention = services_->operational_config.NormalizeRetention(retention);
   state_->thresholds = thresholds;
-  state_->ring_buffer.ApplyHotRetention(
+  services_->ring_buffer.ApplyHotRetention(
       state_->nodes,
       state_->dropped_frames_total,
       state_->retention);
@@ -60,11 +62,11 @@ bool TelemetryLiveStore::Upsert(naim::HostTelemetryFrame frame) {
   if (frame.node_name.empty()) {
     return false;
   }
-  frame = state_->frame_normalizer.Normalize(std::move(frame));
+  frame = services_->frame_normalizer.Normalize(std::move(frame));
   std::lock_guard<std::mutex> lock(mutex_);
   const bool updated = UpsertInMemoryLocked(frame);
   if (updated) {
-    state_->persistence_repository.PersistFrame(state_->persistence, frame);
+    services_->persistence_repository.PersistFrame(state_->persistence, frame);
   }
   return updated;
 }
@@ -73,7 +75,7 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
     const std::optional<std::string>& plane_name,
     const int history_seconds) const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return state_->snapshot_builder.BuildSnapshot(
+  return services_->snapshot_builder.BuildSnapshot(
       state_->nodes,
       state_->retention,
       state_->thresholds,
@@ -83,13 +85,13 @@ nlohmann::json TelemetryLiveStore::BuildSnapshot(
       state_->dropped_frames_total,
       plane_name,
       history_seconds,
-      state_->clock.CurrentUnixMillis());
+      services_->clock.CurrentUnixMillis());
 }
 
 nlohmann::json TelemetryLiveStore::BuildHealth(
     const std::optional<std::string>& plane_name) const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return state_->health_builder.BuildHealth(
+  return services_->health_builder.BuildHealth(
       state_->nodes,
       state_->retention,
       state_->thresholds,
@@ -98,19 +100,19 @@ nlohmann::json TelemetryLiveStore::BuildHealth(
       state_->latest_sequence,
       state_->dropped_frames_total,
       plane_name,
-      state_->clock.CurrentUnixMillis());
+      services_->clock.CurrentUnixMillis());
 }
 
 std::string TelemetryLiveStore::BuildOpenMetrics(
     const std::optional<std::string>& plane_name) const {
-  return state_->open_metrics_exporter.Build(BuildHealth(plane_name), plane_name);
+  return services_->open_metrics_exporter.Build(BuildHealth(plane_name), plane_name);
 }
 
 std::vector<naim::HostTelemetryFrame> TelemetryLiveStore::LoadFramesAfter(
     const std::uint64_t sequence,
     const std::optional<std::string>& plane_name) const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return state_->ring_buffer.LoadFramesAfter(
+  return services_->ring_buffer.LoadFramesAfter(
       state_->nodes,
       state_->retention,
       sequence,
@@ -121,7 +123,7 @@ TelemetryLiveStore::StreamDelta TelemetryLiveStore::LoadStreamDeltaAfter(
     const std::uint64_t sequence,
     const std::optional<std::string>& plane_name) const {
   std::lock_guard<std::mutex> lock(mutex_);
-  return state_->ring_buffer.LoadStreamDeltaAfter(
+  return services_->ring_buffer.LoadStreamDeltaAfter(
       state_->nodes,
       state_->retention,
       state_->latest_sequence,
@@ -137,26 +139,26 @@ std::uint64_t TelemetryLiveStore::LatestSequence() const {
 
 void TelemetryLiveStore::RecordStreamOpened(const std::string& stream_name) {
   std::lock_guard<std::mutex> lock(mutex_);
-  state_->stream_metrics_service.RecordOpened(state_->streams, stream_name);
+  services_->stream_metrics_service.RecordOpened(state_->streams, stream_name);
 }
 
 void TelemetryLiveStore::RecordStreamClosed(const std::string& stream_name) {
   std::lock_guard<std::mutex> lock(mutex_);
-  state_->stream_metrics_service.RecordClosed(state_->streams, stream_name);
+  services_->stream_metrics_service.RecordClosed(state_->streams, stream_name);
 }
 
 void TelemetryLiveStore::RecordStreamReplayRequired(const std::string& stream_name) {
   std::lock_guard<std::mutex> lock(mutex_);
-  state_->stream_metrics_service.RecordReplayRequired(state_->streams, stream_name);
+  services_->stream_metrics_service.RecordReplayRequired(state_->streams, stream_name);
 }
 
 void TelemetryLiveStore::RecordStreamSendFailure(const std::string& stream_name) {
   std::lock_guard<std::mutex> lock(mutex_);
-  state_->stream_metrics_service.RecordSendFailure(state_->streams, stream_name);
+  services_->stream_metrics_service.RecordSendFailure(state_->streams, stream_name);
 }
 
 bool TelemetryLiveStore::UpsertInMemoryLocked(naim::HostTelemetryFrame frame) {
-  return state_->ring_buffer.Upsert(
+  return services_->ring_buffer.Upsert(
       state_->nodes,
       state_->latest_sequence,
       state_->dropped_frames_total,
@@ -168,12 +170,12 @@ void TelemetryLiveStore::ConfigurePersistenceLocked(
     const std::string& db_path,
     const std::size_t retention_capacity) {
   const auto frames =
-      state_->persistence_repository.Configure(
+      services_->persistence_repository.Configure(
           state_->persistence,
           db_path,
           retention_capacity);
   for (auto frame : frames) {
-    frame = state_->frame_normalizer.Normalize(std::move(frame));
+    frame = services_->frame_normalizer.Normalize(std::move(frame));
     UpsertInMemoryLocked(std::move(frame));
   }
 }

--- a/controller/src/telemetry/telemetry_live_store_services.cpp
+++ b/controller/src/telemetry/telemetry_live_store_services.cpp
@@ -1,0 +1,7 @@
+#include "telemetry/telemetry_live_store_services.h"
+
+namespace naim::controller {
+
+TelemetryLiveStoreServices::TelemetryLiveStoreServices() = default;
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_node_alert_builder.cpp
+++ b/controller/src/telemetry/telemetry_node_alert_builder.cpp
@@ -1,0 +1,60 @@
+#include "telemetry/telemetry_node_alert_builder.h"
+
+namespace naim::controller {
+
+nlohmann::json TelemetryNodeAlertBuilder::Build(
+    const TelemetryNodeBuffer& buffer,
+    const TelemetryAlertThresholds& thresholds,
+    const std::uint64_t now_ms) const {
+  nlohmann::json alerts = nlohmann::json::array();
+  const auto& frame = buffer.latest;
+  const auto ingest_ms = matcher_.ControllerIngestDelayMs(frame, now_ms);
+  if (ingest_ms >= thresholds.stale_critical_ms) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.node.stale"},
+        {"severity", "critical"},
+        {"node_name", frame.node_name},
+        {"plane_name", matcher_.PlaneKeyForFrame(frame)},
+        {"age_ms", ingest_ms},
+    });
+  } else if (ingest_ms >= thresholds.stale_warning_ms) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.node.slow"},
+        {"severity", "warning"},
+        {"node_name", frame.node_name},
+        {"plane_name", matcher_.PlaneKeyForFrame(frame)},
+        {"age_ms", ingest_ms},
+    });
+  }
+  if (ingest_ms >= thresholds.ingest_warning_ms) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.controller.ingest_delay"},
+        {"severity", "warning"},
+        {"node_name", frame.node_name},
+        {"plane_name", matcher_.PlaneKeyForFrame(frame)},
+        {"delay_ms", ingest_ms},
+    });
+  }
+  if (frame.publisher_queue_delay_ms >= thresholds.queue_warning_ms) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.publisher.queue_delay"},
+        {"severity", "warning"},
+        {"node_name", frame.node_name},
+        {"plane_name", matcher_.PlaneKeyForFrame(frame)},
+        {"delay_ms", frame.publisher_queue_delay_ms},
+    });
+  }
+  if (frame.publish_error_count > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.publisher.errors"},
+        {"severity", "warning"},
+        {"node_name", frame.node_name},
+        {"plane_name", matcher_.PlaneKeyForFrame(frame)},
+        {"count", frame.publish_error_count},
+        {"last_error", frame.last_publish_error},
+    });
+  }
+  return alerts;
+}
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_persistence_repository.cpp
+++ b/controller/src/telemetry/telemetry_persistence_repository.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <limits>
-#include <stdexcept>
 
 #include "naim/state/sqlite_statement.h"
 #include "telemetry/telemetry_sqlite_connection.h"
@@ -37,7 +36,7 @@ void TelemetryPersistenceRepository::PersistFrame(
   }
   try {
     TelemetrySqliteConnection connection(state.db_path);
-    EnsureSchema(connection.get());
+    schema_.Ensure(connection.get());
     {
       naim::SqliteStatement statement(
           connection.get(),
@@ -84,7 +83,7 @@ std::vector<naim::HostTelemetryFrame> TelemetryPersistenceRepository::LoadFrames
     const std::string& db_path,
     const std::size_t retention_capacity) const {
   TelemetrySqliteConnection connection(db_path);
-  EnsureSchema(connection.get());
+  schema_.Ensure(connection.get());
   naim::SqliteStatement statement(
       connection.get(),
       "SELECT frame_json FROM telemetry_ring_buffer "
@@ -106,44 +105,7 @@ std::vector<naim::HostTelemetryFrame> TelemetryPersistenceRepository::LoadFrames
 
 nlohmann::json TelemetryPersistenceRepository::BuildStatus(
     const TelemetryPersistenceState& state) const {
-  return nlohmann::json{
-      {"enabled", state.enabled},
-      {"backend", state.enabled ? "sqlite" : "memory"},
-      {"db_path", state.db_path},
-      {"retention_capacity", state.retention_capacity},
-      {"loaded_frames_total", state.loaded_frames_total},
-      {"persisted_frames_total", state.persisted_frames_total},
-      {"pruned_frames_total", state.pruned_frames_total},
-      {"error_count", state.error_count},
-      {"last_error", state.last_error},
-  };
-}
-
-void TelemetryPersistenceRepository::EnsureSchema(sqlite3* db) const {
-  Execute(
-      db,
-      "CREATE TABLE IF NOT EXISTS telemetry_ring_buffer ("
-      "sequence INTEGER PRIMARY KEY,"
-      "node_name TEXT NOT NULL,"
-      "plane_name TEXT,"
-      "schema_version TEXT NOT NULL,"
-      "sampled_at TEXT,"
-      "frame_json TEXT NOT NULL,"
-      "created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)");
-  Execute(
-      db,
-      "CREATE INDEX IF NOT EXISTS idx_telemetry_ring_buffer_plane_sequence "
-      "ON telemetry_ring_buffer(plane_name, sequence)");
-}
-
-void TelemetryPersistenceRepository::Execute(sqlite3* db, const std::string& sql) const {
-  char* error_message = nullptr;
-  const int rc = sqlite3_exec(db, sql.c_str(), nullptr, nullptr, &error_message);
-  if (rc != SQLITE_OK) {
-    std::string message = error_message != nullptr ? error_message : sqlite3_errmsg(db);
-    sqlite3_free(error_message);
-    throw std::runtime_error("sqlite exec failed: " + message);
-  }
+  return status_builder_.Build(state);
 }
 
 std::int64_t TelemetryPersistenceRepository::SafeSequenceForSqlite(

--- a/controller/src/telemetry/telemetry_persistence_schema.cpp
+++ b/controller/src/telemetry/telemetry_persistence_schema.cpp
@@ -1,0 +1,34 @@
+#include "telemetry/telemetry_persistence_schema.h"
+
+#include <stdexcept>
+
+namespace naim::controller {
+
+void TelemetryPersistenceSchema::Ensure(sqlite3* db) const {
+  Execute(
+      db,
+      "CREATE TABLE IF NOT EXISTS telemetry_ring_buffer ("
+      "sequence INTEGER PRIMARY KEY,"
+      "node_name TEXT NOT NULL,"
+      "plane_name TEXT,"
+      "schema_version TEXT NOT NULL,"
+      "sampled_at TEXT,"
+      "frame_json TEXT NOT NULL,"
+      "created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)");
+  Execute(
+      db,
+      "CREATE INDEX IF NOT EXISTS idx_telemetry_ring_buffer_plane_sequence "
+      "ON telemetry_ring_buffer(plane_name, sequence)");
+}
+
+void TelemetryPersistenceSchema::Execute(sqlite3* db, const std::string& sql) const {
+  char* error_message = nullptr;
+  const int rc = sqlite3_exec(db, sql.c_str(), nullptr, nullptr, &error_message);
+  if (rc != SQLITE_OK) {
+    std::string message = error_message != nullptr ? error_message : sqlite3_errmsg(db);
+    sqlite3_free(error_message);
+    throw std::runtime_error("sqlite exec failed: " + message);
+  }
+}
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_persistence_status_builder.cpp
+++ b/controller/src/telemetry/telemetry_persistence_status_builder.cpp
@@ -1,0 +1,20 @@
+#include "telemetry/telemetry_persistence_status_builder.h"
+
+namespace naim::controller {
+
+nlohmann::json TelemetryPersistenceStatusBuilder::Build(
+    const TelemetryPersistenceState& state) const {
+  return nlohmann::json{
+      {"enabled", state.enabled},
+      {"backend", state.enabled ? "sqlite" : "memory"},
+      {"db_path", state.db_path},
+      {"retention_capacity", state.retention_capacity},
+      {"loaded_frames_total", state.loaded_frames_total},
+      {"persisted_frames_total", state.persisted_frames_total},
+      {"pruned_frames_total", state.pruned_frames_total},
+      {"error_count", state.error_count},
+      {"last_error", state.last_error},
+  };
+}
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_pipeline_alert_builder.cpp
+++ b/controller/src/telemetry/telemetry_pipeline_alert_builder.cpp
@@ -1,0 +1,55 @@
+#include "telemetry/telemetry_pipeline_alert_builder.h"
+
+namespace naim::controller {
+
+nlohmann::json TelemetryPipelineAlertBuilder::Build(
+    const TelemetryPersistenceState& persistence,
+    const TelemetryStreamMetrics& streams,
+    const std::uint64_t dropped_frames_total) const {
+  nlohmann::json alerts = nlohmann::json::array();
+  if (!persistence.enabled) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.persistence.disabled"},
+        {"severity", "warning"},
+        {"message", "sqlite telemetry ring buffer is disabled"},
+    });
+  }
+  if (persistence.error_count > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.persistence.errors"},
+        {"severity", "warning"},
+        {"message", "sqlite telemetry ring buffer reported errors"},
+        {"count", persistence.error_count},
+        {"last_error", persistence.last_error},
+    });
+  }
+  if (dropped_frames_total > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.controller.dropped_frames"},
+        {"severity", "warning"},
+        {"message", "controller telemetry ring buffer pruned live frames"},
+        {"count", dropped_frames_total},
+    });
+  }
+  if (streams.telemetry.send_failure_total > 0 || streams.live.send_failure_total > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.stream.send_failures"},
+        {"severity", "warning"},
+        {"message", "telemetry stream clients observed send failures"},
+        {"telemetry_failures", streams.telemetry.send_failure_total},
+        {"live_failures", streams.live.send_failure_total},
+    });
+  }
+  if (streams.telemetry.replay_required_total > 0 || streams.live.replay_required_total > 0) {
+    alerts.push_back(nlohmann::json{
+        {"code", "telemetry.stream.replay_required"},
+        {"severity", "warning"},
+        {"message", "telemetry stream replay was required"},
+        {"telemetry_replay_required_total", streams.telemetry.replay_required_total},
+        {"live_replay_required_total", streams.live.replay_required_total},
+    });
+  }
+  return alerts;
+}
+
+}  // namespace naim::controller

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -60,6 +60,16 @@ import {
   selectTelemetryFrames,
   updateTelemetryBrowserLatency,
 } from "./telemetryStore.js";
+import {
+  hostObservationItemsFromPayload,
+  mergeTelemetryIntoObservationPayload,
+} from "./telemetryHostObservations.js";
+import {
+  buildTelemetryBrowserLatency,
+  maxTelemetryReceiveDelayMs,
+  parseTelemetryEventPayload,
+  telemetryFramesFromSnapshot,
+} from "./telemetryStreamClient.js";
 
 const REFRESH_DEBOUNCE_MS = 350;
 const AUTO_REFRESH_MS = 5000;
@@ -987,185 +997,6 @@ function observedStateForObservation(observation) {
 function observedInstancesForObservation(observation) {
   const state = observedStateForObservation(observation);
   return Array.isArray(state.instances) ? state.instances : [];
-}
-
-function hostObservationItemsFromPayload(payload) {
-  if (Array.isArray(payload?.observations)) {
-    return payload.observations.map((item) => ({
-      ...item,
-      observed_at: item?.observed_at || item?.heartbeat_at || null,
-    }));
-  }
-  if (Array.isArray(payload?.items)) {
-    return payload.items.map((item) => ({
-      ...item,
-      observed_at: item?.observed_at || item?.heartbeat_at || null,
-    }));
-  }
-  return [];
-}
-
-function summarizeGpuTelemetryFrame(gpu) {
-  const devices = Array.isArray(gpu?.devices) ? gpu.devices : [];
-  return {
-    available: devices.length > 0,
-    degraded: gpu?.degraded === true,
-    source: gpu?.source || "",
-    collected_at: gpu?.collected_at || "",
-    summary: {
-      device_count: devices.length,
-      total_vram_mb: devices.reduce((sum, item) => sum + Number(item?.total_vram_mb || 0), 0),
-      used_vram_mb: devices.reduce((sum, item) => sum + Number(item?.used_vram_mb || 0), 0),
-      free_vram_mb: devices.reduce((sum, item) => sum + Number(item?.free_vram_mb || 0), 0),
-      temperature_device_count: devices.filter((item) => item?.temperature_available).length,
-      hottest_temperature_c: devices.reduce(
-        (max, item) => Math.max(max, Number(item?.temperature_c || 0)),
-        0,
-      ),
-    },
-    devices,
-  };
-}
-
-function summarizeNetworkTelemetryFrame(network) {
-  const interfaces = Array.isArray(network?.interfaces) ? network.interfaces : [];
-  return {
-    available: interfaces.length > 0,
-    degraded: network?.degraded === true,
-    source: network?.source || "",
-    collected_at: network?.collected_at || "",
-    summary: {
-      interface_count: interfaces.length,
-      rx_bytes: interfaces.reduce((sum, item) => sum + Number(item?.rx_bytes || 0), 0),
-      tx_bytes: interfaces.reduce((sum, item) => sum + Number(item?.tx_bytes || 0), 0),
-    },
-    interfaces,
-    peer_discovery: Array.isArray(network?.peer_discovery) ? network.peer_discovery : [],
-  };
-}
-
-function summarizeDiskTelemetryFrame(disk) {
-  const items = Array.isArray(disk?.items) ? disk.items : [];
-  return {
-    available: items.length > 0,
-    degraded: disk?.degraded === true,
-    source: disk?.source || "",
-    collected_at: disk?.collected_at || "",
-    summary: {
-      disk_count: items.length,
-      total_bytes: items.reduce((sum, item) => sum + Number(item?.total_bytes || 0), 0),
-      used_bytes: items.reduce((sum, item) => sum + Number(item?.used_bytes || 0), 0),
-      free_bytes: items.reduce((sum, item) => sum + Number(item?.free_bytes || 0), 0),
-      read_bytes: items.reduce((sum, item) => sum + Number(item?.read_bytes || 0), 0),
-      write_bytes: items.reduce((sum, item) => sum + Number(item?.write_bytes || 0), 0),
-    },
-    items,
-  };
-}
-
-function hostObservationFromTelemetryFrame(frame) {
-  if (!frame?.node_name) {
-    return null;
-  }
-  const cpuSnapshot = frame?.cpu || {};
-  const instanceRuntime = Array.isArray(frame?.instance_runtime) ? frame.instance_runtime : [];
-  const stale = frame?.stale === true;
-  return {
-    node_name: frame.node_name,
-    plane_name: frame.plane_name || "",
-    status: stale ? "stale" : "healthy",
-    observed_at: frame.sampled_at || null,
-    heartbeat_at: frame.sampled_at || null,
-    telemetry_sequence: frame.sequence || 0,
-    telemetry_schema_version: frame.schema_version || "host.telemetry.v1",
-    telemetry_source: frame.source || "hostd",
-    telemetry_node_id: frame.node_id || frame.node_name,
-    telemetry_plane_id: frame.plane_id || frame.plane_name || "",
-    telemetry_channel: frame.channel || "host.telemetry.v1",
-    telemetry_lane: frame.lane || "fast",
-    telemetry_monotonic_ms: frame.monotonic_ms || 0,
-    telemetry_monotonic_timestamp_ms: frame.monotonic_timestamp_ms || frame.monotonic_ms || 0,
-    telemetry_expires_at: frame.expires_at || "",
-    telemetry_expires_in_ms: frame.expires_in_ms ?? null,
-    telemetry_stale: stale,
-    telemetry_health_status: frame?.telemetry_health?.status || frame?.telemetry_health_status || (stale ? "stale" : "ok"),
-    telemetry_last_frame_age_ms: Number(frame?.telemetry_health?.last_frame_age_ms ?? frame?.last_frame_age_ms ?? 0),
-    telemetry_degraded: Boolean(frame?.degraded_reason),
-    telemetry_degraded_reason: frame?.degraded_reason || "",
-    telemetry_collector_duration_ms: Number(frame?.collector_duration_ms || 0),
-    telemetry_publish_duration_ms: Number(frame?.publish_duration_ms || 0),
-    telemetry_queue_delay_ms: Number(frame?.publisher_queue_delay_ms || 0),
-    telemetry_bus_depth: Number(frame?.telemetry_bus_depth || 0),
-    telemetry_dropped_frames: Number(
-      frame?.controller_dropped_frames_total ?? frame?.telemetry_dropped_frames ?? 0,
-    ),
-    telemetry_publish_errors: Number(frame?.publish_error_count || 0),
-    telemetry_adaptive_interval_ms: Number(frame?.adaptive_interval_ms || frame?.interval_ms || 0),
-    telemetry_adaptive_reason: frame?.adaptive_reason || "",
-    telemetry_controller_ingest_delay_ms: Number(frame?.controller_ingest_delay_ms || 0),
-    telemetry_latency_total_ms: Number(frame?.latency_breakdown?.total_observed_ms || 0),
-    telemetry_browser_receive_delay_ms: Number(frame?.telemetry_browser_receive_delay_ms || 0),
-    telemetry_browser_parse_ms: Number(frame?.telemetry_browser_parse_ms || 0),
-    telemetry_last_publish_error: frame?.last_publish_error || "",
-    telemetry_plane_instance_count: Number(frame?.plane_instance_count || 0),
-    telemetry_plane_ready_instance_count: Number(frame?.plane_ready_instance_count || 0),
-    telemetry_plane_not_ready_instance_count: Number(frame?.plane_not_ready_instance_count || 0),
-    telemetry_plane_runtime_health: frame?.plane_runtime_health || "unknown",
-    runtime_status: { available: instanceRuntime.length > 0 },
-    instance_runtimes: {
-      available: instanceRuntime.length > 0,
-      items: instanceRuntime,
-    },
-    cpu_telemetry: {
-      available: Boolean(cpuSnapshot?.source),
-      degraded: cpuSnapshot?.degraded === true,
-      source: cpuSnapshot?.source || "",
-      collected_at: cpuSnapshot?.collected_at || "",
-      summary: cpuSnapshot,
-    },
-    gpu_telemetry: summarizeGpuTelemetryFrame(frame?.gpu),
-    network_telemetry: summarizeNetworkTelemetryFrame(frame?.network),
-    disk_telemetry: summarizeDiskTelemetryFrame(frame?.disk),
-  };
-}
-
-function mergeTelemetryIntoObservationPayload(currentPayload, frames, planeName = "") {
-  const currentItems = hostObservationItemsFromPayload(currentPayload);
-  const byNode = new Map(currentItems.filter((item) => item?.node_name).map((item) => [item.node_name, item]));
-  let changed = false;
-  for (const frame of frames || []) {
-    if (planeName && frame?.plane_name && frame.plane_name !== planeName) {
-      continue;
-    }
-    const telemetryItem = hostObservationFromTelemetryFrame(frame);
-    if (!telemetryItem?.node_name) {
-      continue;
-    }
-    const previous = byNode.get(telemetryItem.node_name) || {};
-    const previousSequence = Number(previous.telemetry_sequence || 0);
-    const nextSequence = Number(telemetryItem.telemetry_sequence || 0);
-    if (previousSequence > 0 && nextSequence > 0 && nextSequence <= previousSequence) {
-      continue;
-    }
-    const nextItem = {
-      ...previous,
-      ...telemetryItem,
-      observed_state: previous.observed_state,
-      applied_generation: previous.applied_generation,
-      disk_telemetry: telemetryItem.disk_telemetry?.available
-        ? telemetryItem.disk_telemetry
-        : previous.disk_telemetry,
-    };
-    byNode.set(telemetryItem.node_name, nextItem);
-    changed = true;
-  }
-  if (!changed && currentPayload) {
-    return currentPayload;
-  }
-  return {
-    ...(currentPayload || {}),
-    observations: [...byNode.values()],
-  };
 }
 
 function instanceRole(instance) {
@@ -3982,33 +3813,27 @@ function App() {
             selectedPlaneRef.current,
           ),
         );
-        const nextPlaneLatency = {
+        const nextPlaneLatency = buildTelemetryBrowserLatency({
+          frames: validFrames,
           receivedAtMs,
-          receiveDelayMs: Math.max(
-            0,
-            ...validFrames.map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
-          ),
           parseMs,
           reduceMs: planeReduceMs,
-          applyMs: performance.now() - applyStartedAt,
+          applyStartedAt,
           acceptedFrames: planeResult.acceptedFrames.length,
-        };
+        });
         planeTelemetryStoreRef.current = updateTelemetryBrowserLatency(
           planeTelemetryStoreRef.current,
           nextPlaneLatency,
         );
       }
-      const nextGlobalLatency = {
+      const nextGlobalLatency = buildTelemetryBrowserLatency({
+        frames: validFrames,
         receivedAtMs,
-        receiveDelayMs: Math.max(
-          0,
-          ...validFrames.map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
-        ),
         parseMs,
         reduceMs,
-        applyMs: performance.now() - applyStartedAt,
+        applyStartedAt,
         acceptedFrames: globalResult.acceptedFrames.length,
-      };
+      });
       globalTelemetryStoreRef.current = updateTelemetryBrowserLatency(
         globalTelemetryStoreRef.current,
         nextGlobalLatency,
@@ -4039,7 +3864,7 @@ function App() {
         );
       }
       applyFrames(
-        [...(payload?.history || []), ...(payload?.nodes || [])],
+        telemetryFramesFromSnapshot(payload),
         Number(payload?.__telemetry_browser_parse_ms || 0),
       );
     };
@@ -4087,9 +3912,7 @@ function App() {
     }
     source.addEventListener("telemetry.snapshot", (event) => {
       try {
-        const parseStartedAt = performance.now();
-        const payload = JSON.parse(event.data || "{}");
-        const parseMs = performance.now() - parseStartedAt;
+        const { payload, parseMs } = parseTelemetryEventPayload(event);
         payload.__telemetry_browser_parse_ms = parseMs;
         applySnapshotPayload(payload);
       } catch (_) {
@@ -4098,9 +3921,8 @@ function App() {
     });
     source.addEventListener("telemetry.node", (event) => {
       try {
-        const parseStartedAt = performance.now();
-        const frame = JSON.parse(event.data || "{}");
-        applyFrames([frame], performance.now() - parseStartedAt);
+        const { payload: frame, parseMs } = parseTelemetryEventPayload(event);
+        applyFrames([frame], parseMs);
       } catch (_) {
         setTelemetryHealthy(false);
       }
@@ -4149,10 +3971,7 @@ function App() {
           }
           const nextGlobalLatency = {
             receivedAtMs: Date.now(),
-            receiveDelayMs: Math.max(
-              0,
-              ...frames.map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
-            ),
+            receiveDelayMs: maxTelemetryReceiveDelayMs(frames),
             parseMs: 0,
             reduceMs: 0,
             applyMs: 0,

--- a/ui/operator-react/src/telemetryHostObservations.js
+++ b/ui/operator-react/src/telemetryHostObservations.js
@@ -1,0 +1,183 @@
+export function hostObservationItemsFromPayload(payload) {
+  if (Array.isArray(payload?.observations)) {
+    return payload.observations.map((item) => ({
+      ...item,
+      observed_at: item?.observed_at || item?.heartbeat_at || null,
+    }));
+  }
+  if (Array.isArray(payload?.items)) {
+    return payload.items.map((item) => ({
+      ...item,
+      observed_at: item?.observed_at || item?.heartbeat_at || null,
+    }));
+  }
+  return [];
+}
+
+export function summarizeGpuTelemetryFrame(gpu) {
+  const devices = Array.isArray(gpu?.devices) ? gpu.devices : [];
+  return {
+    available: devices.length > 0,
+    degraded: gpu?.degraded === true,
+    source: gpu?.source || "",
+    collected_at: gpu?.collected_at || "",
+    summary: {
+      device_count: devices.length,
+      total_vram_mb: devices.reduce((sum, item) => sum + Number(item?.total_vram_mb || 0), 0),
+      used_vram_mb: devices.reduce((sum, item) => sum + Number(item?.used_vram_mb || 0), 0),
+      free_vram_mb: devices.reduce((sum, item) => sum + Number(item?.free_vram_mb || 0), 0),
+      temperature_device_count: devices.filter((item) => item?.temperature_available).length,
+      hottest_temperature_c: devices.reduce(
+        (max, item) => Math.max(max, Number(item?.temperature_c || 0)),
+        0,
+      ),
+    },
+    devices,
+  };
+}
+
+export function summarizeNetworkTelemetryFrame(network) {
+  const interfaces = Array.isArray(network?.interfaces) ? network.interfaces : [];
+  return {
+    available: interfaces.length > 0,
+    degraded: network?.degraded === true,
+    source: network?.source || "",
+    collected_at: network?.collected_at || "",
+    summary: {
+      interface_count: interfaces.length,
+      rx_bytes: interfaces.reduce((sum, item) => sum + Number(item?.rx_bytes || 0), 0),
+      tx_bytes: interfaces.reduce((sum, item) => sum + Number(item?.tx_bytes || 0), 0),
+    },
+    interfaces,
+    peer_discovery: Array.isArray(network?.peer_discovery) ? network.peer_discovery : [],
+  };
+}
+
+export function summarizeDiskTelemetryFrame(disk) {
+  const items = Array.isArray(disk?.items) ? disk.items : [];
+  return {
+    available: items.length > 0,
+    degraded: disk?.degraded === true,
+    source: disk?.source || "",
+    collected_at: disk?.collected_at || "",
+    summary: {
+      disk_count: items.length,
+      total_bytes: items.reduce((sum, item) => sum + Number(item?.total_bytes || 0), 0),
+      used_bytes: items.reduce((sum, item) => sum + Number(item?.used_bytes || 0), 0),
+      free_bytes: items.reduce((sum, item) => sum + Number(item?.free_bytes || 0), 0),
+      read_bytes: items.reduce((sum, item) => sum + Number(item?.read_bytes || 0), 0),
+      write_bytes: items.reduce((sum, item) => sum + Number(item?.write_bytes || 0), 0),
+    },
+    items,
+  };
+}
+
+export function hostObservationFromTelemetryFrame(frame) {
+  if (!frame?.node_name) {
+    return null;
+  }
+  const cpuSnapshot = frame?.cpu || {};
+  const instanceRuntime = Array.isArray(frame?.instance_runtime) ? frame.instance_runtime : [];
+  const stale = frame?.stale === true;
+  return {
+    node_name: frame.node_name,
+    plane_name: frame.plane_name || "",
+    status: stale ? "stale" : "healthy",
+    observed_at: frame.sampled_at || null,
+    heartbeat_at: frame.sampled_at || null,
+    telemetry_sequence: frame.sequence || 0,
+    telemetry_schema_version: frame.schema_version || "host.telemetry.v1",
+    telemetry_source: frame.source || "hostd",
+    telemetry_node_id: frame.node_id || frame.node_name,
+    telemetry_plane_id: frame.plane_id || frame.plane_name || "",
+    telemetry_channel: frame.channel || "host.telemetry.v1",
+    telemetry_lane: frame.lane || "fast",
+    telemetry_monotonic_ms: frame.monotonic_ms || 0,
+    telemetry_monotonic_timestamp_ms: frame.monotonic_timestamp_ms || frame.monotonic_ms || 0,
+    telemetry_expires_at: frame.expires_at || "",
+    telemetry_expires_in_ms: frame.expires_in_ms ?? null,
+    telemetry_stale: stale,
+    telemetry_health_status:
+      frame?.telemetry_health?.status || frame?.telemetry_health_status || (stale ? "stale" : "ok"),
+    telemetry_last_frame_age_ms: Number(
+      frame?.telemetry_health?.last_frame_age_ms ?? frame?.last_frame_age_ms ?? 0,
+    ),
+    telemetry_degraded: Boolean(frame?.degraded_reason),
+    telemetry_degraded_reason: frame?.degraded_reason || "",
+    telemetry_collector_duration_ms: Number(frame?.collector_duration_ms || 0),
+    telemetry_publish_duration_ms: Number(frame?.publish_duration_ms || 0),
+    telemetry_queue_delay_ms: Number(frame?.publisher_queue_delay_ms || 0),
+    telemetry_bus_depth: Number(frame?.telemetry_bus_depth || 0),
+    telemetry_dropped_frames: Number(
+      frame?.controller_dropped_frames_total ?? frame?.telemetry_dropped_frames ?? 0,
+    ),
+    telemetry_publish_errors: Number(frame?.publish_error_count || 0),
+    telemetry_adaptive_interval_ms: Number(frame?.adaptive_interval_ms || frame?.interval_ms || 0),
+    telemetry_adaptive_reason: frame?.adaptive_reason || "",
+    telemetry_controller_ingest_delay_ms: Number(frame?.controller_ingest_delay_ms || 0),
+    telemetry_latency_total_ms: Number(frame?.latency_breakdown?.total_observed_ms || 0),
+    telemetry_browser_receive_delay_ms: Number(frame?.telemetry_browser_receive_delay_ms || 0),
+    telemetry_browser_parse_ms: Number(frame?.telemetry_browser_parse_ms || 0),
+    telemetry_last_publish_error: frame?.last_publish_error || "",
+    telemetry_plane_instance_count: Number(frame?.plane_instance_count || 0),
+    telemetry_plane_ready_instance_count: Number(frame?.plane_ready_instance_count || 0),
+    telemetry_plane_not_ready_instance_count: Number(frame?.plane_not_ready_instance_count || 0),
+    telemetry_plane_runtime_health: frame?.plane_runtime_health || "unknown",
+    runtime_status: { available: instanceRuntime.length > 0 },
+    instance_runtimes: {
+      available: instanceRuntime.length > 0,
+      items: instanceRuntime,
+    },
+    cpu_telemetry: {
+      available: Boolean(cpuSnapshot?.source),
+      degraded: cpuSnapshot?.degraded === true,
+      source: cpuSnapshot?.source || "",
+      collected_at: cpuSnapshot?.collected_at || "",
+      summary: cpuSnapshot,
+    },
+    gpu_telemetry: summarizeGpuTelemetryFrame(frame?.gpu),
+    network_telemetry: summarizeNetworkTelemetryFrame(frame?.network),
+    disk_telemetry: summarizeDiskTelemetryFrame(frame?.disk),
+  };
+}
+
+export function mergeTelemetryIntoObservationPayload(currentPayload, frames, planeName = "") {
+  const currentItems = hostObservationItemsFromPayload(currentPayload);
+  const byNode = new Map(
+    currentItems.filter((item) => item?.node_name).map((item) => [item.node_name, item]),
+  );
+  let changed = false;
+  for (const frame of frames || []) {
+    if (planeName && frame?.plane_name && frame.plane_name !== planeName) {
+      continue;
+    }
+    const telemetryItem = hostObservationFromTelemetryFrame(frame);
+    if (!telemetryItem?.node_name) {
+      continue;
+    }
+    const previous = byNode.get(telemetryItem.node_name) || {};
+    const previousSequence = Number(previous.telemetry_sequence || 0);
+    const nextSequence = Number(telemetryItem.telemetry_sequence || 0);
+    if (previousSequence > 0 && nextSequence > 0 && nextSequence <= previousSequence) {
+      continue;
+    }
+    const nextItem = {
+      ...previous,
+      ...telemetryItem,
+      observed_state: previous.observed_state,
+      applied_generation: previous.applied_generation,
+      disk_telemetry: telemetryItem.disk_telemetry?.available
+        ? telemetryItem.disk_telemetry
+        : previous.disk_telemetry,
+    };
+    byNode.set(telemetryItem.node_name, nextItem);
+    changed = true;
+  }
+  if (!changed && currentPayload) {
+    return currentPayload;
+  }
+  return {
+    ...(currentPayload || {}),
+    observations: [...byNode.values()],
+  };
+}

--- a/ui/operator-react/src/telemetryHostObservations.test.js
+++ b/ui/operator-react/src/telemetryHostObservations.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hostObservationFromTelemetryFrame,
+  hostObservationItemsFromPayload,
+  mergeTelemetryIntoObservationPayload,
+} from "./telemetryHostObservations.js";
+
+describe("telemetryHostObservations", () => {
+  it("maps telemetry frames into host observation payloads", () => {
+    const observation = hostObservationFromTelemetryFrame({
+      node_name: "node-a",
+      plane_name: "plane-a",
+      sequence: 42,
+      sampled_at: "2026-05-04T10:00:00Z",
+      telemetry_health: { status: "ok", last_frame_age_ms: 12 },
+      gpu: { source: "nvidia-smi", devices: [{ total_vram_mb: 10, used_vram_mb: 4 }] },
+      instance_runtime: [{ instance_name: "plane-a-worker-1" }],
+    });
+
+    expect(observation.node_name).toBe("node-a");
+    expect(observation.telemetry_sequence).toBe(42);
+    expect(observation.telemetry_health_status).toBe("ok");
+    expect(observation.gpu_telemetry.summary.used_vram_mb).toBe(4);
+    expect(observation.instance_runtimes.available).toBe(true);
+  });
+
+  it("merges only newer telemetry frames into observations", () => {
+    const current = {
+      observations: [
+        {
+          node_name: "node-a",
+          telemetry_sequence: 10,
+          observed_state: { instances: [{ name: "existing" }] },
+        },
+      ],
+    };
+
+    const stale = mergeTelemetryIntoObservationPayload(current, [
+      { node_name: "node-a", sequence: 9 },
+    ]);
+    expect(stale).toBe(current);
+
+    const merged = mergeTelemetryIntoObservationPayload(current, [
+      { node_name: "node-a", sequence: 11, sampled_at: "now" },
+    ]);
+    expect(hostObservationItemsFromPayload(merged)[0].telemetry_sequence).toBe(11);
+    expect(hostObservationItemsFromPayload(merged)[0].observed_state.instances[0].name).toBe(
+      "existing",
+    );
+  });
+});

--- a/ui/operator-react/src/telemetryStreamClient.js
+++ b/ui/operator-react/src/telemetryStreamClient.js
@@ -1,0 +1,37 @@
+export function parseTelemetryEventPayload(event, fallbackPayload = {}) {
+  const parseStartedAt = performance.now();
+  const payload = JSON.parse(event?.data || JSON.stringify(fallbackPayload));
+  return {
+    payload,
+    parseMs: performance.now() - parseStartedAt,
+  };
+}
+
+export function telemetryFramesFromSnapshot(payload) {
+  return [...(payload?.history || []), ...(payload?.nodes || [])];
+}
+
+export function maxTelemetryReceiveDelayMs(frames) {
+  return Math.max(
+    0,
+    ...(frames || []).map((frame) => Number(frame?.telemetry_browser_receive_delay_ms || 0)),
+  );
+}
+
+export function buildTelemetryBrowserLatency({
+  frames,
+  receivedAtMs,
+  parseMs,
+  reduceMs,
+  applyStartedAt,
+  acceptedFrames,
+}) {
+  return {
+    receivedAtMs,
+    receiveDelayMs: maxTelemetryReceiveDelayMs(frames),
+    parseMs,
+    reduceMs,
+    applyMs: performance.now() - applyStartedAt,
+    acceptedFrames,
+  };
+}

--- a/ui/operator-react/src/telemetryStreamClient.test.js
+++ b/ui/operator-react/src/telemetryStreamClient.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTelemetryBrowserLatency,
+  maxTelemetryReceiveDelayMs,
+  parseTelemetryEventPayload,
+  telemetryFramesFromSnapshot,
+} from "./telemetryStreamClient.js";
+
+describe("telemetryStreamClient", () => {
+  it("parses telemetry event payloads and reports parse timing", () => {
+    const result = parseTelemetryEventPayload({
+      data: JSON.stringify({ node_name: "node-a", sequence: 10 }),
+    });
+
+    expect(result.payload.node_name).toBe("node-a");
+    expect(result.parseMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("combines snapshot history and nodes in stream order", () => {
+    expect(
+      telemetryFramesFromSnapshot({
+        history: [{ sequence: 1 }],
+        nodes: [{ sequence: 2 }],
+      }).map((frame) => frame.sequence),
+    ).toEqual([1, 2]);
+  });
+
+  it("builds browser latency samples from enriched frames", () => {
+    const latency = buildTelemetryBrowserLatency({
+      frames: [
+        { telemetry_browser_receive_delay_ms: 12 },
+        { telemetry_browser_receive_delay_ms: 18 },
+      ],
+      receivedAtMs: 100,
+      parseMs: 1,
+      reduceMs: 2,
+      applyStartedAt: performance.now(),
+      acceptedFrames: 2,
+    });
+
+    expect(maxTelemetryReceiveDelayMs([])).toBe(0);
+    expect(latency.receiveDelayMs).toBe(18);
+    expect(latency.acceptedFrames).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- split controller telemetry alert, persistence, and live-store state responsibilities into narrower classes
- remove remaining production telemetry lambdas in C++ matching/ring-buffer paths
- extract WebUI telemetry host-observation mapping and stream parsing helpers from App.jsx

## Tests
- cmake --build build/telemetry-debug --target naim-telemetry-live-store-tests naim-controller naim-hostd-http-tests
- ./build/telemetry-debug/naim-telemetry-live-store-tests
- TMPDIR=... ./build/telemetry-debug/naim-hostd-http-tests
- npm test -- --run src/telemetryStore.test.js src/telemetryHostObservations.test.js src/telemetryStreamClient.test.js
- npm run build
- telemetry health CLI env smoke locally and on hpc1 sandbox