### PR TITLE
Wait for telemetry after controller update

### DIFF
--- a/scripts/ci/main-bootstrap-controller-update.sh
+++ b/scripts/ci/main-bootstrap-controller-update.sh
@@ -205,14 +205,19 @@ wait_for_container_http_contains() {
 
 check_telemetry_health() {
   local phase="$1"
+  local attempts="${2:-1}"
+  local interval_sec="${3:-5}"
   local output_path
+  local check_output
+  local last_error=""
   output_path="$(mktemp)"
-  docker run --rm \
-    -v "${main_root}/state:/naim/state" \
-    "${controller_image}" \
-    show-telemetry-health \
-      --db /naim/state/controller.sqlite > "${output_path}"
-  python3 - "${output_path}" "${phase}" <<'PY'
+  for attempt in $(seq 1 "${attempts}"); do
+    docker run --rm \
+      -v "${main_root}/state:/naim/state" \
+      "${controller_image}" \
+      show-telemetry-health \
+        --db /naim/state/controller.sqlite > "${output_path}"
+    if check_output="$(python3 - "${output_path}" "${phase}" <<'PY'
 import json
 import sys
 
@@ -237,13 +242,25 @@ print("telemetry health", phase, json.dumps({
     },
 }, sort_keys=True))
 PY
+    )"; then
+      printf '%s\n' "${check_output}"
+      rm -f "${output_path}"
+      return 0
+    fi
+    last_error="${check_output}"
+    if [[ "${attempt}" -lt "${attempts}" ]]; then
+      sleep "${interval_sec}"
+    fi
+  done
   rm -f "${output_path}"
+  printf '%s\n' "${last_error}" >&2
+  return 1
 }
 
 docker compose -f "${compose_path}" pull naim-controller >/dev/null
 docker compose -f "${compose_path}" up -d --remove-orphans naim-controller >/dev/null
 wait_for_http "http://127.0.0.1:${controller_port}/health" 90
-check_telemetry_health "controller-update"
+check_telemetry_health "controller-update" 36 5
 
 docker compose -f "${compose_path}" pull naim-skills-factory naim-web-ui >/dev/null
 docker compose -f "${compose_path}" up -d --remove-orphans naim-skills-factory naim-web-ui >/dev/null
@@ -388,7 +405,7 @@ raise SystemExit(
     + json.dumps(last, sort_keys=True)
 )
 PY
-check_telemetry_health "managed-rollout"
+check_telemetry_health "managed-rollout" 12 5
 
 plane_refresh_root="$(mktemp -d)"
 plane_refresh_plan="${plane_refresh_root}/planes.tsv"


### PR DESCRIPTION
## Summary
- retry the telemetry health gate after controller restart so hostd publishers can reconnect and publish fresh frames
- keep the managed-rollout telemetry check strict, but give it a short retry window

## Tests
- bash -n scripts/ci/main-bootstrap-controller-update.sh
- git diff --check
- bash scripts/ci/pr-lightweight-checks.sh