### PR TITLE
Fix telemetry overload source of truth

### DIFF
--- a/ui/operator-react/src/telemetryStore.js
+++ b/ui/operator-react/src/telemetryStore.js
@@ -63,12 +63,7 @@ export function reduceTelemetryStore(store, frames, planeName = "") {
       Number(frame?.controller_dropped_frames_total ?? frame?.telemetry_dropped_frames ?? 0),
     ),
   );
-  const overloadFrames = acceptedFrames.filter(
-    (frame) => typeof frame?.telemetry_overloaded === "boolean",
-  );
-  const overloaded = overloadFrames.length > 0
-    ? overloadFrames.some((frame) => frame.telemetry_overloaded === true)
-    : Boolean(current.overloaded);
+  const overloaded = Boolean(current.overloaded);
   const replayRequired =
     Boolean(current.lastReplayRequired) ||
     acceptedFrames.some((frame) => frame?.replay?.required === true);

--- a/ui/operator-react/src/telemetryStore.test.js
+++ b/ui/operator-react/src/telemetryStore.test.js
@@ -56,6 +56,20 @@ describe("telemetryStore", () => {
     expect(result.store.overloaded).toBe(false);
   });
 
+  it("does not treat legacy frame overload flags as authoritative", () => {
+    const result = reduceTelemetryStore(createTelemetryStore(), [
+      {
+        node_name: "node-a",
+        plane_name: "plane-a",
+        sequence: 1000,
+        telemetry_overloaded: true,
+      },
+    ]);
+
+    expect(result.changed).toBe(true);
+    expect(result.store.overloaded).toBe(false);
+  });
+
   it("lets snapshot metadata clear recovered overload state", () => {
     const overloaded = {
       ...createTelemetryStore(),


### PR DESCRIPTION
## Summary
- keep UI telemetry overload state controlled by snapshot metadata
- ignore legacy per-frame telemetry_overloaded flags during live frame reduction
- add regression coverage for legacy frame overload flags

## Tests
- npm test
- npm run build