### PR TITLE
Cancel stale production release runs

### DIFF
--- a/.github/workflows/naim-production-release.yml
+++ b/.github/workflows/naim-production-release.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: naim-production-main
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"


### PR DESCRIPTION
## Summary
- let newer main production releases cancel stale in-progress runs in the same concurrency group
- prevents old release attempts with obsolete gates from blocking the fixed release

## Tests
- git diff --check
- bash scripts/ci/pr-lightweight-checks.sh