### PR TITLE
Fix storage telemetry GPU health policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,6 +563,7 @@ set(
   controller/src/telemetry/telemetry_alert_builder.cpp
   controller/src/telemetry/telemetry_clock.cpp
   controller/src/telemetry/telemetry_environment_reader.cpp
+  controller/src/telemetry/telemetry_frame_health_policy.cpp
   controller/src/telemetry/telemetry_frame_json_builder.cpp
   controller/src/telemetry/telemetry_frame_matcher.cpp
   controller/src/telemetry/telemetry_frame_normalizer.cpp

--- a/controller/include/telemetry/telemetry_frame_health_policy.h
+++ b/controller/include/telemetry/telemetry_frame_health_policy.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "naim/runtime/runtime_status.h"
+
+namespace naim::controller {
+
+class TelemetryFrameHealthPolicy final {
+ public:
+  bool HasActionableDegradedReason(const naim::HostTelemetryFrame& frame) const;
+
+ private:
+  bool HasGpuBoundRuntime(const naim::HostTelemetryFrame& frame) const;
+};
+
+}  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_frame_json_builder.h
+++ b/controller/include/telemetry/telemetry_frame_json_builder.h
@@ -5,6 +5,7 @@
 #include <nlohmann/json.hpp>
 
 #include "naim/runtime/runtime_status.h"
+#include "telemetry/telemetry_frame_health_policy.h"
 #include "telemetry/telemetry_frame_matcher.h"
 
 namespace naim::controller {
@@ -19,6 +20,7 @@ class TelemetryFrameJsonBuilder final {
       std::uint64_t controller_ingest_delay_ms) const;
 
  private:
+  TelemetryFrameHealthPolicy health_policy_;
   TelemetryFrameMatcher matcher_;
 };
 

--- a/controller/include/telemetry/telemetry_node_health_builder.h
+++ b/controller/include/telemetry/telemetry_node_health_builder.h
@@ -5,6 +5,7 @@
 #include <nlohmann/json.hpp>
 
 #include "naim/runtime/runtime_status.h"
+#include "telemetry/telemetry_frame_health_policy.h"
 #include "telemetry/telemetry_state_types.h"
 
 namespace naim::controller {
@@ -16,6 +17,9 @@ class TelemetryNodeHealthBuilder final {
       const TelemetryNodeBuffer& buffer,
       std::uint64_t now_ms,
       std::uint64_t controller_ingest_delay_ms) const;
+
+ private:
+  TelemetryFrameHealthPolicy health_policy_;
 };
 
 }  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_frame_health_policy.cpp
