### PR TITLE
Fix runtime proxy chunked SSE bodies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1101,6 +1101,18 @@ target_link_libraries(naim-hostd-install-layout-support-tests PRIVATE naim-commo
 naim_enable_strict_warnings(naim-hostd-install-layout-support-tests)
 
 add_executable(
+  naim-hostd-runtime-http-proxy-tests
+  hostd/src/app/hostd_runtime_http_proxy.cpp
+  hostd/src/app/hostd_runtime_http_proxy_tests.cpp
+)
+target_include_directories(
+  naim-hostd-runtime-http-proxy-tests PRIVATE common/include hostd/include)
+target_link_libraries(naim-hostd-runtime-http-proxy-tests PRIVATE naim-common)
+target_compile_definitions(
+  naim-hostd-runtime-http-proxy-tests PRIVATE NAIM_HOSTD_RUNTIME_HTTP_PROXY_TESTING)
+naim_enable_strict_warnings(naim-hostd-runtime-http-proxy-tests)
+
+add_executable(
   naim-hostd-post-deploy-support-tests
   hostd/src/app/hostd_command_support.cpp
   hostd/src/app/hostd_local_state_path_support.cpp

--- a/controller/src/interaction/interaction_http_support.cpp
+++ b/controller/src/interaction/interaction_http_support.cpp
@@ -1,6 +1,10 @@
 #include "interaction/interaction_http_support.h"
 
 #include <chrono>
+#include <algorithm>
+#include <cctype>
+#include <limits>
+#include <stdexcept>
 #include <thread>
 
 #include "app/controller_composition_support.h"
@@ -14,6 +18,103 @@ namespace {
 
 bool IsLoopbackHost(const std::string& host) {
   return host == "127.0.0.1" || host == "localhost" || host == "::1";
+}
+
+std::string TrimAscii(std::string value) {
+  const auto begin = std::find_if(
+      value.begin(),
+      value.end(),
+      [](unsigned char ch) { return std::isspace(ch) == 0; });
+  const auto end = std::find_if(
+      value.rbegin(),
+      value.rend(),
+      [](unsigned char ch) { return std::isspace(ch) == 0; }).base();
+  if (begin >= end) {
+    return {};
+  }
+  return std::string(begin, end);
+}
+
+std::string LowercaseAscii(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return value;
+}
+
+bool HeaderValueContainsChunkedTransfer(const std::string& value) {
+  return LowercaseAscii(value).find("chunked") != std::string::npos;
+}
+
+std::map<std::string, std::string>::iterator FindHeaderCaseInsensitive(
+    std::map<std::string, std::string>& headers,
+    const std::string& key) {
+  const std::string lowered_key = LowercaseAscii(key);
+  return std::find_if(
+      headers.begin(),
+      headers.end(),
+      [&](const auto& item) {
+        return LowercaseAscii(item.first) == lowered_key;
+      });
+}
+
+void EraseHeaderCaseInsensitive(
+    std::map<std::string, std::string>& headers,
+    const std::string& key) {
+  const auto it = FindHeaderCaseInsensitive(headers, key);
+  if (it != headers.end()) {
+    headers.erase(it);
+  }
+}
+
+std::string DecodeCompleteChunkedBody(const std::string& encoded) {
+  std::string decoded;
+  std::size_t offset = 0;
+  while (true) {
+    const std::size_t line_end = encoded.find("\r\n", offset);
+    if (line_end == std::string::npos) {
+      throw std::runtime_error("incomplete HTTP chunk size");
+    }
+    std::string chunk_size_text = encoded.substr(offset, line_end - offset);
+    const std::size_t extensions = chunk_size_text.find(';');
+    if (extensions != std::string::npos) {
+      chunk_size_text = chunk_size_text.substr(0, extensions);
+    }
+    chunk_size_text = TrimAscii(chunk_size_text);
+    if (chunk_size_text.empty()) {
+      throw std::runtime_error("empty HTTP chunk size");
+    }
+
+    std::size_t parsed = 0;
+    std::size_t chunk_size = 0;
+    try {
+      const unsigned long long value = std::stoull(chunk_size_text, &parsed, 16);
+      if (parsed != chunk_size_text.size() ||
+          value > std::numeric_limits<std::size_t>::max()) {
+        throw std::runtime_error("invalid");
+      }
+      chunk_size = static_cast<std::size_t>(value);
+    } catch (const std::exception&) {
+      throw std::runtime_error(
+          "invalid HTTP chunk size '" + chunk_size_text + "'");
+    }
+
+    const std::size_t chunk_begin = line_end + 2;
+    if (chunk_size == 0) {
+      if (encoded.size() < chunk_begin + 2) {
+        throw std::runtime_error("incomplete final HTTP chunk");
+      }
+      return decoded;
+    }
+    if (encoded.size() < chunk_begin + chunk_size + 2) {
+      throw std::runtime_error("incomplete HTTP chunk body");
+    }
+    if (encoded.compare(chunk_begin + chunk_size, 2, "\r\n") != 0) {
+      throw std::runtime_error("invalid HTTP chunk terminator");
+    }
+    decoded.append(encoded, chunk_begin, chunk_size);
+    offset = chunk_begin + chunk_size + 2;
+  }
 }
 
 json BuildHeaderArray(
@@ -59,6 +160,14 @@ HttpResponse ParseProxyResponsePayload(const json& progress) {
   }
   if (!response.content_type.empty()) {
     response.headers["Content-Type"] = response.content_type;
+  }
+  const auto transfer_encoding =
+      FindHeaderCaseInsensitive(response.headers, "transfer-encoding");
+  if (transfer_encoding != response.headers.end() &&
+      HeaderValueContainsChunkedTransfer(transfer_encoding->second)) {
+    response.body = DecodeCompleteChunkedBody(response.body);
+    EraseHeaderCaseInsensitive(response.headers, "transfer-encoding");
+    EraseHeaderCaseInsensitive(response.headers, "content-length");
   }
   return response;
 }

--- a/hostd/include/app/hostd_runtime_http_proxy.h
+++ b/hostd/include/app/hostd_runtime_http_proxy.h
@@ -46,6 +46,11 @@ class HostdRuntimeHttpProxy final {
       const std::string& method,
       const std::string& path);
   static std::string PolicyLabel(HostdRuntimeProxyPolicy policy);
+#ifdef NAIM_HOSTD_RUNTIME_HTTP_PROXY_TESTING
+ public:
+#endif
+  static bool HeaderValueContainsChunkedTransfer(const std::string& value);
+  static std::string DecodeCompleteChunkedBody(const std::string& encoded);
   static HostdRuntimeHttpResponse ParseHttpResponse(const std::string& response_text);
 };
 

--- a/hostd/src/app/hostd_runtime_http_proxy.cpp
+++ b/hostd/src/app/hostd_runtime_http_proxy.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
@@ -235,6 +236,62 @@ std::string HostdRuntimeHttpProxy::PolicyLabel(HostdRuntimeProxyPolicy policy) {
   return "runtime-direct-http";
 }
 
+bool HostdRuntimeHttpProxy::HeaderValueContainsChunkedTransfer(
+    const std::string& value) {
+  return LowercaseAscii(value).find("chunked") != std::string::npos;
+}
+
+std::string HostdRuntimeHttpProxy::DecodeCompleteChunkedBody(
+    const std::string& encoded) {
+  std::string decoded;
+  std::size_t offset = 0;
+  while (true) {
+    const std::size_t line_end = encoded.find("\r\n", offset);
+    if (line_end == std::string::npos) {
+      throw std::runtime_error("incomplete HTTP chunk size");
+    }
+    std::string chunk_size_text = encoded.substr(offset, line_end - offset);
+    const std::size_t extensions = chunk_size_text.find(';');
+    if (extensions != std::string::npos) {
+      chunk_size_text = chunk_size_text.substr(0, extensions);
+    }
+    chunk_size_text = TrimAscii(chunk_size_text);
+    if (chunk_size_text.empty()) {
+      throw std::runtime_error("empty HTTP chunk size");
+    }
+
+    std::size_t parsed = 0;
+    std::size_t chunk_size = 0;
+    try {
+      const unsigned long long value = std::stoull(chunk_size_text, &parsed, 16);
+      if (parsed != chunk_size_text.size() ||
+          value > std::numeric_limits<std::size_t>::max()) {
+        throw std::runtime_error("invalid");
+      }
+      chunk_size = static_cast<std::size_t>(value);
+    } catch (const std::exception&) {
+      throw std::runtime_error(
+          "invalid HTTP chunk size '" + chunk_size_text + "'");
+    }
+
+    const std::size_t chunk_begin = line_end + 2;
+    if (chunk_size == 0) {
+      if (encoded.size() < chunk_begin + 2) {
+        throw std::runtime_error("incomplete final HTTP chunk");
+      }
+      return decoded;
+    }
+    if (encoded.size() < chunk_begin + chunk_size + 2) {
+      throw std::runtime_error("incomplete HTTP chunk body");
+    }
+    if (encoded.compare(chunk_begin + chunk_size, 2, "\r\n") != 0) {
+      throw std::runtime_error("invalid HTTP chunk terminator");
+    }
+    decoded.append(encoded, chunk_begin, chunk_size);
+    offset = chunk_begin + chunk_size + 2;
+  }
+}
+
 HostdRuntimeHttpResponse HostdRuntimeHttpProxy::ParseHttpResponse(
     const std::string& response_text) {
   HostdRuntimeHttpResponse response;
@@ -270,6 +327,13 @@ HostdRuntimeHttpResponse HostdRuntimeHttpProxy::ParseHttpResponse(
       break;
     }
     offset = next + 2;
+  }
+  const auto transfer_encoding = response.headers.find("transfer-encoding");
+  if (transfer_encoding != response.headers.end() &&
+      HeaderValueContainsChunkedTransfer(transfer_encoding->second)) {
+    response.body = DecodeCompleteChunkedBody(response.body);
+    response.headers.erase("transfer-encoding");
+    response.headers.erase("content-length");
   }
   return response;
 }

--- a/hostd/src/app/hostd_runtime_http_proxy_tests.cpp
+++ b/hostd/src/app/hostd_runtime_http_proxy_tests.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include "app/hostd_runtime_http_proxy.h"
+
+namespace {
+
+void Expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+std::string Chunk(const std::string& data) {
+  std::ostringstream stream;
+  stream << std::hex << data.size() << "\r\n" << data << "\r\n";
+  return stream.str();
+}
+
+void TestChunkedRuntimeResponseIsDecoded() {
+  const std::string first_frame =
+      "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n";
+  const std::string done_frame = "data: [DONE]\n\n";
+  const std::string response_text =
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: text/event-stream\r\n"
+      "Transfer-Encoding: chunked\r\n"
+      "Connection: close\r\n"
+      "\r\n"
+      + Chunk(first_frame) + Chunk(done_frame) + "0\r\n\r\n";
+
+  const auto response =
+      naim::hostd::HostdRuntimeHttpProxy::ParseHttpResponse(response_text);
+
+  Expect(response.status_code == 200, "status should be preserved");
+  Expect(
+      response.content_type == "text/event-stream",
+      "content type should be preserved");
+  Expect(
+      response.body == first_frame + done_frame,
+      "chunk framing should be removed from SSE body");
+  Expect(
+      response.headers.find("transfer-encoding") == response.headers.end(),
+      "decoded proxy response should not retain transfer-encoding");
+}
+
+}  // namespace
+
+int main() {
+  TestChunkedRuntimeResponseIsDecoded();
+  std::cout << "hostd runtime HTTP proxy tests passed\n";
+  return 0;
+}


### PR DESCRIPTION
## Summary
- decode chunked runtime proxy responses in hostd before persisting assignment progress
- defensively decode chunked proxy payloads in controller when reading hostd progress
- add a hostd runtime HTTP proxy test for chunked SSE bodies

## Verification
- cmake --build build/macos/arm64 --target naim-hostd-runtime-http-proxy-tests naim-controller -j 8
- ./build/macos/arm64/naim-hostd-runtime-http-proxy-tests
- git diff --check
- bash scripts/ci/pr-lightweight-checks.sh