### PR TITLE
Speed up peer model transfer buffers

### DIFF
--- a/hostd/src/app/hostd_bootstrap_model_support.cpp
+++ b/hostd/src/app/hostd_bootstrap_model_support.cpp
@@ -135,7 +135,8 @@ PeerHttpResponse SendPeerHttpRawRequest(
     remaining -= static_cast<std::size_t>(written);
   }
   std::string response_text;
-  std::array<char, 8192> buffer{};
+  std::array<char, 1024 * 1024> buffer{};
+  bool reserved_body = false;
   while (true) {
     const ssize_t read_count = recv(fd, buffer.data(), buffer.size(), 0);
     if (read_count < 0) {
@@ -146,6 +147,42 @@ PeerHttpResponse SendPeerHttpRawRequest(
       break;
     }
     response_text.append(buffer.data(), static_cast<std::size_t>(read_count));
+    if (!reserved_body) {
+      const std::size_t headers_end = response_text.find("\r\n\r\n");
+      if (headers_end != std::string::npos) {
+        const std::string headers = response_text.substr(0, headers_end);
+        std::istringstream header_lines(headers);
+        std::string header_line;
+        while (std::getline(header_lines, header_line)) {
+          if (!header_line.empty() && header_line.back() == '\r') {
+            header_line.pop_back();
+          }
+          const std::size_t colon = header_line.find(':');
+          if (colon == std::string::npos) {
+            continue;
+          }
+          std::string key = header_line.substr(0, colon);
+          std::transform(key.begin(), key.end(), key.begin(), [](unsigned char ch) {
+            return static_cast<char>(std::tolower(ch));
+          });
+          if (key != "content-length") {
+            continue;
+          }
+          std::string value = header_line.substr(colon + 1);
+          while (!value.empty() && value.front() == ' ') {
+            value.erase(value.begin());
+          }
+          try {
+            const std::size_t content_length =
+                static_cast<std::size_t>(std::stoull(value));
+            response_text.reserve(headers_end + 4 + content_length);
+          } catch (const std::exception&) {
+          }
+          break;
+        }
+        reserved_body = true;
+      }
+    }
   }
   naim::platform::CloseSocket(fd);
   const std::size_t headers_end = response_text.find("\r\n\r\n");

--- a/hostd/src/app/hostd_desired_state_apply_support.cpp
+++ b/hostd/src/app/hostd_desired_state_apply_support.cpp
@@ -118,7 +118,8 @@ PeerHttpResponse SendPeerHttpRawRequest(
     remaining -= static_cast<std::size_t>(written);
   }
   std::string response_text;
-  std::array<char, 8192> buffer{};
+  std::array<char, 1024 * 1024> buffer{};
+  bool reserved_body = false;
   while (true) {
     const ssize_t read_count = recv(fd, buffer.data(), buffer.size(), 0);
     if (read_count < 0) {
@@ -129,6 +130,42 @@ PeerHttpResponse SendPeerHttpRawRequest(
       break;
     }
     response_text.append(buffer.data(), static_cast<std::size_t>(read_count));
+    if (!reserved_body) {
+      const std::size_t headers_end = response_text.find("\r\n\r\n");
+      if (headers_end != std::string::npos) {
+        const std::string headers = response_text.substr(0, headers_end);
+        std::istringstream header_lines(headers);
+        std::string header_line;
+        while (std::getline(header_lines, header_line)) {
+          if (!header_line.empty() && header_line.back() == '\r') {
+            header_line.pop_back();
+          }
+          const std::size_t colon = header_line.find(':');
+          if (colon == std::string::npos) {
+            continue;
+          }
+          std::string key = header_line.substr(0, colon);
+          std::transform(key.begin(), key.end(), key.begin(), [](unsigned char ch) {
+            return static_cast<char>(std::tolower(ch));
+          });
+          if (key != "content-length") {
+            continue;
+          }
+          std::string value = header_line.substr(colon + 1);
+          while (!value.empty() && value.front() == ' ') {
+            value.erase(value.begin());
+          }
+          try {
+            const std::size_t content_length =
+                static_cast<std::size_t>(std::stoull(value));
+            response_text.reserve(headers_end + 4 + content_length);
+          } catch (const std::exception&) {
+          }
+          break;
+        }
+        reserved_body = true;
+      }
+    }
   }
   naim::platform::CloseSocket(fd);
   const std::size_t headers_end = response_text.find("\r\n\r\n");

--- a/launcher/src/run/hostd_peer_service.cpp
+++ b/launcher/src/run/hostd_peer_service.cpp
@@ -612,17 +612,19 @@ void HostdPeerService::HandleHttpClient(int client_fd) const {
               << " node=" << options_.node_name
               << " message=" << error.what() << std::endl;
   }
-  std::ostringstream response;
-  response << "HTTP/1.1 " << status_code << " " << HttpReason(status_code) << "\r\n";
-  response << "Content-Type: " << content_type << "\r\n";
+  std::ostringstream response_headers_text;
+  response_headers_text << "HTTP/1.1 " << status_code << " " << HttpReason(status_code) << "\r\n";
+  response_headers_text << "Content-Type: " << content_type << "\r\n";
   for (const auto& [key, value] : response_headers) {
-    response << key << ": " << value << "\r\n";
+    response_headers_text << key << ": " << value << "\r\n";
   }
-  response << "Content-Length: " << response_body.size() << "\r\n";
-  response << "Connection: close\r\n\r\n";
-  response << response_body;
-  const std::string text = response.str();
-  SendAll(client_fd, text.data(), text.size());
+  response_headers_text << "Content-Length: " << response_body.size() << "\r\n";
+  response_headers_text << "Connection: close\r\n\r\n";
+  const std::string headers = response_headers_text.str();
+  SendAll(client_fd, headers.data(), headers.size());
+  if (!response_body.empty()) {
+    SendAll(client_fd, response_body.data(), response_body.size());
+  }
   close(client_fd);
 }
 


### PR DESCRIPTION
## Summary
- send peer HTTP headers and large bodies separately to avoid copying 64MB chunks into a second response string
- reserve peer response buffers from Content-Length and read with a 1MiB buffer on hostd clients
- apply the same read path to bootstrap model and desired-state model mount transfers

## Live diagnosis
- storage1 -> hpc1 raw TCP: 1GiB in 9.13s (~117 MB/s)
- peer chunk API: 1GiB in 11.9s (~90 MB/s)
- peer chunk API + client sha256 + target write: 1GiB in 13.6s (~79 MB/s)
- production hostd path was only ~18.6GB in ~34m, so the bottleneck was the C++ peer response buffering/copy path, not LAN or disk

## Tests
- cmake --build build/macos/arm64 --target naim-hostd naim-node naim-hostd-bootstrap-model-support-factory-tests naim-hostd-bootstrap-transfer-support-tests -j 8
- ./build/macos/arm64/naim-hostd-bootstrap-model-support-factory-tests
- ./build/macos/arm64/naim-hostd-bootstrap-transfer-support-tests
- git diff --check && bash scripts/ci/pr-lightweight-checks.sh