### PR TITLE
Fix plane detail refresh and telemetry latency

### DIFF
--- a/controller/src/telemetry/telemetry_health_builder.cpp
+++ b/controller/src/telemetry/telemetry_health_builder.cpp
@@ -27,13 +27,14 @@ nlohmann::json TelemetryHealthBuilder::BuildHealth(
       thresholds,
       now_ms);
   std::string status = "ok";
-  if (!alerts.empty()) {
-    status = "degraded";
-    for (const auto& alert : alerts) {
-      if (alert.value("severity", std::string{}) == "critical") {
-        status = "critical";
-        break;
-      }
+  for (const auto& alert : alerts) {
+    const auto severity = alert.value("severity", std::string{});
+    if (severity == "critical") {
+      status = "critical";
+      break;
+    }
+    if (severity == "warning") {
+      status = "degraded";
     }
   }
   return nlohmann::json{

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -416,6 +416,18 @@ void TestGpuUnavailableStorageNodeDoesNotDegradeHealth() {
 void TestStreamMetricsAndOpenMetrics() {
   auto& store = naim::controller::TelemetryLiveStore::Instance();
   store.ResetForTests();
+  const auto replay_db_path =
+      (std::filesystem::temp_directory_path() / "naim-telemetry-replay-health-test.sqlite").string();
+  store.ConfigurePersistence(replay_db_path);
+  Expect(store.Upsert(MakeFrame("node-replay", "plane-replay", CurrentMillis())), "replay frame");
+  store.RecordStreamReplayRequired("live");
+  const auto replay_health = store.BuildHealth(std::string("plane-replay"));
+  Expect(
+      replay_health.at("status").get<std::string>() == "ok",
+      "stream replay alone should not degrade telemetry health");
+  std::filesystem::remove(replay_db_path);
+  store.ResetForTests();
+
   Expect(store.Upsert(MakeFrame("node-metrics", "plane-metrics", CurrentMillis())), "metrics frame");
   store.RecordStreamOpened("live");
   store.RecordStreamOpened("live");

--- a/controller/src/telemetry/telemetry_pipeline_alert_builder.cpp
+++ b/controller/src/telemetry/telemetry_pipeline_alert_builder.cpp
@@ -34,7 +34,7 @@ nlohmann::json TelemetryPipelineAlertBuilder::Build(
   if (streams.telemetry.replay_required_total > 0 || streams.live.replay_required_total > 0) {
     alerts.push_back(nlohmann::json{
         {"code", "telemetry.stream.replay_required"},
-        {"severity", "warning"},
+        {"severity", "info"},
         {"message", "telemetry stream replay was required"},
         {"telemetry_replay_required_total", streams.telemetry.replay_required_total},
         {"live_replay_required_total", streams.live.replay_required_total},

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -66,6 +66,7 @@ import {
 } from "./telemetryHostObservations.js";
 import {
   buildTelemetryBrowserLatency,
+  latestTelemetryFramesByNode,
   maxTelemetryReceiveDelayMs,
   parseTelemetryEventPayload,
   telemetryFramesFromSnapshot,
@@ -3695,13 +3696,20 @@ function App() {
     const refreshDelay = selectedPage === "dashboard" ? FLEET_REFRESH_MS : AUTO_REFRESH_MS;
     const timer = setInterval(() => {
       if (selectedPlane && selectedPage === "dashboard") {
-        refreshSelectedPlaneLive(selectedPlane);
+        const selectedPlaneDetailLoaded =
+          planeDetail?.plane_name === selectedPlane ||
+          (planeDetail?.planes || []).some((item) => item?.name === selectedPlane);
+        if (selectedPlaneDetailLoaded) {
+          refreshSelectedPlaneLive(selectedPlane);
+        } else {
+          refreshAll(selectedPlane);
+        }
         return;
       }
       refreshAll(selectedPlane);
     }, refreshDelay);
     return () => clearInterval(timer);
-  }, [authState.authenticated, selectedPlane, selectedPage]);
+  }, [authState.authenticated, selectedPlane, selectedPage, planeDetail]);
 
   useEffect(() => {
     globalHostObservationsRef.current = globalHostObservations;
@@ -3825,7 +3833,7 @@ function App() {
         );
       }
       const nextGlobalLatency = buildTelemetryBrowserLatency({
-        frames: validFrames,
+        frames: globalResult.acceptedFrames,
         receivedAtMs,
         parseMs,
         reduceMs,
@@ -3969,7 +3977,9 @@ function App() {
           }
           const nextGlobalLatency = {
             receivedAtMs: Date.now(),
-            receiveDelayMs: maxTelemetryReceiveDelayMs(frames),
+            receiveDelayMs: maxTelemetryReceiveDelayMs(
+              latestTelemetryFramesByNode(globalResult.acceptedFrames),
+            ),
             parseMs: 0,
             reduceMs: 0,
             applyMs: 0,
@@ -4068,7 +4078,10 @@ function App() {
   const desiredState = planeDetail?.desired_state || null;
   const desiredStateV2 = planeDetail?.desired_state_v2 || null;
   const planeRecord =
-    planeDetail?.planes?.find((item) => item.name === selectedPlane) || null;
+    planeDetail?.planes?.find((item) => item.name === selectedPlane) ||
+    dashboard?.planes?.find((item) => item.name === selectedPlane) ||
+    planes.find((item) => item.name === selectedPlane) ||
+    null;
   const planeMode =
     dashboard?.plane?.plane_mode ||
     desiredState?.plane_mode ||

--- a/ui/operator-react/src/telemetryStreamClient.js
+++ b/ui/operator-react/src/telemetryStreamClient.js
@@ -18,6 +18,20 @@ export function maxTelemetryReceiveDelayMs(frames) {
   );
 }
 
+export function latestTelemetryFramesByNode(frames) {
+  const byNode = new Map();
+  for (const frame of frames || []) {
+    if (!frame?.node_name) {
+      continue;
+    }
+    const previous = byNode.get(frame.node_name);
+    if (Number(frame?.sequence || 0) >= Number(previous?.sequence || 0)) {
+      byNode.set(frame.node_name, frame);
+    }
+  }
+  return [...byNode.values()];
+}
+
 export function buildTelemetryBrowserLatency({
   frames,
   receivedAtMs,
@@ -26,9 +40,10 @@ export function buildTelemetryBrowserLatency({
   applyStartedAt,
   acceptedFrames,
 }) {
+  const latestFrames = latestTelemetryFramesByNode(frames);
   return {
     receivedAtMs,
-    receiveDelayMs: maxTelemetryReceiveDelayMs(frames),
+    receiveDelayMs: maxTelemetryReceiveDelayMs(latestFrames),
     parseMs,
     reduceMs,
     applyMs: performance.now() - applyStartedAt,

--- a/ui/operator-react/src/telemetryStreamClient.test.js
+++ b/ui/operator-react/src/telemetryStreamClient.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildTelemetryBrowserLatency,
+  latestTelemetryFramesByNode,
   maxTelemetryReceiveDelayMs,
   parseTelemetryEventPayload,
   telemetryFramesFromSnapshot,
@@ -29,8 +30,8 @@ describe("telemetryStreamClient", () => {
   it("builds browser latency samples from enriched frames", () => {
     const latency = buildTelemetryBrowserLatency({
       frames: [
-        { telemetry_browser_receive_delay_ms: 12 },
-        { telemetry_browser_receive_delay_ms: 18 },
+        { node_name: "node-a", sequence: 1, telemetry_browser_receive_delay_ms: 12 },
+        { node_name: "node-b", sequence: 2, telemetry_browser_receive_delay_ms: 18 },
       ],
       receivedAtMs: 100,
       parseMs: 1,
@@ -42,5 +43,24 @@ describe("telemetryStreamClient", () => {
     expect(maxTelemetryReceiveDelayMs([])).toBe(0);
     expect(latency.receiveDelayMs).toBe(18);
     expect(latency.acceptedFrames).toBe(2);
+  });
+
+  it("measures browser latency from the latest frame per node", () => {
+    const frames = [
+      { node_name: "node-a", sequence: 100, telemetry_browser_receive_delay_ms: 900 },
+      { node_name: "node-a", sequence: 200, telemetry_browser_receive_delay_ms: 20 },
+      { node_name: "node-b", sequence: 150, telemetry_browser_receive_delay_ms: 40 },
+    ];
+    const latency = buildTelemetryBrowserLatency({
+      frames,
+      receivedAtMs: 250,
+      parseMs: 0,
+      reduceMs: 0,
+      applyStartedAt: performance.now(),
+      acceptedFrames: frames.length,
+    });
+
+    expect(latestTelemetryFramesByNode(frames).map((frame) => frame.sequence)).toEqual([200, 150]);
+    expect(latency.receiveDelayMs).toBe(40);
   });
 });


### PR DESCRIPTION
Fixes WebUI plane detail recovery and telemetry latency display issues found during maglev-service e2e.\n\nChanges:\n- Refresh full plane detail until the selected dashboard plane is loaded, then switch back to lightweight live refresh.\n- Use plane/fleet fallback records so selected planes can render detail while full payload catches up.\n- Compute browser telemetry receive delay from latest accepted frames per node, not historical snapshot frames.\n- Treat telemetry stream replay as informational so reconnect replay alone does not degrade health.\n\nValidation:\n- npm test\n- npm run build\n- cmake --build build/telemetry-debug --target naim-telemetry-live-store-tests -j 6\n- ./build/telemetry-debug/naim-telemetry-live-store-tests