+++ b/controller/src/telemetry/telemetry_frame_health_policy.cpp
@@ -1,0 +1,26 @@
+#include "telemetry/telemetry_frame_health_policy.h"
+
+namespace naim::controller {
+
+bool TelemetryFrameHealthPolicy::HasGpuBoundRuntime(
+    const naim::HostTelemetryFrame& frame) const {
+  for (const auto& runtime : frame.instance_runtime) {
+    if (!runtime.gpu_device.empty()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool TelemetryFrameHealthPolicy::HasActionableDegradedReason(
+    const naim::HostTelemetryFrame& frame) const {
+  if (frame.degraded_reason.empty()) {
+    return false;
+  }
+  if (frame.degraded_reason != "gpu:unavailable") {
+    return true;
+  }
+  return !frame.gpu.devices.empty() || HasGpuBoundRuntime(frame);
+}
+
+}  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_frame_json_builder.cpp
+++ b/controller/src/telemetry/telemetry_frame_json_builder.cpp
@@ -19,7 +19,8 @@ nlohmann::json TelemetryFrameJsonBuilder::Build(
   payload["last_frame_age_ms"] = controller_ingest_delay_ms;
   payload["telemetry_health_status"] =
       stale ? "stale"
-            : frame.telemetry_dropped_frames > 0 || !frame.last_publish_error.empty()
+            : frame.telemetry_dropped_frames > 0 || !frame.last_publish_error.empty() ||
+                    health_policy_.HasActionableDegradedReason(frame)
                 ? "degraded"
                 : "ok";
   payload["latency_breakdown"] = BuildLatencyBreakdown(frame, controller_ingest_delay_ms);

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -346,6 +346,73 @@ void TestRecoveredTelemetryCountersDoNotDegradeHealth() {
   std::cout << "ok: telemetry-live-store-recovered-counters-health\n";
 }
 
+void TestGpuUnavailableStorageNodeDoesNotDegradeHealth() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  store.ResetForTests();
+  const auto db_path =
+      std::filesystem::temp_directory_path() /
+      ("naim-telemetry-storage-gpu-health-" + std::to_string(CurrentMillis()) + ".sqlite");
+  store.ConfigurePersistence(db_path.string(), 8);
+
+  auto frame = MakeFrame("node-storage-gpuless", "plane-storage-gpuless", CurrentMillis());
+  frame.ttl_ms = 60000;
+  frame.adaptive_interval_ms = 10000;
+  frame.adaptive_reason = "idle-no-plane";
+  frame.degraded_reason = "gpu:unavailable";
+  frame.gpu.degraded = true;
+  frame.gpu.devices.clear();
+  frame.instance_runtime.clear();
+  Expect(store.Upsert(frame), "gpuless storage frame should update");
+
+  const auto health = store.BuildHealth(std::string("plane-storage-gpuless"));
+  Expect(
+      health.at("status").get<std::string>() == "ok",
+      "gpuless storage node should not degrade global health");
+  Expect(
+      health.at("planes").at(0).at("status").get<std::string>() == "ok",
+      "gpuless storage node should not degrade plane health");
+  Expect(
+      health.at("planes").at(0).at("degraded_nodes").get<std::uint64_t>() == 0,
+      "gpuless storage node should not count as degraded");
+
+  const auto snapshot = store.BuildSnapshot(std::string("plane-storage-gpuless"), 0);
+  const auto node = snapshot.at("nodes").at(0);
+  Expect(
+      node.at("telemetry_health").at("status").get<std::string>() == "ok",
+      "gpuless storage node telemetry health should remain ok");
+  Expect(
+      node.at("telemetry_health_status").get<std::string>() == "ok",
+      "gpuless storage frame health status should remain ok");
+
+  auto gpu_runtime_frame =
+      MakeFrame("node-gpu-runtime", "plane-gpu-runtime", CurrentMillis());
+  gpu_runtime_frame.ttl_ms = 60000;
+  gpu_runtime_frame.degraded_reason = "gpu:unavailable";
+  gpu_runtime_frame.gpu.devices.clear();
+  gpu_runtime_frame.instance_runtime.push_back(naim::RuntimeProcessStatus{
+      "worker-0",
+      "worker",
+      "node-gpu-runtime",
+      "/models/qwen",
+      "0",
+      "running",
+      "",
+      "",
+      0,
+      0,
+      false,
+  });
+  Expect(store.Upsert(gpu_runtime_frame), "gpu-bound runtime frame should update");
+  const auto gpu_runtime_health = store.BuildHealth(std::string("plane-gpu-runtime"));
+  Expect(
+      gpu_runtime_health.at("planes").at(0).at("status").get<std::string>() == "degraded",
+      "gpu-bound runtime should still degrade when gpu is unavailable");
+
+  std::filesystem::remove(db_path);
+  store.ResetForTests();
+  std::cout << "ok: telemetry-live-store-storage-gpu-health\n";
+}
+
 void TestStreamMetricsAndOpenMetrics() {
   auto& store = naim::controller::TelemetryLiveStore::Instance();
   store.ResetForTests();
@@ -384,6 +451,7 @@ int main() {
     TestSqlitePersistenceReplayAndHealth();
     TestConfigurableRetentionAndMetrics();
     TestRecoveredTelemetryCountersDoNotDegradeHealth();
+    TestGpuUnavailableStorageNodeDoesNotDegradeHealth();
     TestStreamMetricsAndOpenMetrics();
     return 0;
   } catch (const std::exception& error) {

--- a/controller/src/telemetry/telemetry_node_health_builder.cpp
+++ b/controller/src/telemetry/telemetry_node_health_builder.cpp
@@ -19,7 +19,7 @@ nlohmann::json TelemetryNodeHealthBuilder::Build(
   } else if (
       frame.telemetry_dropped_frames > 0 ||
       !frame.last_publish_error.empty() ||
-      !frame.degraded_reason.empty()) {
+      health_policy_.HasActionableDegradedReason(frame)) {
     status = "degraded";
   }
   return nlohmann::json{


### PR DESCRIPTION
## Summary
- treat gpu:unavailable as actionable only for GPU-bound telemetry frames
- keep storage-only nodes without GPU runtime out of degraded plane counts
- add telemetry live-store coverage for gpuless storage and GPU-bound runtime cases

## Tests
- cmake --build build/telemetry-debug --target naim-telemetry-live-store-tests naim-controller naim-hostd-http-tests
- ./build/telemetry-debug/naim-telemetry-live-store-tests
- TMPDIR=/tmp/naim-hostd-http.vhLWeg ./build/telemetry-debug/naim-hostd-http-tests
- telemetry health CLI smoke