### PR TITLE
Fix empty WebUI post-deploy hook default

### DIFF
--- a/ui/operator-react/src/planeV2Form.jsx
+++ b/ui/operator-react/src/planeV2Form.jsx
@@ -857,7 +857,7 @@ export function buildNewPlaneFormState() {
     gpuFraction: 1.0,
     memoryCapMb: 24576,
     sharedDiskGb: 40,
-    postDeployScript: "bundle://deploy/scripts/post-deploy.sh",
+    postDeployScript: "",
   });
 }
 

--- a/ui/operator-react/src/skillsFactory.test.js
+++ b/ui/operator-react/src/skillsFactory.test.js
@@ -128,6 +128,14 @@ describe("planeV2Form SkillsFactory mapping", () => {
     expect(desiredState.network.server_name).toBe("maglev-web.local");
   });
 
+  it("does not emit a post-deploy hook unless one is configured", () => {
+    const form = buildNewPlaneFormState();
+    form.planeName = "no-hook-plane";
+
+    const desiredState = buildDesiredStateV2FromForm(form);
+    expect(desiredState.hooks).toBeUndefined();
+  });
+
   it("round-trips factory skill ids through desired state v2", () => {
     const form = buildNewPlaneFormState();
     form.planeName = "skills-plane";


### PR DESCRIPTION
Fixes the WebUI plane form default that emitted a bundle post-deploy hook even when the source desired-state did not configure one. This prevents planes created through the form from failing runtime apply on a missing deploy/scripts/post-deploy.sh artifact.\n\nTests:\n- npm test -- --run src/skillsFactory.test.js\n- npm run build