### PR TITLE
Fix Maglev interaction proxy routing

### DIFF
--- a/common/src/state/desired_state_sqlite_codec.cpp
+++ b/common/src/state/desired_state_sqlite_codec.cpp
@@ -443,6 +443,9 @@ DiskKind DesiredStateSqliteCodec::ParseDiskKind(const std::string& value) {
   if (value == "interaction-private") {
     return DiskKind::InteractionPrivate;
   }
+  if (value == "voice-module-private") {
+    return DiskKind::VoiceModulePrivate;
+  }
   throw std::runtime_error("unknown disk kind '" + value + "'");
 }
 
@@ -467,6 +470,9 @@ InstanceRole DesiredStateSqliteCodec::ParseInstanceRole(const std::string& value
   }
   if (value == "interaction") {
     return InstanceRole::Interaction;
+  }
+  if (value == "voice-module") {
+    return InstanceRole::VoiceModule;
   }
   throw std::runtime_error("unknown instance role '" + value + "'");
 }

--- a/controller/src/interaction/interaction_service.cpp
+++ b/controller/src/interaction/interaction_service.cpp
@@ -1620,6 +1620,14 @@ StreamedInteractionSegmentResult InteractionStreamSegmentExecutor::Execute(
     return fallback_result;
   };
 
+  if (resolution.target.has_value() && resolution.target->route_via_hostd_proxy) {
+    if (const auto fallback = run_non_stream_fallback();
+        fallback.has_value()) {
+      return *fallback;
+    }
+    throw std::runtime_error("hostd runtime proxy interaction request failed");
+  }
+
   try {
     const auto prompt_build_started_at = std::chrono::steady_clock::now();
     const std::string upstream_body = build_interaction_upstream_body_(


### PR DESCRIPTION
## Summary
- route streamed interaction requests for hostd-proxy targets through non-stream hostd execution instead of controller-local loopback
- allow current voice module disk and instance kinds in the SQLite desired-state codec

## Verification
- cmake --build build/e2e-fix --target naim-controller naim-interaction-runtime-server-tests -j 8
- ./build/e2e-fix/naim-interaction-runtime-server-tests
- cmake --build build/e2e-fix --target naim-interaction-stream-http-request-preparation-service-tests naim-interaction-http-support-tests -j 8
- ./build/e2e-fix/naim-interaction-stream-http-request-preparation-service-tests
- ./build/e2e-fix/naim-interaction-http-support-tests