### PR TITLE
Stabilize hostd telemetry session coexistence

### DIFF
--- a/hostd/src/app/hostd_controller_transport_support.cpp
+++ b/hostd/src/app/hostd_controller_transport_support.cpp
@@ -207,6 +207,20 @@ HttpResponse SendControllerHttpRequest(
   return ParseHttpResponse(response_text);
 }
 
+std::string ResponseBodyExcerpt(std::string body) {
+  body = Trim(body);
+  for (char& ch : body) {
+    if (ch == '\n' || ch == '\r' || ch == '\t') {
+      ch = ' ';
+    }
+  }
+  constexpr std::size_t kMaxExcerptSize = 240;
+  if (body.size() > kMaxExcerptSize) {
+    body.resize(kMaxExcerptSize);
+  }
+  return body;
+}
+
 }  // namespace
 
 std::string Trim(const std::string& value) {
@@ -234,12 +248,25 @@ nlohmann::json SendControllerJsonRequest(
           path,
           payload.is_null() ? std::string{} : payload.dump(),
           headers);
-  const json body = response.body.empty() ? json::object() : json::parse(response.body);
+  json body = json::object();
+  if (!response.body.empty()) {
+    try {
+      body = json::parse(response.body);
+    } catch (const std::exception&) {
+      if (response.status_code < 400) {
+        throw;
+      }
+    }
+  }
   if (response.status_code >= 400) {
+    if (body.contains("message") && body["message"].is_string()) {
+      throw std::runtime_error(body.value("message", "controller request failed"));
+    }
     throw std::runtime_error(
         body.contains("error") && body["error"].is_object()
             ? body["error"].value("message", "controller request failed")
-            : "controller request failed with status " + std::to_string(response.status_code));
+            : "controller request failed with status " + std::to_string(response.status_code) +
+                  (response.body.empty() ? "" : ": " + ResponseBodyExcerpt(response.body)));
   }
   return body;
 }

--- a/hostd/src/backend/http_hostd_backend.cpp
+++ b/hostd/src/backend/http_hostd_backend.cpp
@@ -47,7 +47,7 @@ std::optional<naim::HostAssignment> HttpHostdBackend::ClaimNextHostAssignment(
       nlohmann::json{
           {"node_name", node_name},
           {"preferred_control_transport", "http-long-poll"},
-          {"wait_ms", 15000},
+          {"wait_ms", 1000},
       },
       "assignments/next");
   if (!payload.contains("assignment") || payload["assignment"].is_null()) {

--- a/launcher/src/run/launcher_run_service.cpp
+++ b/launcher/src/run/launcher_run_service.cpp
@@ -830,10 +830,6 @@ int LauncherRunService::RunHostdLoop(
               options.node_name,
               options.storage_root);
           while (!telemetry_runtime_stop.load()) {
-            if (!options.controller_url.empty() && apply_session_owner_active.load()) {
-              std::this_thread::sleep_for(std::chrono::milliseconds(250));
-              continue;
-            }
             auto item = telemetry_bus.WaitPop(telemetry_runtime_stop);
             if (!item.has_value()) {
               continue;


### PR DESCRIPTION
## Summary
- keep hostd telemetry publishing while apply-next-assignment is active and let backend session recovery handle token rotation
- reduce idle assignment long-poll time to avoid holding host sessions open without work
- make hostd controller transport report non-JSON HTTP errors instead of surfacing JSON parse failures

## Tests
- cmake --build build/macos/arm64 --target naim-hostd naim-node -j 8
- ./build/macos/arm64/naim-hostd-bootstrap-transfer-support-tests
- ./build/macos/arm64/naim-hostd-bootstrap-model-support-factory-tests
- git diff --check
- bash scripts/ci/pr-lightweight-checks.sh