### PR TITLE
Stream direct peer model chunks

### DIFF
--- a/hostd/src/app/hostd_bootstrap_model_support.cpp
+++ b/hostd/src/app/hostd_bootstrap_model_support.cpp
@@ -7,12 +7,15 @@
 #include <filesystem>
 #include <fstream>
 #include <cstdlib>
+#include <iomanip>
 #include <map>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <thread>
 
 #include <netdb.h>
+#include <sodium.h>
 
 #include "naim/core/platform_compat.h"
 #include "naim/security/crypto_utils.h"
@@ -34,6 +37,10 @@ struct PeerHttpResponse {
   int status_code = 0;
   std::map<std::string, std::string> headers;
   std::string body;
+};
+
+struct PeerChunkStreamResult {
+  std::uintmax_t bytes_written = 0;
 };
 
 struct PeerEndpoint {
@@ -72,7 +79,23 @@ PeerHttpResponse SendPeerHttpRawRequest(
     const std::string& content_type,
     const std::map<std::string, std::string>& extra_headers);
 
+std::string NormalizeLowercase(std::string value);
+
 void ApplyPeerSocketTimeouts(naim::platform::SocketHandle fd) {
+  const int receive_buffer_bytes = 16 * 1024 * 1024;
+  const int send_buffer_bytes = 1024 * 1024;
+  setsockopt(
+      fd,
+      SOL_SOCKET,
+      SO_RCVBUF,
+      reinterpret_cast<const char*>(&receive_buffer_bytes),
+      sizeof(receive_buffer_bytes));
+  setsockopt(
+      fd,
+      SOL_SOCKET,
+      SO_SNDBUF,
+      reinterpret_cast<const char*>(&send_buffer_bytes),
+      sizeof(send_buffer_bytes));
 #if defined(_WIN32)
   const DWORD timeout_ms = kPeerHttpTimeoutSeconds * 1000;
   setsockopt(
@@ -94,6 +117,236 @@ void ApplyPeerSocketTimeouts(naim::platform::SocketHandle fd) {
   setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
   setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
 #endif
+}
+
+std::string Sha256DigestHex(const std::array<unsigned char, crypto_hash_sha256_BYTES>& digest) {
+  std::ostringstream out;
+  out << std::hex << std::setfill('0');
+  for (unsigned char byte : digest) {
+    out << std::setw(2) << static_cast<int>(byte);
+  }
+  return out.str();
+}
+
+std::map<std::string, std::string> ParsePeerHeaders(const std::string& headers) {
+  std::map<std::string, std::string> parsed;
+  std::istringstream header_lines(headers);
+  std::string header_line;
+  bool first_header = true;
+  while (std::getline(header_lines, header_line)) {
+    if (!header_line.empty() && header_line.back() == '\r') {
+      header_line.pop_back();
+    }
+    if (first_header) {
+      first_header = false;
+      continue;
+    }
+    const std::size_t colon = header_line.find(':');
+    if (colon == std::string::npos) {
+      continue;
+    }
+    std::string key = header_line.substr(0, colon);
+    std::transform(key.begin(), key.end(), key.begin(), [](unsigned char ch) {
+      return static_cast<char>(std::tolower(ch));
+    });
+    std::string value = header_line.substr(colon + 1);
+    while (!value.empty() && value.front() == ' ') {
+      value.erase(value.begin());
+    }
+    parsed[key] = value;
+  }
+  return parsed;
+}
+
+std::optional<std::uintmax_t> ParseContentLength(
+    const std::map<std::string, std::string>& headers) {
+  const auto it = headers.find("content-length");
+  if (it == headers.end()) {
+    return std::nullopt;
+  }
+  try {
+    return static_cast<std::uintmax_t>(std::stoull(it->second));
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
+naim::platform::SocketHandle ConnectPeerSocket(const PeerEndpoint& target) {
+  naim::platform::EnsureSocketsInitialized();
+  addrinfo hints{};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  addrinfo* results = nullptr;
+  const std::string port_text = std::to_string(target.port);
+  const int lookup = getaddrinfo(target.host.c_str(), port_text.c_str(), &hints, &results);
+  if (lookup != 0) {
+    throw std::runtime_error("failed to resolve peer endpoint: " + target.raw);
+  }
+  naim::platform::SocketHandle fd = naim::platform::kInvalidSocket;
+  for (addrinfo* candidate = results; candidate != nullptr; candidate = candidate->ai_next) {
+    fd = socket(candidate->ai_family, candidate->ai_socktype, candidate->ai_protocol);
+    if (!naim::platform::IsSocketValid(fd)) {
+      continue;
+    }
+    ApplyPeerSocketTimeouts(fd);
+    if (connect(fd, candidate->ai_addr, candidate->ai_addrlen) == 0) {
+      break;
+    }
+    naim::platform::CloseSocket(fd);
+    fd = naim::platform::kInvalidSocket;
+  }
+  freeaddrinfo(results);
+  if (!naim::platform::IsSocketValid(fd)) {
+    throw std::runtime_error("failed to connect to peer endpoint: " + target.raw);
+  }
+  return fd;
+}
+
+void SendPeerRequestBytes(naim::platform::SocketHandle fd, const std::string& request_text) {
+  const char* data = request_text.data();
+  std::size_t remaining = request_text.size();
+  while (remaining > 0) {
+    const ssize_t written = send(fd, data, remaining, 0);
+    if (written <= 0) {
+      throw std::runtime_error(
+          "failed to write peer request: " + naim::platform::LastSocketErrorMessage());
+    }
+    data += written;
+    remaining -= static_cast<std::size_t>(written);
+  }
+}
+
+std::string BuildPeerPostRequest(
+    const PeerEndpoint& target,
+    const std::string& path,
+    const std::string& body,
+    const std::string& content_type,
+    const std::map<std::string, std::string>& extra_headers = {}) {
+  std::ostringstream request;
+  request << "POST " << path << " HTTP/1.1\r\n";
+  request << "Host: " << target.host << ":" << target.port << "\r\n";
+  request << "Connection: close\r\n";
+  request << "Content-Type: " << content_type << "\r\n";
+  for (const auto& [key, value] : extra_headers) {
+    request << key << ": " << value << "\r\n";
+  }
+  request << "Content-Length: " << body.size() << "\r\n\r\n";
+  request << body;
+  return request.str();
+}
+
+PeerChunkStreamResult StreamPeerChunkToOutput(
+    const std::string& endpoint,
+    const nlohmann::json& payload,
+    std::ostream& output,
+    bool require_checksum) {
+  naim::InitializeCrypto();
+  const PeerEndpoint target = ParsePeerEndpoint(endpoint);
+  naim::platform::SocketHandle fd = ConnectPeerSocket(target);
+  try {
+    SendPeerRequestBytes(
+        fd,
+        BuildPeerPostRequest(
+            target,
+            "/peer/v1/files/chunk",
+            payload.dump(),
+            "application/json"));
+
+    std::array<char, 1024 * 1024> buffer{};
+    std::string response_prefix;
+    std::size_t headers_end = std::string::npos;
+    while (headers_end == std::string::npos) {
+      const ssize_t read_count = recv(fd, buffer.data(), buffer.size(), 0);
+      if (read_count < 0) {
+        throw std::runtime_error(
+            "failed to read peer response: " + naim::platform::LastSocketErrorMessage());
+      }
+      if (read_count == 0) {
+        throw std::runtime_error("peer chunk response ended before headers");
+      }
+      response_prefix.append(buffer.data(), static_cast<std::size_t>(read_count));
+      headers_end = response_prefix.find("\r\n\r\n");
+    }
+
+    const std::string header_text = response_prefix.substr(0, headers_end);
+    std::istringstream status(header_text.substr(0, header_text.find("\r\n")));
+    std::string version;
+    int status_code = 0;
+    status >> version >> status_code;
+    const std::map<std::string, std::string> headers = ParsePeerHeaders(header_text);
+    const std::string initial_body = response_prefix.substr(headers_end + 4);
+    if (status_code >= 400) {
+      std::string detail = initial_body.substr(0, 512);
+      naim::platform::CloseSocket(fd);
+      throw std::runtime_error(
+          "peer request failed with status " + std::to_string(status_code) +
+          (detail.empty() ? std::string{} : ": " + detail));
+    }
+
+    crypto_hash_sha256_state context;
+    crypto_hash_sha256_init(&context);
+    std::uintmax_t bytes_written = 0;
+    const std::optional<std::uintmax_t> content_length = ParseContentLength(headers);
+
+    auto consume_body = [&](const char* data, std::size_t size) {
+      if (size == 0) {
+        return;
+      }
+      crypto_hash_sha256_update(
+          &context,
+          reinterpret_cast<const unsigned char*>(data),
+          static_cast<unsigned long long>(size));
+      output.write(data, static_cast<std::streamsize>(size));
+      if (!output.good()) {
+        throw std::runtime_error("failed to write peer chunk to output");
+      }
+      bytes_written += size;
+    };
+
+    if (!initial_body.empty()) {
+      const std::size_t allowed =
+          content_length ? static_cast<std::size_t>(
+                               std::min<std::uintmax_t>(*content_length, initial_body.size()))
+                         : initial_body.size();
+      consume_body(initial_body.data(), allowed);
+    }
+    while (!content_length || bytes_written < *content_length) {
+      const ssize_t read_count = recv(fd, buffer.data(), buffer.size(), 0);
+      if (read_count < 0) {
+        throw std::runtime_error(
+            "failed to read peer response: " + naim::platform::LastSocketErrorMessage());
+      }
+      if (read_count == 0) {
+        break;
+      }
+      std::size_t body_size = static_cast<std::size_t>(read_count);
+      if (content_length && bytes_written + body_size > *content_length) {
+        body_size = static_cast<std::size_t>(*content_length - bytes_written);
+      }
+      consume_body(buffer.data(), body_size);
+    }
+    if (content_length && bytes_written != *content_length) {
+      throw std::runtime_error("peer chunk response ended before content-length was satisfied");
+    }
+
+    const auto chunk_sha256_it = headers.find("x-naim-chunk-sha256");
+    if (require_checksum && chunk_sha256_it == headers.end()) {
+      throw std::runtime_error("direct LAN transfer chunk is missing checksum header");
+    }
+    if (chunk_sha256_it != headers.end()) {
+      std::array<unsigned char, crypto_hash_sha256_BYTES> digest{};
+      crypto_hash_sha256_final(&context, digest.data());
+      if (NormalizeLowercase(Sha256DigestHex(digest)) !=
+          NormalizeLowercase(chunk_sha256_it->second)) {
+        throw std::runtime_error("direct LAN transfer chunk checksum mismatch");
+      }
+    }
+    naim::platform::CloseSocket(fd);
+    return PeerChunkStreamResult{bytes_written};
+  } catch (...) {
+    naim::platform::CloseSocket(fd);
+    throw;
+  }
 }
 
 PeerHttpResponse SendPeerHttpRequest(
@@ -724,38 +977,26 @@ bool HostdBootstrapModelSupport::TryAcquireControllerRelayedBootstrapModel(
         try {
           const std::uintmax_t expected_size =
               JsonUintmax(files[file_index], "size_bytes").value_or(0);
-          const PeerHttpResponse peer_chunk = SendPeerHttpRequestWithRetries(
+          const PeerChunkStreamResult peer_chunk = StreamPeerChunkToOutput(
               peer_endpoint,
-              "/peer/v1/files/chunk",
               nlohmann::json{
                   {"ticket_id", peer_ticket_id},
                   {"source_path", source_path},
                   {"offset", offset},
                   {"max_bytes", kPeerDirectChunkBytes},
               },
-              "direct LAN chunk request at offset " + std::to_string(offset));
-          if (peer_chunk.body.empty() && offset < expected_size) {
+              output,
+              deferred_peer_sha256);
+          if (peer_chunk.bytes_written == 0 && offset < expected_size) {
             throw std::runtime_error("direct LAN transfer returned an empty non-final chunk");
           }
-          if (!peer_chunk.body.empty()) {
-            const auto chunk_sha256_it = peer_chunk.headers.find("x-naim-chunk-sha256");
-            if (deferred_peer_sha256 && chunk_sha256_it == peer_chunk.headers.end()) {
-              throw std::runtime_error("direct LAN transfer chunk is missing checksum header");
-            }
-            if (chunk_sha256_it != peer_chunk.headers.end() &&
-                NormalizeLowercase(naim::ComputeSha256Hex(peer_chunk.body)) !=
-                    NormalizeLowercase(chunk_sha256_it->second)) {
-              throw std::runtime_error("direct LAN transfer chunk checksum mismatch");
-            }
-            output.write(peer_chunk.body.data(), static_cast<std::streamsize>(peer_chunk.body.size()));
-            if (!output.good()) {
-              throw std::runtime_error("failed to write bootstrap model direct target: " + temp_path);
-            }
+          if (!output.good()) {
+            throw std::runtime_error("failed to write bootstrap model direct target: " + temp_path);
           }
-          const std::uintmax_t next_offset = offset + peer_chunk.body.size();
+          const std::uintmax_t next_offset = offset + peer_chunk.bytes_written;
           aggregate_done += next_offset - offset;
           offset = next_offset;
-          eof = offset >= expected_size || peer_chunk.body.size() < kPeerDirectChunkBytes;
+          eof = offset >= expected_size || peer_chunk.bytes_written < kPeerDirectChunkBytes;
           int percent = 60;
           if (aggregate_total > 0) {
             percent = 20 + static_cast<int>(

--- a/hostd/src/app/hostd_desired_state_apply_support.cpp
+++ b/hostd/src/app/hostd_desired_state_apply_support.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <map>
 #include <optional>
@@ -21,6 +22,7 @@
 #include "naim/planning/planner.h"
 
 #include <netdb.h>
+#include <sodium.h>
 
 namespace naim::hostd {
 
@@ -39,11 +41,17 @@ struct PeerHttpResponse {
   std::string body;
 };
 
+struct PeerChunkStreamResult {
+  std::uintmax_t bytes_written = 0;
+};
+
 struct PeerEndpoint {
   std::string raw;
   std::string host;
   int port = 29999;
 };
+
+std::string Lowercase(std::string value);
 
 PeerEndpoint ParsePeerEndpoint(std::string endpoint) {
   PeerEndpoint parsed;
@@ -69,6 +77,20 @@ PeerEndpoint ParsePeerEndpoint(std::string endpoint) {
 }
 
 void ApplyPeerSocketTimeouts(naim::platform::SocketHandle fd) {
+  const int receive_buffer_bytes = 16 * 1024 * 1024;
+  const int send_buffer_bytes = 1024 * 1024;
+  setsockopt(
+      fd,
+      SOL_SOCKET,
+      SO_RCVBUF,
+      reinterpret_cast<const char*>(&receive_buffer_bytes),
+      sizeof(receive_buffer_bytes));
+  setsockopt(
+      fd,
+      SOL_SOCKET,
+      SO_SNDBUF,
+      reinterpret_cast<const char*>(&send_buffer_bytes),
+      sizeof(send_buffer_bytes));
 #if defined(_WIN32)
   const DWORD timeout_ms = kPeerHttpTimeoutSeconds * 1000;
   setsockopt(
@@ -90,6 +112,227 @@ void ApplyPeerSocketTimeouts(naim::platform::SocketHandle fd) {
   setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
   setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
 #endif
+}
+
+std::string Sha256DigestHex(const std::array<unsigned char, crypto_hash_sha256_BYTES>& digest) {
+  std::ostringstream out;
+  out << std::hex << std::setfill('0');
+  for (unsigned char byte : digest) {
+    out << std::setw(2) << static_cast<int>(byte);
+  }
+  return out.str();
+}
+
+std::map<std::string, std::string> ParsePeerHeaders(const std::string& headers) {
+  std::map<std::string, std::string> parsed;
+  std::istringstream header_lines(headers);
+  std::string header_line;
+  bool first_header = true;
+  while (std::getline(header_lines, header_line)) {
+    if (!header_line.empty() && header_line.back() == '\r') {
+      header_line.pop_back();
+    }
+    if (first_header) {
+      first_header = false;
+      continue;
+    }
+    const std::size_t colon = header_line.find(':');
+    if (colon == std::string::npos) {
+      continue;
+    }
+    std::string key = header_line.substr(0, colon);
+    std::transform(key.begin(), key.end(), key.begin(), [](unsigned char ch) {
+      return static_cast<char>(std::tolower(ch));
+    });
+    std::string value = header_line.substr(colon + 1);
+    while (!value.empty() && value.front() == ' ') {
+      value.erase(value.begin());
+    }
+    parsed[key] = value;
+  }
+  return parsed;
+}
+
+std::optional<std::uintmax_t> ParseContentLength(
+    const std::map<std::string, std::string>& headers) {
+  const auto it = headers.find("content-length");
+  if (it == headers.end()) {
+    return std::nullopt;
+  }
+  try {
+    return static_cast<std::uintmax_t>(std::stoull(it->second));
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
+naim::platform::SocketHandle ConnectPeerSocket(const PeerEndpoint& target) {
+  naim::platform::EnsureSocketsInitialized();
+  addrinfo hints{};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  addrinfo* results = nullptr;
+  const std::string port_text = std::to_string(target.port);
+  const int lookup = getaddrinfo(target.host.c_str(), port_text.c_str(), &hints, &results);
+  if (lookup != 0) {
+    throw std::runtime_error("failed to resolve peer endpoint: " + target.raw);
+  }
+  naim::platform::SocketHandle fd = naim::platform::kInvalidSocket;
+  for (addrinfo* candidate = results; candidate != nullptr; candidate = candidate->ai_next) {
+    fd = socket(candidate->ai_family, candidate->ai_socktype, candidate->ai_protocol);
+    if (!naim::platform::IsSocketValid(fd)) {
+      continue;
+    }
+    ApplyPeerSocketTimeouts(fd);
+    if (connect(fd, candidate->ai_addr, candidate->ai_addrlen) == 0) {
+      break;
+    }
+    naim::platform::CloseSocket(fd);
+    fd = naim::platform::kInvalidSocket;
+  }
+  freeaddrinfo(results);
+  if (!naim::platform::IsSocketValid(fd)) {
+    throw std::runtime_error("failed to connect to peer endpoint: " + target.raw);
+  }
+  return fd;
+}
+
+void SendPeerRequestBytes(naim::platform::SocketHandle fd, const std::string& request_text) {
+  const char* data = request_text.data();
+  std::size_t remaining = request_text.size();
+  while (remaining > 0) {
+    const ssize_t written = send(fd, data, remaining, 0);
+    if (written <= 0) {
+      throw std::runtime_error(
+          "failed to write peer request: " + naim::platform::LastSocketErrorMessage());
+    }
+    data += written;
+    remaining -= static_cast<std::size_t>(written);
+  }
+}
+
+std::string BuildPeerPostRequest(
+    const PeerEndpoint& target,
+    const std::string& path,
+    const std::string& body,
+    const std::string& content_type) {
+  std::ostringstream request;
+  request << "POST " << path << " HTTP/1.1\r\n";
+  request << "Host: " << target.host << ":" << target.port << "\r\n";
+  request << "Connection: close\r\n";
+  request << "Content-Type: " << content_type << "\r\n";
+  request << "Content-Length: " << body.size() << "\r\n\r\n";
+  request << body;
+  return request.str();
+}
+
+PeerChunkStreamResult StreamPeerChunkToOutput(
+    const std::string& endpoint,
+    const nlohmann::json& payload,
+    std::ostream& output) {
+  naim::InitializeCrypto();
+  const PeerEndpoint target = ParsePeerEndpoint(endpoint);
+  naim::platform::SocketHandle fd = ConnectPeerSocket(target);
+  try {
+    SendPeerRequestBytes(
+        fd,
+        BuildPeerPostRequest(
+            target,
+            "/peer/v1/files/chunk",
+            payload.dump(),
+            "application/json"));
+
+    std::array<char, 1024 * 1024> buffer{};
+    std::string response_prefix;
+    std::size_t headers_end = std::string::npos;
+    while (headers_end == std::string::npos) {
+      const ssize_t read_count = recv(fd, buffer.data(), buffer.size(), 0);
+      if (read_count < 0) {
+        throw std::runtime_error(
+            "failed to read peer response: " + naim::platform::LastSocketErrorMessage());
+      }
+      if (read_count == 0) {
+        throw std::runtime_error("peer chunk response ended before headers");
+      }
+      response_prefix.append(buffer.data(), static_cast<std::size_t>(read_count));
+      headers_end = response_prefix.find("\r\n\r\n");
+    }
+
+    const std::string header_text = response_prefix.substr(0, headers_end);
+    std::istringstream status(header_text.substr(0, header_text.find("\r\n")));
+    std::string version;
+    int status_code = 0;
+    status >> version >> status_code;
+    const std::map<std::string, std::string> headers = ParsePeerHeaders(header_text);
+    const std::string initial_body = response_prefix.substr(headers_end + 4);
+    if (status_code >= 400) {
+      std::string detail = initial_body.substr(0, 512);
+      naim::platform::CloseSocket(fd);
+      throw std::runtime_error(
+          "peer request failed with status " + std::to_string(status_code) +
+          (detail.empty() ? std::string{} : ": " + detail));
+    }
+
+    crypto_hash_sha256_state context;
+    crypto_hash_sha256_init(&context);
+    std::uintmax_t bytes_written = 0;
+    const std::optional<std::uintmax_t> content_length = ParseContentLength(headers);
+
+    auto consume_body = [&](const char* data, std::size_t size) {
+      if (size == 0) {
+        return;
+      }
+      crypto_hash_sha256_update(
+          &context,
+          reinterpret_cast<const unsigned char*>(data),
+          static_cast<unsigned long long>(size));
+      output.write(data, static_cast<std::streamsize>(size));
+      if (!output.good()) {
+        throw std::runtime_error("failed to write peer chunk to output");
+      }
+      bytes_written += size;
+    };
+
+    if (!initial_body.empty()) {
+      const std::size_t allowed =
+          content_length ? static_cast<std::size_t>(
+                               std::min<std::uintmax_t>(*content_length, initial_body.size()))
+                         : initial_body.size();
+      consume_body(initial_body.data(), allowed);
+    }
+    while (!content_length || bytes_written < *content_length) {
+      const ssize_t read_count = recv(fd, buffer.data(), buffer.size(), 0);
+      if (read_count < 0) {
+        throw std::runtime_error(
+            "failed to read peer response: " + naim::platform::LastSocketErrorMessage());
+      }
+      if (read_count == 0) {
+        break;
+      }
+      std::size_t body_size = static_cast<std::size_t>(read_count);
+      if (content_length && bytes_written + body_size > *content_length) {
+        body_size = static_cast<std::size_t>(*content_length - bytes_written);
+      }
+      consume_body(buffer.data(), body_size);
+    }
+    if (content_length && bytes_written != *content_length) {
+      throw std::runtime_error("peer chunk response ended before content-length was satisfied");
+    }
+
+    const auto chunk_sha256_it = headers.find("x-naim-chunk-sha256");
+    if (chunk_sha256_it != headers.end()) {
+      std::array<unsigned char, crypto_hash_sha256_BYTES> digest{};
+      crypto_hash_sha256_final(&context, digest.data());
+      if (Lowercase(Sha256DigestHex(digest)) != Lowercase(chunk_sha256_it->second)) {
+        throw std::runtime_error("direct app model transfer chunk checksum mismatch");
+      }
+    }
+    naim::platform::CloseSocket(fd);
+    return PeerChunkStreamResult{bytes_written};
+  } catch (...) {
+    naim::platform::CloseSocket(fd);
+    throw;
+  }
 }
 
 PeerHttpResponse SendPeerHttpRawRequest(
@@ -366,29 +609,22 @@ bool TryMaterializeAppModelMountDirectly(
 
   std::uintmax_t offset = 0;
   while (offset < *expected_size) {
-    const PeerHttpResponse chunk = SendPeerHttpRequestWithRetries(
+    const PeerChunkStreamResult chunk = StreamPeerChunkToOutput(
         peer_endpoint,
-        "/peer/v1/files/chunk",
         nlohmann::json{
             {"ticket_id", ticket_id},
             {"source_path", files.front().value("source_path", source_paths.front())},
             {"offset", offset},
             {"max_bytes", kAppModelPeerChunkBytes},
         },
-        "direct app model chunk request at offset " + std::to_string(offset));
-    if (chunk.body.empty() && offset < *expected_size) {
+        output);
+    if (chunk.bytes_written == 0 && offset < *expected_size) {
       throw std::runtime_error("direct app model transfer returned an empty non-final chunk");
     }
-    const auto chunk_sha256_it = chunk.headers.find("x-naim-chunk-sha256");
-    if (chunk_sha256_it != chunk.headers.end() &&
-        Lowercase(naim::ComputeSha256Hex(chunk.body)) != Lowercase(chunk_sha256_it->second)) {
-      throw std::runtime_error("direct app model transfer chunk checksum mismatch");
-    }
-    output.write(chunk.body.data(), static_cast<std::streamsize>(chunk.body.size()));
     if (!output.good()) {
       throw std::runtime_error("failed to write app model direct target: " + temp_path);
     }
-    offset += chunk.body.size();
+    offset += chunk.bytes_written;
     const int percent =
         *expected_size > 0
             ? 20 + static_cast<int>(


### PR DESCRIPTION
## Summary
- stream direct peer model chunks to the target file instead of buffering 64 MB responses in memory
- validate peer chunk checksums while streaming
- increase peer socket buffers for bulk LAN transfer

## Tests
- cmake --build build/macos/arm64 --target naim-hostd naim-node naim-hostd-bootstrap-model-support-factory-tests naim-hostd-bootstrap-transfer-support-tests -j 8
- ./build/macos/arm64/naim-hostd-bootstrap-model-support-factory-tests
- ./build/macos/arm64/naim-hostd-bootstrap-transfer-support-tests
- git diff --check
- bash scripts/ci/pr-lightweight-checks.sh