### PR TITLE
Fix node telemetry historical counter health

### DIFF
--- a/controller/src/telemetry/telemetry_frame_json_builder.cpp
+++ b/controller/src/telemetry/telemetry_frame_json_builder.cpp
@@ -19,7 +19,7 @@ nlohmann::json TelemetryFrameJsonBuilder::Build(
   payload["last_frame_age_ms"] = controller_ingest_delay_ms;
   payload["telemetry_health_status"] =
       stale ? "stale"
-            : frame.telemetry_dropped_frames > 0 || !frame.last_publish_error.empty() ||
+            : !frame.last_publish_error.empty() ||
                     health_policy_.HasActionableDegradedReason(frame)
                 ? "degraded"
                 : "ok";

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -325,6 +325,7 @@ void TestRecoveredTelemetryCountersDoNotDegradeHealth() {
     auto frame = MakeFrame("node-recovered", "plane-recovered", now - 5000 + index);
     frame.adaptive_interval_ms = 10000;
     frame.adaptive_reason = "idle-no-plane";
+    frame.telemetry_dropped_frames = 12;
     frame.publish_error_count = 2;
     frame.last_publish_error.clear();
     Expect(store.Upsert(frame), "recovered counter frame should update");
@@ -348,7 +349,14 @@ void TestRecoveredTelemetryCountersDoNotDegradeHealth() {
       "snapshot overload should report active backpressure, not historical retention pruning");
   Expect(
       snapshot.at("nodes").at(0).at("telemetry_health").at("status").get<std::string>() == "ok",
-      "node health should not degrade on recovered publish counters");
+      "node health should not degrade on historical publisher counters");
+  Expect(
+      snapshot.at("nodes").at(0).at("telemetry_health_status").get<std::string>() == "ok",
+      "frame health should not degrade on historical publisher counters");
+  Expect(
+      snapshot.at("nodes").at(0).at("telemetry_health").at("publisher_dropped_frames_total")
+          .get<std::uint64_t>() == 12,
+      "node health should still expose historical publisher drops");
   std::filesystem::remove(db_path);
   store.ResetForTests();
   std::cout << "ok: telemetry-live-store-recovered-counters-health\n";

--- a/controller/src/telemetry/telemetry_node_health_builder.cpp
+++ b/controller/src/telemetry/telemetry_node_health_builder.cpp
@@ -17,7 +17,6 @@ nlohmann::json TelemetryNodeHealthBuilder::Build(
   if (stale) {
     status = "stale";
   } else if (
-      frame.telemetry_dropped_frames > 0 ||
       !frame.last_publish_error.empty() ||
       health_policy_.HasActionableDegradedReason(frame)) {
     status = "degraded";
@@ -26,6 +25,7 @@ nlohmann::json TelemetryNodeHealthBuilder::Build(
       {"status", status},
       {"last_frame_age_ms", controller_ingest_delay_ms},
       {"dropped_frames_total", buffer.dropped_frames_total},
+      {"publisher_dropped_frames_total", frame.telemetry_dropped_frames},
       {"publish_error_count", frame.publish_error_count},
       {"publish_error", frame.last_publish_error},
       {"degraded_reason", frame.degraded_reason},


### PR DESCRIPTION
## Summary
- keep historical publisher dropped frames visible without degrading node health
- align frame telemetry_health_status with node health semantics
- cover recovered historical publisher counters in telemetry live store tests

## Tests
- cmake --build build/telemetry-debug --target naim-telemetry-live-store-tests -j 6
- ./build/telemetry-debug/naim-telemetry-live-store-tests
- npm test
- npm run build