### PR TITLE
Fix runtime proxy retries and dev runtime rebuilds

### DIFF
--- a/controller/src/interaction/interaction_http_support.cpp
+++ b/controller/src/interaction/interaction_http_support.cpp
@@ -243,7 +243,7 @@ HttpResponse InteractionHttpSupport::SendHostdRuntimeProxyRequest(
   assignment.node_name = node_name;
   assignment.plane_name = proxy_plane_name;
   assignment.desired_generation = 0;
-  assignment.max_attempts = 1;
+  assignment.max_attempts = 3;
   assignment.assignment_type = "runtime-http-proxy";
   assignment.desired_state_json =
       json{

--- a/hostd/include/app/hostd_compose_runtime_support.h
+++ b/hostd/include/app/hostd_compose_runtime_support.h
@@ -41,7 +41,8 @@ class HostdComposeRuntimeSupport final {
       const std::string& image) const;
   void EnsureLocalRuntimeBinary(
       const std::filesystem::path& repo_root,
-      const std::string& image) const;
+      const std::string& image,
+      bool force_rebuild = false) const;
   void BuildNaimRuntimeImage(
       const std::filesystem::path& repo_root,
       const std::string& image) const;

--- a/hostd/src/app/hostd_compose_runtime_support.cpp
+++ b/hostd/src/app/hostd_compose_runtime_support.cpp
@@ -143,8 +143,9 @@ bool HostdComposeRuntimeSupport::TurboQuantRuntimeBinaryExists(
 
 void HostdComposeRuntimeSupport::EnsureLocalRuntimeBinary(
     const std::filesystem::path& repo_root,
-    const std::string& image) const {
-  if (LocalRuntimeBinaryExists(repo_root, image)) {
+    const std::string& image,
+    const bool force_rebuild) const {
+  if (!force_rebuild && LocalRuntimeBinaryExists(repo_root, image)) {
     return;
   }
 
@@ -218,7 +219,7 @@ void HostdComposeRuntimeSupport::BuildNaimRuntimeImage(
     if (!DockerImageExists("naim/base-runtime:dev")) {
       build_base();
     }
-    EnsureLocalRuntimeBinary(repo_root, image);
+    EnsureLocalRuntimeBinary(repo_root, image, true);
     build_runtime("runtime/infer/Dockerfile", image);
     return;
   }
@@ -226,7 +227,7 @@ void HostdComposeRuntimeSupport::BuildNaimRuntimeImage(
     if (!DockerImageExists("naim/base-runtime:dev")) {
       build_base();
     }
-    EnsureLocalRuntimeBinary(repo_root, image);
+    EnsureLocalRuntimeBinary(repo_root, image, true);
     build_runtime("runtime/worker/Dockerfile", image);
     return;
   }
@@ -234,7 +235,7 @@ void HostdComposeRuntimeSupport::BuildNaimRuntimeImage(
     if (!DockerImageExists("naim/base-runtime:dev")) {
       build_base();
     }
-    EnsureLocalRuntimeBinary(repo_root, image);
+    EnsureLocalRuntimeBinary(repo_root, image, true);
     build_runtime("runtime/skills/Dockerfile", image);
     return;
   }
@@ -242,7 +243,7 @@ void HostdComposeRuntimeSupport::BuildNaimRuntimeImage(
     if (!DockerImageExists("naim/base-runtime:dev")) {
       build_base();
     }
-    EnsureLocalRuntimeBinary(repo_root, image);
+    EnsureLocalRuntimeBinary(repo_root, image, true);
     build_runtime("runtime/browsing/Dockerfile", image);
     return;
   }
@@ -250,7 +251,7 @@ void HostdComposeRuntimeSupport::BuildNaimRuntimeImage(
     if (!DockerImageExists("naim/base-runtime:dev")) {
       build_base();
     }
-    EnsureLocalRuntimeBinary(repo_root, image);
+    EnsureLocalRuntimeBinary(repo_root, image, true);
     build_runtime("runtime/interaction/Dockerfile", image);
     return;
   }
@@ -270,13 +271,9 @@ void HostdComposeRuntimeSupport::BuildNaimRuntimeImage(
 
 void HostdComposeRuntimeSupport::EnsureRuntimeImageAvailable(const std::string& image) const {
   static std::set<std::string> ensured_images;
-  if (image.empty() || ensured_images.count(image) > 0 || DockerImageExists(image)) {
-    if (!image.empty()) {
-      ensured_images.insert(image);
-    }
+  if (image.empty()) {
     return;
   }
-
   if (image.rfind("naim/", 0) == 0 && image.ends_with(":dev")) {
     if (const auto repo_root = repo_root_support_.DetectNaimRepoRoot(); repo_root.has_value()) {
       BuildNaimRuntimeImage(*repo_root, image);
@@ -285,6 +282,11 @@ void HostdComposeRuntimeSupport::EnsureRuntimeImageAvailable(const std::string& 
         return;
       }
     }
+  }
+
+  if (ensured_images.count(image) > 0 || DockerImageExists(image)) {
+    ensured_images.insert(image);
+    return;
   }
 
   if (!command_support_.RunCommandOk(


### PR DESCRIPTION
## Summary
- retry hostd runtime proxy assignments up to 3 attempts for transient host-session failures
- rebuild local binaries for naim/*:dev runtime images before docker image build
- avoid treating existing dev images as already valid when source changed

## Verification
- cmake --build build/e2e-fix --target naim-hostd naim-controller naim-interaction-http-support-tests -j 8
- ./build/e2e-fix/naim-interaction-http-support-tests