### PR TITLE
Fix UI telemetry overload state

### DIFF
--- a/ui/operator-react/src/telemetryStore.js
+++ b/ui/operator-react/src/telemetryStore.js
@@ -63,10 +63,12 @@ export function reduceTelemetryStore(store, frames, planeName = "") {
       Number(frame?.controller_dropped_frames_total ?? frame?.telemetry_dropped_frames ?? 0),
     ),
   );
-  const overloaded =
-    Boolean(current.overloaded) ||
-    acceptedFrames.some((frame) => frame?.telemetry_overloaded === true) ||
-    droppedFramesTotal > 0;
+  const overloadFrames = acceptedFrames.filter(
+    (frame) => typeof frame?.telemetry_overloaded === "boolean",
+  );
+  const overloaded = overloadFrames.length > 0
+    ? overloadFrames.some((frame) => frame.telemetry_overloaded === true)
+    : Boolean(current.overloaded);
   const replayRequired =
     Boolean(current.lastReplayRequired) ||
     acceptedFrames.some((frame) => frame?.replay?.required === true);
@@ -126,7 +128,10 @@ export function applyTelemetrySnapshotMetadata(store, payload) {
       Number(current.droppedFramesTotal || 0),
       Number(payload?.dropped_frames_total || replay?.dropped_frames_total || 0),
     ),
-    overloaded: Boolean(current.overloaded) || payload?.telemetry_overloaded === true,
+    overloaded:
+      typeof payload?.telemetry_overloaded === "boolean"
+        ? payload.telemetry_overloaded
+        : Boolean(current.overloaded),
     lastReplayRequired: replay?.required === true,
     lastReplayReason: replay?.reason || current.lastReplayReason || "",
     browserLatency: current.browserLatency || createTelemetryStore().browserLatency,

--- a/ui/operator-react/src/telemetryStore.test.js
+++ b/ui/operator-react/src/telemetryStore.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  applyTelemetrySnapshotMetadata,
   createTelemetryStore,
   enrichTelemetryFrames,
   reduceTelemetryStore,
@@ -37,5 +38,36 @@ describe("telemetryStore", () => {
     expect(result.changed).toBe(true);
     expect(result.store.browserLatency.receiveDelayMs).toBe(250);
     expect(result.store.browserLatency.applyMs).toBe(3);
+  });
+
+  it("does not treat historical dropped frame counters as active overload", () => {
+    const result = reduceTelemetryStore(createTelemetryStore(), [
+      {
+        node_name: "node-a",
+        plane_name: "plane-a",
+        sequence: 1000,
+        controller_dropped_frames_total: 25,
+        telemetry_dropped_frames: 4,
+      },
+    ]);
+
+    expect(result.changed).toBe(true);
+    expect(result.store.droppedFramesTotal).toBe(25);
+    expect(result.store.overloaded).toBe(false);
+  });
+
+  it("lets snapshot metadata clear recovered overload state", () => {
+    const overloaded = {
+      ...createTelemetryStore(),
+      overloaded: true,
+      droppedFramesTotal: 10,
+    };
+    const recovered = applyTelemetrySnapshotMetadata(overloaded, {
+      telemetry_overloaded: false,
+      dropped_frames_total: 12,
+    });
+
+    expect(recovered.droppedFramesTotal).toBe(12);
+    expect(recovered.overloaded).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- stop treating historical dropped frame counters as active UI telemetry overload
- let snapshot metadata clear recovered overload state
- add UI store tests for recovered telemetry counters

## Tests
- npm test
- npm run build