### PR TITLE
Gate WebGateway proxy on applied plane runtime

### DIFF
--- a/controller/src/plane/dashboard_service.cpp
+++ b/controller/src/plane/dashboard_service.cpp
@@ -790,6 +790,12 @@ nlohmann::json DashboardService::BuildPayload(
 
   const std::optional<std::string> selected_plane_state =
       ResolveSelectedPlaneState(view.planes, plane_name);
+  std::optional<std::string> webgateway_plane_state = selected_plane_state;
+  if (dashboard_plane_record.has_value() &&
+      dashboard_plane_record->state == "running" &&
+      dashboard_plane_record->generation > effective_plane_applied_generation) {
+    webgateway_plane_state = "starting";
+  }
   const auto dashboard_nodes =
       BuildDashboardNodes(plane_name, *view.desired_state, view.desired_states);
   const auto nodes_payload = BuildNodesPayload(
@@ -823,7 +829,7 @@ nlohmann::json DashboardService::BuildPayload(
   payload["webgateway"] = PlaneBrowsingService().BuildStatusPayload(
       db_path,
       *view.desired_state,
-      selected_plane_state);
+      webgateway_plane_state);
 
   const auto latest_assignments_by_node =
       BuildLatestPlaneAssignmentsByNode(

--- a/controller/src/plane/plane_http_service.cpp
+++ b/controller/src/plane/plane_http_service.cpp
@@ -332,6 +332,13 @@ HttpResponse PlaneHttpService::HandlePlanePath(
         const auto plane = store.LoadPlane(plane_name);
         const std::optional<std::string> plane_state =
             plane.has_value() ? std::optional<std::string>(plane->state) : std::nullopt;
+        const bool plane_runtime_ready =
+            plane.has_value() && plane->state == "running" &&
+            plane->generation <= plane->applied_generation;
+        std::optional<std::string> webgateway_plane_state = plane_state;
+        if (plane.has_value() && plane->state == "running" && !plane_runtime_ready) {
+          webgateway_plane_state = "starting";
+        }
         const naim::controller::PlaneBrowsingService browsing_service;
         if (path_suffix.empty() || path_suffix == "/" || path_suffix == "/status") {
           if (request.method != "GET") {
@@ -340,7 +347,18 @@ HttpResponse PlaneHttpService::HandlePlanePath(
           }
           return support_.build_json_response(
               200,
-              browsing_service.BuildStatusPayload(db_path, *desired_state, plane_state),
+              browsing_service.BuildStatusPayload(db_path, *desired_state, webgateway_plane_state),
+              {});
+        }
+        if (!plane_runtime_ready) {
+          return support_.build_json_response(
+              409,
+              json{{"status", "error"},
+                   {"message", "webgateway plane runtime is not ready"},
+                   {"error",
+                    {{"code", "webgateway_plane_not_ready"},
+                     {"message", "webgateway plane runtime is not ready"}}},
+                   {"path", request.path}},
               {});
         }
 


### PR DESCRIPTION
## Summary
- avoid probing WebGateway through hostd runtime proxy while a running plane still has unapplied generation
- return a clear 409 for WebGateway proxy requests before the plane runtime is applied
- keep dashboard/WebGateway status in plane_not_running/starting mode until runtime is ready

## Tests
- cmake --build build/macos/arm64 --target naim-controller naim-plane-skills-tests -j 8
- ./build/macos/arm64/naim-plane-skills-tests
- git diff --check && bash scripts/ci/pr-lightweight-checks.sh