### PR TITLE
Fix telemetry snapshot health status

### DIFF
--- a/controller/include/telemetry/telemetry_snapshot_builder.h
+++ b/controller/include/telemetry/telemetry_snapshot_builder.h
@@ -34,6 +34,9 @@ class TelemetrySnapshotBuilder final {
       std::uint64_t now_ms) const;
 
  private:
+  bool HasActiveBackpressure(const nlohmann::json& alerts) const;
+  std::string StatusFromAlerts(const nlohmann::json& alerts, bool overloaded) const;
+
   TelemetryAlertBuilder alert_builder_;
   TelemetryFrameMatcher matcher_;
   TelemetryFrameJsonBuilder frame_json_builder_;

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -198,7 +198,9 @@ void TestBackpressureProjection() {
         "backpressure frame should update");
   }
   const auto snapshot = store.BuildSnapshot(std::string("plane-backpressure"), 600);
-  Expect(snapshot.at("telemetry_overloaded").get<bool>(), "snapshot should expose overload");
+  Expect(
+      !snapshot.at("telemetry_overloaded").get<bool>(),
+      "retention pruning alone should not expose active overload");
   Expect(
       snapshot.at("dropped_frames_total").get<std::uint64_t>() >= 20,
       "snapshot should count dropped frames");
@@ -339,6 +341,12 @@ void TestRecoveredTelemetryCountersDoNotDegradeHealth() {
 
   const auto snapshot = store.BuildSnapshot(std::string("plane-recovered"), 0);
   Expect(
+      snapshot.at("telemetry_health").at("status").get<std::string>() == "ok",
+      "snapshot health should not degrade on recovered counters or retention pruning");
+  Expect(
+      !snapshot.at("telemetry_overloaded").get<bool>(),
+      "snapshot overload should report active backpressure, not historical retention pruning");
+  Expect(
       snapshot.at("nodes").at(0).at("telemetry_health").at("status").get<std::string>() == "ok",
       "node health should not degrade on recovered publish counters");
   std::filesystem::remove(db_path);
@@ -425,6 +433,10 @@ void TestStreamMetricsAndOpenMetrics() {
   Expect(
       replay_health.at("status").get<std::string>() == "ok",
       "stream replay alone should not degrade telemetry health");
+  const auto replay_snapshot = store.BuildSnapshot(std::string("plane-replay"), 0);
+  Expect(
+      replay_snapshot.at("telemetry_health").at("status").get<std::string>() == "ok",
+      "info-only stream replay should not degrade snapshot health");
   std::filesystem::remove(replay_db_path);
   store.ResetForTests();
 

--- a/controller/src/telemetry/telemetry_node_alert_builder.cpp
+++ b/controller/src/telemetry/telemetry_node_alert_builder.cpp
@@ -13,7 +13,7 @@ std::uint64_t TelemetryNodeAlertBuilder::IngestWarningBudgetMs(
           : static_cast<std::uint64_t>(std::max(0, frame.interval_ms));
   return std::max(
       thresholds.ingest_warning_ms,
-      adaptive_interval_ms + thresholds.ingest_warning_ms);
+      adaptive_interval_ms * 2 + thresholds.ingest_warning_ms);
 }
 
 bool TelemetryNodeAlertBuilder::HasActivePublishError(

--- a/controller/src/telemetry/telemetry_snapshot_builder.cpp
+++ b/controller/src/telemetry/telemetry_snapshot_builder.cpp
@@ -5,6 +5,34 @@
 
 namespace naim::controller {
 
+bool TelemetrySnapshotBuilder::HasActiveBackpressure(const nlohmann::json& alerts) const {
+  for (const auto& alert : alerts) {
+    const auto code = alert.value("code", std::string{});
+    if (code == "telemetry.publisher.queue_delay" ||
+        code == "telemetry.publisher.errors" ||
+        code == "telemetry.stream.send_failures") {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string TelemetrySnapshotBuilder::StatusFromAlerts(
+    const nlohmann::json& alerts,
+    const bool overloaded) const {
+  std::string status = overloaded ? "overloaded" : "ok";
+  for (const auto& alert : alerts) {
+    const auto severity = alert.value("severity", std::string{});
+    if (severity == "critical") {
+      return "critical";
+    }
+    if (severity == "warning") {
+      status = "degraded";
+    }
+  }
+  return status;
+}
+
 nlohmann::json TelemetrySnapshotBuilder::BuildSnapshot(
     const std::vector<TelemetryNodeBuffer>& nodes,
     const TelemetryRetentionConfig& retention,
@@ -46,15 +74,14 @@ nlohmann::json TelemetrySnapshotBuilder::BuildSnapshot(
       history.push_back(frame_json_builder_.Build(buffer.history[index], now_ms));
     }
   }
-  const bool overloaded = dropped_frames_total > 0;
   const auto alerts = alert_builder_.Build(
       matched_buffers,
       persistence,
       streams,
       thresholds,
       now_ms);
-  const std::string status =
-      !alerts.empty() ? "degraded" : overloaded ? "overloaded" : "ok";
+  const bool overloaded = HasActiveBackpressure(alerts);
+  const std::string status = StatusFromAlerts(alerts, overloaded);
   return nlohmann::json{
       {"schema_version", "telemetry.snapshot.v2"},
       {"service", "naim-controller"},


### PR DESCRIPTION
## Summary
- make telemetry snapshot health use alert severity instead of treating info alerts as degraded
- report telemetry_overloaded only for active delivery backpressure alerts, not historical retention pruning
- widen adaptive ingest warning budget for idle telemetry cadence

## Tests
- cmake --build build/telemetry-debug --target naim-telemetry-live-store-tests -j 6
- ./build/telemetry-debug/naim-telemetry-live-store-tests
- npm test
- npm run build