### PR TITLE
Honor wrapped stream mode in interaction runtime

### DIFF
--- a/runtime/interaction/src/interaction_runtime_server.cpp
+++ b/runtime/interaction/src/interaction_runtime_server.cpp
@@ -59,10 +59,7 @@ bool RequestWantsStream(const HttpRequest& request) {
   try {
     const auto wrapped_request =
         naim::controller::InteractionRuntimeRequestCodec{}.Deserialize(request.body);
-    if (wrapped_request.force_stream) {
-      return true;
-    }
-    return wrapped_request.payload.value("stream", false);
+    return wrapped_request.force_stream;
   } catch (const std::exception&) {
   }
   try {


### PR DESCRIPTION
## Summary
- make wrapped interaction-runtime requests use wrapper force_stream as the authoritative stream mode
- allows controller SSE fallback over hostd proxy to execute non-stream upstream requests even when original public payload had stream=true

## Verification
- cmake --build build/e2e-fix --target naim-interaction-runtime-server-tests -j 8
- ./build/e2e-fix/naim-interaction-runtime-server-tests