### PR TITLE
Ensure hostd assignment transitions have sessions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1312,6 +1312,16 @@ target_link_libraries(naim-hostd-reporting-support-tests PRIVATE naim-common)
 naim_enable_strict_warnings(naim-hostd-reporting-support-tests)
 
 add_executable(
+  naim-http-hostd-backend-tests
+  hostd/src/backend/http_hostd_backend.cpp
+  hostd/src/backend/http_hostd_backend_tests.cpp
+)
+target_include_directories(
+  naim-http-hostd-backend-tests PRIVATE common/include hostd/include)
+target_link_libraries(naim-http-hostd-backend-tests PRIVATE naim-common)
+naim_enable_strict_warnings(naim-http-hostd-backend-tests)
+
+add_executable(
   naim-hostd-repo-root-support-tests
   hostd/src/app/hostd_repo_root_support.cpp
   hostd/src/app/hostd_repo_root_support_tests.cpp

--- a/hostd/src/backend/http_hostd_backend.cpp
+++ b/hostd/src/backend/http_hostd_backend.cpp
@@ -60,6 +60,7 @@ bool HttpHostdBackend::TransitionClaimedHostAssignment(
     const int assignment_id,
     const naim::HostAssignmentStatus status,
     const std::string& status_message) {
+  EnsureSession(configured_node_name_, "transitioning assignment status");
   if (status == naim::HostAssignmentStatus::Applied) {
     SendEncryptedControllerJsonRequest(
         "/api/v1/hostd/assignments/" + std::to_string(assignment_id) + "/applied",

--- a/hostd/src/backend/http_hostd_backend_tests.cpp
+++ b/hostd/src/backend/http_hostd_backend_tests.cpp
@@ -1,0 +1,118 @@
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "backend/http_hostd_backend.h"
+#include "naim/security/crypto_utils.h"
+
+namespace {
+
+void Expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+class FakeHttpHostdBackendSupport final : public naim::hostd::IHttpHostdBackendSupport {
+ public:
+  nlohmann::json SendControllerJsonRequest(
+      const std::string&,
+      const std::string& method,
+      const std::string& path,
+      const nlohmann::json&,
+      const std::map<std::string, std::string>& headers = {}) const override {
+    requests.push_back(Request{method, path, headers});
+    if (path == "/api/v1/hostd/session/open") {
+      return nlohmann::json{
+          {"service", "naim-controller"},
+          {"node_name", "hpc1"},
+          {"session_state", "connected"},
+          {"session_token", session_token},
+          {"controller_sequence", 0},
+      };
+    }
+    return nlohmann::json{{"status", "ok"}};
+  }
+
+  naim::HostAssignment ParseAssignmentPayload(const nlohmann::json&) const override {
+    return {};
+  }
+
+  nlohmann::json BuildHostObservationPayload(const naim::HostObservation&) const override {
+    return nlohmann::json::object();
+  }
+
+  nlohmann::json BuildHostTelemetryPayload(const naim::HostTelemetryFrame&) const override {
+    return nlohmann::json::object();
+  }
+
+  nlohmann::json BuildDiskRuntimeStatePayload(const naim::DiskRuntimeState&) const override {
+    return nlohmann::json::object();
+  }
+
+  naim::DiskRuntimeState ParseDiskRuntimeStatePayload(const nlohmann::json&) const override {
+    return {};
+  }
+
+  std::string Trim(const std::string& value) const override {
+    return value;
+  }
+
+  struct Request {
+    std::string method;
+    std::string path;
+    std::map<std::string, std::string> headers;
+  };
+
+  std::string session_token = naim::RandomTokenBase64(32);
+  mutable std::vector<Request> requests;
+};
+
+void TestTransitionOpensSessionWhenNeeded() {
+  const auto keypair = naim::GenerateSigningKeypair();
+  FakeHttpHostdBackendSupport support;
+  naim::hostd::HttpHostdBackend backend(
+      "http://controller",
+      keypair.private_key_base64,
+      "",
+      "",
+      "hpc1",
+      "/storage",
+      support);
+
+  Expect(
+      backend.TransitionClaimedHostAssignment(
+          42,
+          naim::HostAssignmentStatus::Applied,
+          "applied"),
+      "transition should succeed");
+
+  Expect(support.requests.size() == 3, "transition should open session, heartbeat, and post status");
+  Expect(
+      support.requests[0].path == "/api/v1/hostd/session/open",
+      "transition should open a host session before encrypted status update");
+  Expect(
+      support.requests[1].path == "/api/v1/hostd/session/heartbeat",
+      "transition should heartbeat the new host session");
+  Expect(
+      support.requests[2].path == "/api/v1/hostd/assignments/42/applied",
+      "transition should post the assignment status");
+  Expect(
+      support.requests[2].headers.count("X-Naim-Host-Session") == 1,
+      "assignment transition should include host session header");
+}
+
+}  // namespace
+
+int main() {
+  try {
+    TestTransitionOpensSessionWhenNeeded();
+    std::cout << "ok: http-hostd-backend-transition-opens-session\n";
+    return 0;
+  } catch (const std::exception& error) {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+}


### PR DESCRIPTION
Fixes HTTP hostd assignment status transitions so they open or refresh the host session before posting applied/failed. Without this, a transient session reset during progress or observation reporting can leave apply assignments stuck in claimed with 'missing host session token'.\n\nTests:\n- cmake --build build/e2e-fix --target naim-http-hostd-backend-tests\n- ./build/e2e-fix/naim-http-hostd-backend-tests\n- cmake --build build/e2e-fix --target naim-hostd