### PR TITLE
Fix telemetry health alert policy

### DIFF
--- a/controller/include/telemetry/telemetry_alert_builder.h
+++ b/controller/include/telemetry/telemetry_alert_builder.h
@@ -19,7 +19,6 @@ class TelemetryAlertBuilder final {
       const TelemetryPersistenceState& persistence,
       const TelemetryStreamMetrics& streams,
       const TelemetryAlertThresholds& thresholds,
-      std::uint64_t dropped_frames_total,
       std::uint64_t now_ms) const;
 
  private:

--- a/controller/include/telemetry/telemetry_node_alert_builder.h
+++ b/controller/include/telemetry/telemetry_node_alert_builder.h
@@ -18,6 +18,11 @@ class TelemetryNodeAlertBuilder final {
       std::uint64_t now_ms) const;
 
  private:
+  std::uint64_t IngestWarningBudgetMs(
+      const naim::HostTelemetryFrame& frame,
+      const TelemetryAlertThresholds& thresholds) const;
+  bool HasActivePublishError(const naim::HostTelemetryFrame& frame) const;
+
   TelemetryFrameMatcher matcher_;
 };
 

--- a/controller/include/telemetry/telemetry_pipeline_alert_builder.h
+++ b/controller/include/telemetry/telemetry_pipeline_alert_builder.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cstdint>
-
 #include <nlohmann/json.hpp>
 
 #include "telemetry/telemetry_state_types.h"
@@ -12,8 +10,7 @@ class TelemetryPipelineAlertBuilder final {
  public:
   nlohmann::json Build(
       const TelemetryPersistenceState& persistence,
-      const TelemetryStreamMetrics& streams,
-      std::uint64_t dropped_frames_total) const;
+      const TelemetryStreamMetrics& streams) const;
 };
 
 }  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_alert_builder.cpp
