### PR TITLE
Fix proxy retries and stream fallback mode

### DIFF
--- a/controller/src/browsing/plane_browsing_service.cpp
+++ b/controller/src/browsing/plane_browsing_service.cpp
@@ -137,7 +137,7 @@ HttpResponse SendPlaneWebGatewayRequest(
   assignment.node_name = target.node_name;
   assignment.plane_name = proxy_plane_name;
   assignment.desired_generation = 0;
-  assignment.max_attempts = 1;
+  assignment.max_attempts = 3;
   assignment.assignment_type = "runtime-http-proxy";
   assignment.desired_state_json =
       json{

--- a/controller/src/interaction/interaction_payload_builder.cpp
+++ b/controller/src/interaction/interaction_payload_builder.cpp
@@ -194,9 +194,7 @@ std::string BuildInteractionUpstreamBodyPayload(
       &payload,
       model_identity_builder.BuildStatusPreferred(resolution),
       naim::runtime::ModelAdapterPolicy{thinking_enabled});
-  if (force_stream) {
-    payload["stream"] = true;
-  }
+  payload["stream"] = force_stream;
   payload["max_tokens"] = policy.max_tokens;
   if (!payload.contains("temperature")) {
     payload["temperature"] =

--- a/controller/src/knowledge/knowledge_vault_service.cpp
+++ b/controller/src/knowledge/knowledge_vault_service.cpp
@@ -491,7 +491,7 @@ HttpResponse KnowledgeVaultService::SendHostdRuntimeProxy(
   assignment.node_name = record.node_name;
   assignment.plane_name = proxy_plane_name;
   assignment.desired_generation = 0;
-  assignment.max_attempts = 1;
+  assignment.max_attempts = 3;
   assignment.assignment_type = "runtime-http-proxy";
   assignment.desired_state_json =
       nlohmann::json{

--- a/controller/src/skills/plane_skills_service_tests.cpp
+++ b/controller/src/skills/plane_skills_service_tests.cpp
@@ -3734,6 +3734,37 @@ int main() {
       std::cout << "ok: interaction-payload-builder-sanitizes-invalid-utf8" << '\n';
     }
 
+    {
+      naim::controller::PlaneInteractionResolution resolution;
+      resolution.desired_state = BuildDesiredStateWithBrowsingPort("127.0.0.1", 28130);
+      resolution.desired_state.interaction = naim::InteractionSettings{};
+      resolution.status_payload =
+          json{{"active_model_id", "test-model"},
+               {"served_model_name", "test-model"}};
+      json payload{
+          {"stream", true},
+          {"messages",
+           json::array(
+               {json{{"role", "user"}, {"content", std::string("hello")}}})},
+      };
+      const auto resolved_policy =
+          naim::controller::InteractionCompletionPolicySupport{}.ResolvePolicy(
+              resolution.desired_state,
+              payload);
+      const json parsed = json::parse(
+          naim::controller::BuildInteractionUpstreamBodyPayload(
+              resolution,
+              payload,
+              false,
+              resolved_policy,
+              false));
+      Expect(
+          parsed.contains("stream") && parsed.at("stream").is_boolean() &&
+              !parsed.at("stream").get<bool>(),
+          "payload builder should force non-stream mode when requested");
+      std::cout << "ok: interaction-payload-builder-forces-non-stream" << '\n';
+    }
+
     return 0;
   } catch (const std::exception& error) {
     std::cerr << "plane_skills_service_tests failed: " << error.what() << '\n';

--- a/controller/src/skills/plane_skills_target_resolver.cpp
+++ b/controller/src/skills/plane_skills_target_resolver.cpp
@@ -162,7 +162,7 @@ PlaneSkillsTargetResolver::ResolvePlaneLocalTarget(
   assignment.node_name = target.node_name;
   assignment.plane_name = proxy_plane_name;
   assignment.desired_generation = 0;
-  assignment.max_attempts = 1;
+  assignment.max_attempts = 3;
   assignment.assignment_type = "runtime-http-proxy";
   assignment.desired_state_json =
       json{


### PR DESCRIPTION
## Summary
- retry hostd runtime proxy assignments for Knowledge Vault, skills, and WebGateway paths
- force interaction upstream payloads into the requested stream/non-stream mode
- add regression coverage for non-stream fallback payload shaping

## Tests
- cmake --build build/macos/arm64 --target naim-controller naim-knowledge-vault-service-tests naim-plane-skills-tests -j 8
- ./build/macos/arm64/naim-knowledge-vault-service-tests
- ./build/macos/arm64/naim-plane-skills-tests
- git diff --check && bash scripts/ci/pr-lightweight-checks.sh