### PR TITLE
Fix hostd plane cleanup E2E blockers

### DIFF
--- a/controller/src/plane/plane_deletion_support_tests.cpp
+++ b/controller/src/plane/plane_deletion_support_tests.cpp
@@ -27,7 +27,7 @@ naim::DesiredState BuildDesiredState(
     const std::vector<std::string>& node_names = {}) {
   naim::DesiredState state;
   state.plane_name = plane_name;
-  state.plane_mode = naim::PlaneMode::Llm;
+  state.plane_mode = naim::PlaneMode::Compute;
   state.control_root = "/tmp/" + plane_name;
   for (const auto& node_name : node_names) {
     naim::NodeInventory node;
@@ -80,6 +80,9 @@ class TestPlaneStatePresentationSupport final
 
 class TestPlaneLifecycleSupport final : public naim::controller::PlaneLifecycleSupport {
  public:
+  explicit TestPlaneLifecycleSupport(bool build_delete_assignments = false)
+      : build_delete_assignments_(build_delete_assignments) {}
+
   void PrepareDesiredState(
       naim::ControllerStore&,
       naim::DesiredState*) const override {}
@@ -122,19 +125,41 @@ class TestPlaneLifecycleSupport final : public naim::controller::PlaneLifecycleS
   }
 
   std::vector<naim::HostAssignment> BuildDeleteAssignments(
-      const naim::DesiredState&,
-      int,
-      const std::string&) const override {
-    return {};
+      const naim::DesiredState& desired_state,
+      int desired_generation,
+      const std::string& artifacts_root) const override {
+    if (!build_delete_assignments_) {
+      return {};
+    }
+    std::vector<naim::HostAssignment> assignments;
+    for (const auto& node : desired_state.nodes) {
+      naim::HostAssignment assignment;
+      assignment.node_name = node.name;
+      assignment.plane_name = desired_state.plane_name;
+      assignment.desired_generation = desired_generation;
+      assignment.assignment_type = "delete-plane-state";
+      assignment.desired_state_json = "{}";
+      assignment.artifacts_root = artifacts_root;
+      assignment.status = naim::HostAssignmentStatus::Pending;
+      assignment.status_message = "test delete";
+      assignments.push_back(std::move(assignment));
+    }
+    return assignments;
   }
 
   std::string DefaultArtifactsRoot() const override { return "/tmp/artifacts"; }
+
+ private:
+  bool build_delete_assignments_ = false;
 };
 
-naim::controller::PlaneService BuildPlaneService(const std::string& db_path) {
+naim::controller::PlaneService BuildPlaneService(
+    const std::string& db_path,
+    bool build_delete_assignments = false) {
   auto state_presentation_support =
       std::make_shared<TestPlaneStatePresentationSupport>();
-  auto lifecycle_support = std::make_shared<TestPlaneLifecycleSupport>();
+  auto lifecycle_support =
+      std::make_shared<TestPlaneLifecycleSupport>(build_delete_assignments);
   return naim::controller::PlaneService(
       db_path,
       std::move(state_presentation_support),
@@ -384,6 +409,30 @@ int main() {
       Expect(
           assignment.front().status == naim::HostAssignmentStatus::Claimed,
           "unconverged assignment should remain claimed");
+    }
+
+    {
+      naim::ControllerStore store(db_path.string());
+      store.Initialize();
+      store.ReplaceDesiredState(BuildDesiredState("plane-delete-offline", {"hpc-delete"}), 11);
+
+      auto plane_service = BuildPlaneService(db_path.string(), true);
+      Expect(
+          plane_service.DeletePlane("plane-delete-offline") == 0,
+          "delete-plane should accept offline runtime cleanup");
+
+      const auto plane = store.LoadPlane("plane-delete-offline");
+      Expect(plane.has_value(), "plane-delete-offline should remain in registry during cleanup");
+      Expect(plane->state == "deleting", "plane-delete-offline should enter deleting state");
+      const auto assignments = store.LoadHostAssignments(
+          std::nullopt, std::nullopt, "plane-delete-offline");
+      Expect(assignments.size() == 1, "delete should enqueue cleanup for desired node");
+      Expect(
+          assignments.front().assignment_type == "delete-plane-state",
+          "delete should enqueue a delete-plane-state assignment");
+      Expect(
+          assignments.front().node_name == "hpc-delete",
+          "delete cleanup should target the desired runtime node");
     }
 
     fs::remove(db_path, error);

--- a/controller/src/plane/plane_service.cpp
+++ b/controller/src/plane/plane_service.cpp
@@ -306,28 +306,9 @@ int PlaneService::DeletePlane(const std::string& plane_name) const {
     throw std::runtime_error("failed to update plane state for '" + plane_name + "'");
   }
 
-  const auto all_observations = store.LoadHostObservations();
-  const auto registered_hosts = store.LoadRegisteredHosts();
   std::set<std::string> cleanup_nodes;
-  std::vector<std::string> skipped_nodes;
   for (const auto& node : desired_state->nodes) {
-    const bool has_observation = std::any_of(
-        all_observations.begin(),
-        all_observations.end(),
-        [&](const auto& observation) { return observation.node_name == node.name; });
-    const bool connected_host = std::any_of(
-        registered_hosts.begin(),
-        registered_hosts.end(),
-        [&](const auto& host) {
-          return host.node_name == node.name &&
-                 host.registration_state == "registered" &&
-                 host.session_state == "connected";
-        });
-    if (has_observation || connected_host) {
-      cleanup_nodes.insert(node.name);
-    } else {
-      skipped_nodes.push_back(node.name);
-    }
+    cleanup_nodes.insert(node.name);
   }
 
   store.ReplaceRolloutActions(plane_name, plane->generation, {});
@@ -359,7 +340,7 @@ int PlaneService::DeletePlane(const std::string& plane_name) const {
           {"superseded_assignments", superseded},
           {"desired_generation", plane->generation},
           {"cleanup_nodes", cleanup_nodes},
-          {"skipped_nodes", skipped_nodes},
+          {"skipped_nodes", nlohmann::json::array()},
       },
       plane_name);
   std::cout << "plane delete started: " << plane_name

--- a/hostd/src/state_apply/hostd_assignment_service.cpp
+++ b/hostd/src/state_apply/hostd_assignment_service.cpp
@@ -32,6 +32,15 @@ void WriteSelfUpdateMarker(
   }
 }
 
+template <typename Fn>
+void RunBestEffort(const std::string& label, Fn&& fn) {
+  try {
+    fn();
+  } catch (const std::exception& error) {
+    std::cerr << "hostd warning: " << label << " failed: " << error.what() << "\n";
+  }
+}
+
 }  // namespace
 
 HostdAssignmentService::HostdAssignmentService(
@@ -368,16 +377,18 @@ void HostdAssignmentService::ApplyNextAssignment(
                                  ? "hostd eviction-assignment-ops"
                                  : "hostd apply-assignment-ops")));
 
