### PR TITLE
Fix hostd plane runtime recreation

### DIFF
--- a/hostd/src/app/hostd_compose_runtime_support.cpp
+++ b/hostd/src/app/hostd_compose_runtime_support.cpp
@@ -83,7 +83,7 @@ void HostdComposeRuntimeSupport::RunComposeCommand(
 
   std::string effective_subcommand = subcommand;
   if (subcommand == "up -d") {
-    effective_subcommand += " --remove-orphans";
+    effective_subcommand += " --remove-orphans --force-recreate";
   }
   const std::string command =
       command_support_.ResolvedDockerComposeCommand() + " -f " +


### PR DESCRIPTION
## Summary
- force docker compose to recreate plane containers during hostd apply
- prevents stale containers from keeping deleted plane shared-disk loop mounts after WebUI delete/create flows

## Test
- cmake --build build/e2e-fix --target naim-hostd-desired-state-apply-plan-support-tests -j 6
- ./build/e2e-fix/naim-hostd-desired-state-apply-plan-support-tests