### PR TITLE
Avoid telemetry session churn during apply

### DIFF
--- a/launcher/src/run/launcher_run_service.cpp
+++ b/launcher/src/run/launcher_run_service.cpp
@@ -830,6 +830,10 @@ int LauncherRunService::RunHostdLoop(
               options.node_name,
               options.storage_root);
           while (!telemetry_runtime_stop.load()) {
+            if (!options.controller_url.empty() && apply_session_owner_active.load()) {
+              std::this_thread::sleep_for(std::chrono::milliseconds(250));
+              continue;
+            }
             auto item = telemetry_bus.WaitPop(telemetry_runtime_stop);
             if (!item.has_value()) {
               continue;


### PR DESCRIPTION
## Summary
- pause remote telemetry publishing while an apply child owns the host session
- keep the short 1s assignment long-poll and handoff gap so telemetry still publishes between idle apply polls
- avoids noisy invalid-session warnings during active apply without reintroducing the old 15s telemetry starvation

## Tests
- cmake --build build/macos/arm64 --target naim-node -j 8
- git diff --check
- bash scripts/ci/pr-lightweight-checks.sh