-    observation_service_.ReportObservedState(
-        *backend,
-        support_.BuildObservedStateSnapshot(
-            node_name,
-            storage_root,
-            state_root,
-            naim::HostObservationStatus::Applying,
-            applying_status_message,
-            assignment->id),
-        "hostd observed-state-update");
+    RunBestEffort("report applying observed state", [&]() {
+      observation_service_.ReportObservedState(
+          *backend,
+          support_.BuildObservedStateSnapshot(
+              node_name,
+              storage_root,
+              state_root,
+              naim::HostObservationStatus::Applying,
+              applying_status_message,
+              assignment->id),
+          "hostd observed-state-update");
+    });
 
     support_.ApplyDesiredNodeState(
         rebased_state,
@@ -402,22 +413,24 @@ void HostdAssignmentService::ApplyNextAssignment(
       throw std::runtime_error("eviction verification timed out; gpu resources were not released");
     }
 
-    observation_service_.ReportObservedState(
-        *backend,
-        support_.BuildObservedStateSnapshot(
-            node_name,
-            storage_root,
-            state_root,
-            naim::HostObservationStatus::Applied,
-            (is_drain_assignment ? "drained node for desired generation "
-                                 : (is_stop_assignment
-                                        ? "stopped plane state for desired generation "
-                                 : (is_eviction_assignment
-                                        ? "evicted rollout workers for desired generation "
-                                        : "applied desired generation "))) +
-                std::to_string(assignment->desired_generation) + assignment_context,
-            assignment->id),
-        "hostd observed-state-update");
+    RunBestEffort("report applied observed state", [&]() {
+      observation_service_.ReportObservedState(
+          *backend,
+          support_.BuildObservedStateSnapshot(
+              node_name,
+              storage_root,
+              state_root,
+              naim::HostObservationStatus::Applied,
+              (is_drain_assignment ? "drained node for desired generation "
+                                   : (is_stop_assignment
+                                          ? "stopped plane state for desired generation "
+                                   : (is_eviction_assignment
+                                          ? "evicted rollout workers for desired generation "
+                                          : "applied desired generation "))) +
+                  std::to_string(assignment->desired_generation) + assignment_context,
+              assignment->id),
+          "hostd observed-state-update");
+    });
 
     backend->TransitionClaimedHostAssignment(
         assignment->id,
@@ -432,45 +445,51 @@ void HostdAssignmentService::ApplyNextAssignment(
             assignment_context +
             " on attempt " + std::to_string(assignment->attempt_count) + "/" +
             std::to_string(assignment->max_attempts));
-    support_.AppendHostdEvent(
-        *backend,
-        "host-assignment",
-        "applied",
-        "applied assignment on node " + node_name,
-        nlohmann::json{
-            {"assignment_type", assignment->assignment_type},
-            {"desired_generation", assignment->desired_generation},
-            {"attempt_count", assignment->attempt_count},
-            {"max_attempts", assignment->max_attempts},
-        },
-        assignment->plane_name,
-        node_name,
-        "",
-        assignment->id,
-        std::nullopt,
-        "info");
+    RunBestEffort("append applied hostd event", [&]() {
+      support_.AppendHostdEvent(
+          *backend,
+          "host-assignment",
+          "applied",
+          "applied assignment on node " + node_name,
+          nlohmann::json{
+              {"assignment_type", assignment->assignment_type},
+              {"desired_generation", assignment->desired_generation},
+              {"attempt_count", assignment->attempt_count},
+              {"max_attempts", assignment->max_attempts},
+          },
+          assignment->plane_name,
+          node_name,
+          "",
+          assignment->id,
+          std::nullopt,
+          "info");
+    });
   } catch (const std::exception& error) {
     const std::string error_message = error.what();
-    support_.PublishAssignmentProgress(
-        backend.get(),
-        assignment->id,
-        support_.BuildAssignmentProgressPayload(
-            "failed",
-            "Assignment failed",
-            error_message,
-            100,
-            assignment->plane_name,
-            node_name));
-    observation_service_.ReportObservedState(
-        *backend,
-        support_.BuildObservedStateSnapshot(
-            node_name,
-            storage_root,
-            state_root,
-            naim::HostObservationStatus::Failed,
-            error_message,
-            assignment->id),
-        "hostd observed-state-update");
+    RunBestEffort("publish failed assignment progress", [&]() {
+      support_.PublishAssignmentProgress(
+          backend.get(),
+          assignment->id,
+          support_.BuildAssignmentProgressPayload(
+              "failed",
+              "Assignment failed",
+              error_message,
+              100,
+              assignment->plane_name,
+              node_name));
+    });
+    RunBestEffort("report failed observed state", [&]() {
+      observation_service_.ReportObservedState(
+          *backend,
+          support_.BuildObservedStateSnapshot(
+              node_name,
+              storage_root,
+              state_root,
+              naim::HostObservationStatus::Failed,
+              error_message,
+              assignment->id),
+          "hostd observed-state-update");
+    });
     if (assignment->attempt_count < assignment->max_attempts) {
       backend->TransitionClaimedHostAssignment(
           assignment->id,
@@ -486,23 +505,25 @@ void HostdAssignmentService::ApplyNextAssignment(
               std::to_string(assignment->max_attempts) + " exhausted: " +
               error_message + assignment_context);
     }
-    support_.AppendHostdEvent(
-        *backend,
-        "host-assignment",
-        "failed",
-        error_message,
-        nlohmann::json{
-            {"assignment_type", assignment->assignment_type},
-            {"desired_generation", assignment->desired_generation},
-            {"attempt_count", assignment->attempt_count},
-            {"max_attempts", assignment->max_attempts},
-        },
-        assignment->plane_name,
-        node_name,
-        "",
-        assignment->id,
-        std::nullopt,
-        "error");
+    RunBestEffort("append failed hostd event", [&]() {
+      support_.AppendHostdEvent(
+          *backend,
+          "host-assignment",
+          "failed",
+          error_message,
+          nlohmann::json{
+              {"assignment_type", assignment->assignment_type},
+              {"desired_generation", assignment->desired_generation},
+              {"attempt_count", assignment->attempt_count},
+              {"max_attempts", assignment->max_attempts},
+          },
+          assignment->plane_name,
+          node_name,
+          "",
+          assignment->id,
+          std::nullopt,
+          "error");
+    });
     throw;
   }
 }


### PR DESCRIPTION
## Summary
- keep delete-plane lifecycle in deleting state until cleanup assignments are queued for all desired runtime nodes
- make hostd assignment observation/progress/event reporting best-effort so session upload races do not leave assignments stuck claimed
- add regression coverage for delete-plane cleanup assignment creation

## Tests
- cmake -S . -B build/e2e-fix -G Ninja -DCMAKE_BUILD_TYPE=Debug -DNAIM_ENABLE_CUDA=OFF
- cmake --build build/e2e-fix --target naim-controller-plane-deletion-tests
- ./build/e2e-fix/naim-controller-plane-deletion-tests
- cmake --build build/e2e-fix --target naim-hostd
- cmake --build build/e2e-fix --target naim-controller