### PR TITLE
Fix runtime proxy queue priority

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,14 @@ target_link_libraries(naim-state-v2-projector-tests PRIVATE naim-common)
 naim_enable_strict_warnings(naim-state-v2-projector-tests)
 
 add_executable(
+  naim-assignment-repository-tests
+  common/src/state/assignment_repository_tests.cpp
+)
+target_include_directories(naim-assignment-repository-tests PRIVATE common/include)
+target_link_libraries(naim-assignment-repository-tests PRIVATE naim-common)
+naim_enable_strict_warnings(naim-assignment-repository-tests)
+
+add_executable(
   naim-compose-renderer-tests
   common/src/planning/compose_renderer_tests.cpp
 )

--- a/common/src/state/assignment_repository.cpp
+++ b/common/src/state/assignment_repository.cpp
@@ -211,6 +211,21 @@ std::optional<HostAssignment> AssignmentRepository::ClaimNextHostAssignment(
       statement.StepDone();
     }
 
+    {
+      Statement statement(
+          db_,
+          "UPDATE host_assignments "
+          "SET status = 'failed', "
+          "status_message = 'runtime HTTP proxy request expired before hostd claimed it', "
+          "updated_at = CURRENT_TIMESTAMP "
+          "WHERE node_name = ?1 "
+          "  AND assignment_type = 'runtime-http-proxy' "
+          "  AND status = 'pending' "
+          "  AND updated_at <= datetime('now', '-45 seconds');");
+      statement.BindText(1, node_name);
+      statement.StepDone();
+    }
+
     std::optional<HostAssignment> assignment;
     {
       Statement statement(
@@ -219,7 +234,14 @@ std::optional<HostAssignment> AssignmentRepository::ClaimNextHostAssignment(
           "assignment_type, desired_state_json, artifacts_root, status, status_message, progress_json "
           "FROM host_assignments "
           "WHERE node_name = ?1 AND status = 'pending' AND attempt_count < max_attempts "
-          "ORDER BY id ASC LIMIT 1;");
+          "ORDER BY "
+          "CASE "
+          "  WHEN assignment_type != 'runtime-http-proxy' THEN 0 "
+          "  WHEN plane_name LIKE 'runtime-http-proxy:webgateway:%' THEN 30 "
+          "  WHEN plane_name LIKE 'runtime-http-proxy:skills:%' THEN 20 "
+          "  WHEN plane_name LIKE 'runtime-http-proxy:knowledge-vault:%' THEN 20 "
+          "  ELSE 10 "
+          "END ASC, id ASC LIMIT 1;");
       statement.BindText(1, node_name);
       if (statement.StepRow()) {
         assignment = ReadHostAssignment(statement.raw());

--- a/common/src/state/assignment_repository_tests.cpp
+++ b/common/src/state/assignment_repository_tests.cpp
@@ -1,0 +1,125 @@
+#include "naim/state/sqlite_store.h"
+
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include <sqlite3.h>
+
+namespace {
+
+void Expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+naim::HostAssignment MakeAssignment(
+    const std::string& node_name,
+    const std::string& plane_name,
+    const std::string& assignment_type = "runtime-http-proxy") {
+  naim::HostAssignment assignment;
+  assignment.node_name = node_name;
+  assignment.plane_name = plane_name;
+  assignment.desired_generation = 0;
+  assignment.max_attempts = 3;
+  assignment.assignment_type = assignment_type;
+  assignment.desired_state_json = "{}";
+  assignment.status = naim::HostAssignmentStatus::Pending;
+  assignment.status_message = "queued by test";
+  return assignment;
+}
+
+std::filesystem::path TempDbPath(const std::string& name) {
+  const auto suffix =
+      std::chrono::steady_clock::now().time_since_epoch().count();
+  return std::filesystem::temp_directory_path() /
+         (name + "-" + std::to_string(suffix) + ".sqlite");
+}
+
+void ExecSql(const std::filesystem::path& db_path, const std::string& sql) {
+  sqlite3* db = nullptr;
+  if (sqlite3_open(db_path.string().c_str(), &db) != SQLITE_OK) {
+    const std::string message = db == nullptr ? "unknown" : sqlite3_errmsg(db);
+    if (db != nullptr) {
+      sqlite3_close(db);
+    }
+    throw std::runtime_error("failed to open test sqlite db: " + message);
+  }
+  char* error_message = nullptr;
+  const int rc = sqlite3_exec(db, sql.c_str(), nullptr, nullptr, &error_message);
+  if (rc != SQLITE_OK) {
+    const std::string message =
+        error_message == nullptr ? "unknown" : error_message;
+    sqlite3_free(error_message);
+    sqlite3_close(db);
+    throw std::runtime_error("test sqlite exec failed: " + message);
+  }
+  sqlite3_close(db);
+}
+
+void RuntimeProxyInteractionClaimsAheadOfWebGatewayStatus() {
+  const auto db_path = TempDbPath("naim-assignment-priority-test");
+  naim::ControllerStore store(db_path.string());
+  store.Initialize();
+  store.EnqueueHostAssignments(
+      {MakeAssignment(
+           "hpc1",
+           "runtime-http-proxy:webgateway:maglev-service:webgateway-old"),
+       MakeAssignment("hpc1", "runtime-http-proxy:maglev-service:chat-new")},
+      "test supersede");
+
+  const auto claimed = store.ClaimNextHostAssignment("hpc1");
+  Expect(claimed.has_value(), "expected a claimed assignment");
+  Expect(
+      claimed->plane_name == "runtime-http-proxy:maglev-service:chat-new",
+      "interaction proxy should claim before webgateway status proxy");
+  std::filesystem::remove(db_path);
+  std::cout << "ok: runtime-proxy-interaction-priority\n";
+}
+
+void ExpiredRuntimeProxyPendingAssignmentsAreFailedBeforeClaim() {
+  const auto db_path = TempDbPath("naim-assignment-expiry-test");
+  naim::ControllerStore store(db_path.string());
+  store.Initialize();
+  store.EnqueueHostAssignments(
+      {MakeAssignment("hpc1", "runtime-http-proxy:webgateway:plane:old"),
+       MakeAssignment("hpc1", "regular-plane", "desired-state-apply")},
+      "test supersede");
+  ExecSql(
+      db_path,
+      "UPDATE host_assignments "
+      "SET updated_at = datetime('now', '-120 seconds') "
+      "WHERE assignment_type = 'runtime-http-proxy';");
+
+  const auto claimed = store.ClaimNextHostAssignment("hpc1");
+  Expect(claimed.has_value(), "expected a non-expired assignment");
+  Expect(
+      claimed->assignment_type == "desired-state-apply",
+      "expired runtime proxy should not be claimed ahead of regular work");
+  const auto proxy_assignments = store.LoadHostAssignments(
+      std::optional<std::string>("hpc1"),
+      std::optional<naim::HostAssignmentStatus>(naim::HostAssignmentStatus::Failed),
+      std::optional<std::string>("runtime-http-proxy:webgateway:plane:old"));
+  Expect(
+      proxy_assignments.size() == 1,
+      "expired runtime proxy should be marked failed");
+  std::filesystem::remove(db_path);
+  std::cout << "ok: runtime-proxy-expiry-before-claim\n";
+}
+
+}  // namespace
+
+int main() {
+  try {
+    RuntimeProxyInteractionClaimsAheadOfWebGatewayStatus();
+    ExpiredRuntimeProxyPendingAssignmentsAreFailedBeforeClaim();
+    return 0;
+  } catch (const std::exception& ex) {
+    std::cerr << "assignment_repository_tests failed: " << ex.what() << '\n';
+    return 1;
+  }
+}

--- a/controller/src/browsing/plane_browsing_service.cpp
+++ b/controller/src/browsing/plane_browsing_service.cpp
@@ -251,9 +251,12 @@ nlohmann::json PlaneBrowsingService::BuildStatusPayload(
   const auto* browsing_instance = FindBrowsingInstance(desired_state);
   const auto target = ResolveTarget(desired_state);
   const bool running_plane = plane_state.has_value() && *plane_state == "running";
+  const bool should_probe_runtime =
+      enabled && running_plane && target.has_value() && !target->route_via_hostd_proxy;
   const bool ready =
       enabled && running_plane && target.has_value() &&
-      ProbeWebGatewayTargetOk(db_path, desired_state.plane_name, *target);
+      (target->route_via_hostd_proxy ||
+       ProbeWebGatewayTargetOk(db_path, desired_state.plane_name, *target));
 
   std::string reason = "ready";
   if (!enabled) {
@@ -282,6 +285,10 @@ nlohmann::json PlaneBrowsingService::BuildStatusPayload(
            : nlohmann::json(nullptr)},
       {"webgateway_route_mode",
        target.has_value() ? nlohmann::json(target->route_mode) : nlohmann::json(nullptr)},
+      {"webgateway_status_source",
+       target.has_value() && target->route_via_hostd_proxy
+           ? nlohmann::json("node-aware-target")
+           : nlohmann::json("runtime-probe")},
       {"browser_session_enabled",
        desired_state.browsing.has_value() && desired_state.browsing->policy.has_value()
            ? nlohmann::json(desired_state.browsing->policy->browser_session_enabled)
@@ -296,7 +303,7 @@ nlohmann::json PlaneBrowsingService::BuildStatusPayload(
            : nlohmann::json(false)},
   };
 
-  if (ready) {
+  if (ready && should_probe_runtime) {
     try {
       const auto response = SendPlaneWebGatewayRequest(
           db_path,


### PR DESCRIPTION
## Summary
- stop WebGateway status from using blocking hostd runtime proxy probes for node-owned loopback targets
- expire stale runtime-http-proxy assignments before hostd claims fresh work
- prioritize real interaction runtime proxy assignments ahead of WebGateway status proxy traffic

## Tests
- cmake --build build/telemetry-debug --target naim-assignment-repository-tests naim-plane-skills-tests -j 6
- ./build/telemetry-debug/naim-assignment-repository-tests
- ./build/telemetry-debug/naim-plane-skills-tests
- npm test
- npm run build