### PR TITLE
Fix stale compose cleanup on plane stop

### DIFF
--- a/hostd/include/app/hostd_desired_state_apply_plan_support.h
+++ b/hostd/include/app/hostd_desired_state_apply_plan_support.h
@@ -44,6 +44,12 @@ class HostdDesiredStateApplyPlanSupport final {
   std::size_t ExpectedRuntimeStatusCountForComposePlan(
       const naim::NodeComposePlan& compose_plan) const;
 
+  bool StopAndRemoveComposeArtifactIfPresent(
+      const std::string& artifacts_root,
+      const std::string& plane_name,
+      const std::string& node_name,
+      ComposeMode compose_mode) const;
+
   static bool IsDesiredNodeStateEmpty(const naim::DesiredState& state);
 
  private:

--- a/hostd/src/app/hostd_desired_state_apply_plan_support.cpp
+++ b/hostd/src/app/hostd_desired_state_apply_plan_support.cpp
@@ -242,6 +242,26 @@ std::size_t HostdDesiredStateApplyPlanSupport::ExpectedRuntimeStatusCountForComp
   return count;
 }
 
+bool HostdDesiredStateApplyPlanSupport::StopAndRemoveComposeArtifactIfPresent(
+    const std::string& artifacts_root,
+    const std::string& plane_name,
+    const std::string& node_name,
+    ComposeMode compose_mode) const {
+  const std::filesystem::path compose_file_path =
+      std::filesystem::path(artifacts_root) / plane_name / node_name /
+      "docker-compose.yml";
+  if (!std::filesystem::exists(compose_file_path)) {
+    return false;
+  }
+  compose_runtime_support_.RunComposeCommand(
+      compose_file_path.string(),
+      "down",
+      compose_mode);
+  file_support_.RemoveFileIfExists(compose_file_path.string());
+  compose_runtime_support_.RemoveComposeMeshNetworkIfUnused(plane_name, compose_mode);
+  return true;
+}
+
 bool HostdDesiredStateApplyPlanSupport::IsDesiredNodeStateEmpty(
     const naim::DesiredState& state) {
   return state.disks.empty() && state.instances.empty();

--- a/hostd/src/app/hostd_desired_state_apply_support.cpp
+++ b/hostd/src/app/hostd_desired_state_apply_support.cpp
@@ -724,6 +724,20 @@ void HostdDesiredStateApplySupport::ApplyDesiredNodeState(
         node_name,
         backend,
         maybe_publish_progress);
+    if (desired_node_state.instances.empty()) {
+      maybe_publish_progress(
+          "stopping-runtime",
+          "Stopping runtime",
+          "Ensuring stale compose runtime is stopped on the node.",
+          92,
+          plane_name,
+          node_name);
+      apply_plan_support_.StopAndRemoveComposeArtifactIfPresent(
+          artifacts_root,
+          plane_name,
+          node_name,
+          compose_mode);
+    }
     if (HostdDesiredStateApplyPlanSupport::IsDesiredNodeStateEmpty(desired_node_state)) {
       local_state_repository_.RemoveLocalAppliedPlaneState(
           state_root,
@@ -780,6 +794,20 @@ void HostdDesiredStateApplySupport::ApplyDesiredNodeState(
       compose_mode,
       backend,
       maybe_publish_progress);
+  if (desired_node_state.instances.empty()) {
+    maybe_publish_progress(
+        "stopping-runtime",
+        "Stopping runtime",
+        "Ensuring stale compose runtime is stopped on the node.",
+        92,
+        plane_name,
+        node_name);
+    apply_plan_support_.StopAndRemoveComposeArtifactIfPresent(
+        artifacts_root,
+        plane_name,
+        node_name,
+        compose_mode);
+  }
   disk_runtime_support_.PersistDiskRuntimeStateForRemovedDisks(
       backend,
       current_local_state,

--- a/hostd/src/app/hostd_desired_state_apply_support_tests.cpp
+++ b/hostd/src/app/hostd_desired_state_apply_support_tests.cpp
@@ -1,4 +1,6 @@
+#include <algorithm>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -164,6 +166,62 @@ int main() {
     Expect(
         !phases.empty() && phases.back() == "completed",
         "ApplyDesiredNodeState should publish completed progress");
+
+    naim::DesiredState stopped_node_state = node_state;
+    stopped_node_state.instances.clear();
+    local_state_repository.RemoveLocalAppliedPlaneState(
+        state_root,
+        node_name,
+        plane_name);
+    local_state_repository.RewriteAggregateLocalState(state_root, node_name);
+    local_state_repository.RewriteAggregateLocalGeneration(state_root, node_name);
+    fs::create_directories(fs::path(artifacts_root) / plane_name / node_name);
+    const fs::path stale_compose_path =
+        fs::path(artifacts_root) / plane_name / node_name / "docker-compose.yml";
+    {
+      std::ofstream stale_compose(stale_compose_path, std::ios::binary | std::ios::trunc);
+      stale_compose << "name: stale\nservices: {}\n";
+    }
+    std::vector<std::string> stop_phases;
+    support.ApplyDesiredNodeState(
+        stopped_node_state,
+        artifacts_root,
+        storage_root,
+        runtime_root,
+        state_root,
+        naim::hostd::ComposeMode::Skip,
+        "test-stop-support",
+        8,
+        43,
+        nullptr,
+        [&](const std::string& phase,
+            const std::string&,
+            const std::string&,
+            int,
+            const std::string&,
+            const std::string&) {
+          stop_phases.push_back(phase);
+        });
+    Expect(
+        !fs::exists(stale_compose_path),
+        "stopped desired state should remove stale compose artifact even when local state is empty");
+    const auto stopped_persisted_state =
+        local_state_repository.LoadLocalAppliedState(state_root, node_name, plane_name);
+    Expect(
+        stopped_persisted_state.has_value(),
+        "stopped state should persist disk ownership without runtime instances");
+    Expect(
+        stopped_persisted_state->instances.empty(),
+        "stopped state should persist without runtime instances");
+    const auto stopped_generation =
+        local_state_repository.LoadLocalAppliedGeneration(state_root, node_name, plane_name);
+    Expect(
+        stopped_generation.has_value() && *stopped_generation == 8,
+        "stopped state should persist the applied generation");
+    Expect(
+        std::find(stop_phases.begin(), stop_phases.end(), "stopping-runtime") !=
+            stop_phases.end(),
+        "stopped empty state should publish stale runtime cleanup progress");
 
     fs::remove_all(temp_root, cleanup_error);
 


### PR DESCRIPTION
## Summary
- force hostd to run compose down/remove compose artifact when desired node state has no runtime instances
- covers stale local-state cases where the plane is marked stopped but compose containers are still running
- add regression coverage for stopped state with stale compose artifact and empty local state

## Verification
- cmake --build build/macos/arm64 --target naim-hostd-desired-state-apply-support-tests -j 8
- ./build/macos/arm64/naim-hostd-desired-state-apply-support-tests
- git diff --check
- bash scripts/ci/pr-lightweight-checks.sh