### PR TITLE
Fallback from peer model transfer failures

### DIFF
--- a/hostd/src/app/hostd_bootstrap_model_support.cpp
+++ b/hostd/src/app/hostd_bootstrap_model_support.cpp
@@ -689,9 +689,6 @@ bool HostdBootstrapModelSupport::TryAcquireControllerRelayedBootstrapModel(
               aggregate_total_progress);
           continue;
         } catch (const std::exception& direct_error) {
-          if (deferred_peer_sha256) {
-            throw;
-          }
           output.close();
           std::error_code cleanup_error;
           fs::remove(temp_path, cleanup_error);


### PR DESCRIPTION
## Summary
- let bootstrap model acquisition fall back to controller relay when an established peer-direct transfer fails
- prevents large prepare_on_worker model copies from restarting from scratch when the storage peer endpoint drops mid-transfer

## Tests
- cmake --build build/macos/arm64 --target naim-hostd naim-hostd-bootstrap-transfer-support-tests naim-hostd-bootstrap-model-support-factory-tests -j 8
- ./build/macos/arm64/naim-hostd-bootstrap-transfer-support-tests
- ./build/macos/arm64/naim-hostd-bootstrap-model-support-factory-tests
- git diff --check && bash scripts/ci/pr-lightweight-checks.sh