+++ b/controller/src/telemetry/telemetry_alert_builder.cpp
@@ -7,11 +7,9 @@ nlohmann::json TelemetryAlertBuilder::Build(
     const TelemetryPersistenceState& persistence,
     const TelemetryStreamMetrics& streams,
     const TelemetryAlertThresholds& thresholds,
-    const std::uint64_t dropped_frames_total,
     const std::uint64_t now_ms) const {
   nlohmann::json alerts = nlohmann::json::array();
-  const auto pipeline_alerts =
-      pipeline_alert_builder_.Build(persistence, streams, dropped_frames_total);
+  const auto pipeline_alerts = pipeline_alert_builder_.Build(persistence, streams);
   alerts.insert(alerts.end(), pipeline_alerts.begin(), pipeline_alerts.end());
   for (const auto* buffer : buffers) {
     if (buffer == nullptr) {

--- a/controller/src/telemetry/telemetry_frame_json_builder.cpp
+++ b/controller/src/telemetry/telemetry_frame_json_builder.cpp
@@ -19,7 +19,7 @@ nlohmann::json TelemetryFrameJsonBuilder::Build(
   payload["last_frame_age_ms"] = controller_ingest_delay_ms;
   payload["telemetry_health_status"] =
       stale ? "stale"
-            : frame.telemetry_dropped_frames > 0 || frame.publish_error_count > 0
+            : frame.telemetry_dropped_frames > 0 || !frame.last_publish_error.empty()
                 ? "degraded"
                 : "ok";
   payload["latency_breakdown"] = BuildLatencyBreakdown(frame, controller_ingest_delay_ms);

--- a/controller/src/telemetry/telemetry_health_builder.cpp
+++ b/controller/src/telemetry/telemetry_health_builder.cpp
@@ -25,7 +25,6 @@ nlohmann::json TelemetryHealthBuilder::BuildHealth(
       persistence,
       streams,
       thresholds,
-      dropped_frames_total,
       now_ms);
   std::string status = "ok";
   if (!alerts.empty()) {

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -304,6 +304,48 @@ void TestConfigurableRetentionAndMetrics() {
   std::cout << "ok: telemetry-live-store-configurable-retention\n";
 }
 
+void TestRecoveredTelemetryCountersDoNotDegradeHealth() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  store.ResetForTests();
+  naim::controller::TelemetryLiveStore::RetentionConfig retention;
+  retention.hot_history_capacity = 3;
+  retention.stream_batch_limit = 2;
+  retention.durable_history_capacity = 5;
+  naim::controller::TelemetryLiveStore::AlertThresholds thresholds;
+  store.ConfigureOperationalPolicy(retention, thresholds);
+  const auto db_path =
+      std::filesystem::temp_directory_path() /
+      ("naim-telemetry-recovered-counters-" + std::to_string(CurrentMillis()) + ".sqlite");
+  store.ConfigurePersistence(db_path.string(), retention.durable_history_capacity);
+
+  const auto now = CurrentMillis();
+  for (std::uint64_t index = 0; index < 6; ++index) {
+    auto frame = MakeFrame("node-recovered", "plane-recovered", now - 5000 + index);
+    frame.adaptive_interval_ms = 10000;
+    frame.adaptive_reason = "idle-no-plane";
+    frame.publish_error_count = 2;
+    frame.last_publish_error.clear();
+    Expect(store.Upsert(frame), "recovered counter frame should update");
+  }
+
+  const auto health = store.BuildHealth(std::string("plane-recovered"));
+  Expect(
+      health.at("status").get<std::string>() == "ok",
+      "retention pruning and recovered publish counters should not degrade health");
+  Expect(health.at("alerts").empty(), "recovered counters should not produce alerts");
+  Expect(
+      health.at("planes").at(0).at("status").get<std::string>() == "ok",
+      "plane status should not degrade on retention pruning alone");
+
+  const auto snapshot = store.BuildSnapshot(std::string("plane-recovered"), 0);
+  Expect(
+      snapshot.at("nodes").at(0).at("telemetry_health").at("status").get<std::string>() == "ok",
+      "node health should not degrade on recovered publish counters");
+  std::filesystem::remove(db_path);
+  store.ResetForTests();
+  std::cout << "ok: telemetry-live-store-recovered-counters-health\n";
+}
+
 void TestStreamMetricsAndOpenMetrics() {
   auto& store = naim::controller::TelemetryLiveStore::Instance();
   store.ResetForTests();
@@ -341,6 +383,7 @@ int main() {
     TestPlaneAggregatesAndDownsampling();
     TestSqlitePersistenceReplayAndHealth();
     TestConfigurableRetentionAndMetrics();
+    TestRecoveredTelemetryCountersDoNotDegradeHealth();
     TestStreamMetricsAndOpenMetrics();
     return 0;
   } catch (const std::exception& error) {

--- a/controller/src/telemetry/telemetry_node_alert_builder.cpp
+++ b/controller/src/telemetry/telemetry_node_alert_builder.cpp
@@ -1,6 +1,25 @@
 #include "telemetry/telemetry_node_alert_builder.h"
 
+#include <algorithm>
+
 namespace naim::controller {
+
+std::uint64_t TelemetryNodeAlertBuilder::IngestWarningBudgetMs(
+    const naim::HostTelemetryFrame& frame,
+    const TelemetryAlertThresholds& thresholds) const {
+  const std::uint64_t adaptive_interval_ms =
+      frame.adaptive_interval_ms > 0
+          ? static_cast<std::uint64_t>(frame.adaptive_interval_ms)
+          : static_cast<std::uint64_t>(std::max(0, frame.interval_ms));
+  return std::max(
+      thresholds.ingest_warning_ms,
+      adaptive_interval_ms + thresholds.ingest_warning_ms);
+}
+
+bool TelemetryNodeAlertBuilder::HasActivePublishError(
+    const naim::HostTelemetryFrame& frame) const {
+  return frame.publish_error_count > 0 && !frame.last_publish_error.empty();
+}
 
 nlohmann::json TelemetryNodeAlertBuilder::Build(
     const TelemetryNodeBuffer& buffer,
@@ -26,13 +45,16 @@ nlohmann::json TelemetryNodeAlertBuilder::Build(
         {"age_ms", ingest_ms},
     });
   }
-  if (ingest_ms >= thresholds.ingest_warning_ms) {
+  const auto ingest_warning_budget_ms = IngestWarningBudgetMs(frame, thresholds);
+  if (ingest_ms >= ingest_warning_budget_ms) {
     alerts.push_back(nlohmann::json{
         {"code", "telemetry.controller.ingest_delay"},
         {"severity", "warning"},
         {"node_name", frame.node_name},
         {"plane_name", matcher_.PlaneKeyForFrame(frame)},
         {"delay_ms", ingest_ms},
+        {"expected_interval_ms", frame.adaptive_interval_ms},
+        {"warning_budget_ms", ingest_warning_budget_ms},
     });
   }
   if (frame.publisher_queue_delay_ms >= thresholds.queue_warning_ms) {
@@ -44,7 +66,7 @@ nlohmann::json TelemetryNodeAlertBuilder::Build(
         {"delay_ms", frame.publisher_queue_delay_ms},
     });
   }
-  if (frame.publish_error_count > 0) {
+  if (HasActivePublishError(frame)) {
     alerts.push_back(nlohmann::json{
         {"code", "telemetry.publisher.errors"},
         {"severity", "warning"},

--- a/controller/src/telemetry/telemetry_node_health_builder.cpp
+++ b/controller/src/telemetry/telemetry_node_health_builder.cpp
@@ -17,8 +17,9 @@ nlohmann::json TelemetryNodeHealthBuilder::Build(
   if (stale) {
     status = "stale";
   } else if (
-      buffer.dropped_frames_total > 0 || frame.telemetry_dropped_frames > 0 ||
-      frame.publish_error_count > 0 || !frame.degraded_reason.empty()) {
+      frame.telemetry_dropped_frames > 0 ||
+      !frame.last_publish_error.empty() ||
+      !frame.degraded_reason.empty()) {
     status = "degraded";
   }
   return nlohmann::json{

--- a/controller/src/telemetry/telemetry_pipeline_alert_builder.cpp
+++ b/controller/src/telemetry/telemetry_pipeline_alert_builder.cpp
@@ -4,8 +4,7 @@ namespace naim::controller {
 
 nlohmann::json TelemetryPipelineAlertBuilder::Build(
     const TelemetryPersistenceState& persistence,
-    const TelemetryStreamMetrics& streams,
-    const std::uint64_t dropped_frames_total) const {
+    const TelemetryStreamMetrics& streams) const {
   nlohmann::json alerts = nlohmann::json::array();
   if (!persistence.enabled) {
     alerts.push_back(nlohmann::json{
@@ -21,14 +20,6 @@ nlohmann::json TelemetryPipelineAlertBuilder::Build(
         {"message", "sqlite telemetry ring buffer reported errors"},
         {"count", persistence.error_count},
         {"last_error", persistence.last_error},
-    });
-  }
-  if (dropped_frames_total > 0) {
-    alerts.push_back(nlohmann::json{
-        {"code", "telemetry.controller.dropped_frames"},
-        {"severity", "warning"},
-        {"message", "controller telemetry ring buffer pruned live frames"},
-        {"count", dropped_frames_total},
     });
   }
   if (streams.telemetry.send_failure_total > 0 || streams.live.send_failure_total > 0) {

--- a/controller/src/telemetry/telemetry_plane_aggregate_builder.cpp
+++ b/controller/src/telemetry/telemetry_plane_aggregate_builder.cpp
@@ -43,11 +43,10 @@ nlohmann::json TelemetryPlaneAggregateBuilder::Build(
   }
   nlohmann::json result = nlohmann::json::array();
   for (const auto& [_, plane] : planes) {
-    const bool overloaded = plane.dropped_frames_total > 0;
     std::string status = "ok";
     if (plane.stale_nodes > 0) {
       status = "stale";
-    } else if (plane.degraded_nodes > 0 || overloaded) {
+    } else if (plane.degraded_nodes > 0) {
       status = "degraded";
     }
     const double node_count = static_cast<double>(std::max<std::uint64_t>(1, plane.node_count));

--- a/controller/src/telemetry/telemetry_snapshot_builder.cpp
+++ b/controller/src/telemetry/telemetry_snapshot_builder.cpp
@@ -52,7 +52,6 @@ nlohmann::json TelemetrySnapshotBuilder::BuildSnapshot(
       persistence,
       streams,
       thresholds,
-      dropped_frames_total,
       now_ms);
   const std::string status =
       !alerts.empty() ? "degraded" : overloaded ? "overloaded" : "ok";


### PR DESCRIPTION
## Summary
- stop treating normal controller ring retention pruning as a health warning
- make ingest-delay alerts respect the node adaptive telemetry interval
- stop keeping recovered publish-error counters as active degraded health when the current error is clear

## Cause
Production telemetry was degraded by stale/lifetime counters and by applying a 3s ingest threshold to storage1 even though storage1 was intentionally publishing every 10s in idle mode.

## Tests
- cmake --build build/telemetry-debug --target naim-telemetry-live-store-tests naim-controller naim-hostd-http-tests
- ./build/telemetry-debug/naim-telemetry-live-store-tests
- TMPDIR=... ./build/telemetry-debug/naim-hostd-http-tests
- telemetry health CLI env smoke locally
- hpc1 sandbox build/tests/telemetry health smoke