### PR TITLE
Prevent controller SIGPIPE restarts

### DIFF
--- a/controller/src/http/controller_http_server.cpp
+++ b/controller/src/http/controller_http_server.cpp
@@ -126,6 +126,9 @@ void ControllerHttpServer::InstallSignalHandlers(
   g_controller_http_server_stop_requested = stop_requested;
   ::signal(SIGINT, ControllerHttpServerSignalHandler);
   ::signal(SIGTERM, ControllerHttpServerSignalHandler);
+#if !defined(_WIN32)
+  ::signal(SIGPIPE, SIG_IGN);
+#endif
 }
 
 std::string ControllerHttpServer::BuildSseEventName(

--- a/controller/src/http/controller_http_transport.cpp
+++ b/controller/src/http/controller_http_transport.cpp
@@ -15,6 +15,14 @@ namespace {
 using SocketHandle = naim::platform::SocketHandle;
 using ControllerNetworkManager = naim::controller::ControllerNetworkManager;
 
+int SocketSendFlags() {
+#if defined(MSG_NOSIGNAL)
+  return MSG_NOSIGNAL;
+#else
+  return 0;
+#endif
+}
+
 std::string TrimCopy(const std::string& value) {
   std::size_t start = 0;
   while (start < value.size() &&
@@ -218,7 +226,7 @@ HttpResponse SendControllerHttpRequest(
   const char* data = request_text.c_str();
   std::size_t remaining = request_text.size();
   while (remaining > 0) {
-    const ssize_t written = send(fd, data, remaining, 0);
+    const ssize_t written = send(fd, data, remaining, SocketSendFlags());
     if (written <= 0) {
       const std::string error = ControllerNetworkManager::SocketErrorMessage();
       ControllerNetworkManager::CloseSocket(fd);

--- a/controller/src/infra/controller_network_manager.cpp
+++ b/controller/src/infra/controller_network_manager.cpp
@@ -8,6 +8,18 @@
 
 namespace naim::controller {
 
+namespace {
+
+int SocketSendFlags() {
+#if defined(MSG_NOSIGNAL)
+  return MSG_NOSIGNAL;
+#else
+  return 0;
+#endif
+}
+
+}  // namespace
+
 std::string ControllerNetworkManager::LowercaseCopy(const std::string& value) {
   std::string lowered;
   lowered.reserve(value.size());
@@ -40,7 +52,7 @@ bool ControllerNetworkManager::SendAll(
   const char* data = payload.c_str();
   std::size_t remaining = payload.size();
   while (remaining > 0) {
-    const ssize_t written = send(fd, data, remaining, 0);
+    const ssize_t written = send(fd, data, remaining, SocketSendFlags());
     if (written <= 0) {
       return false;
     }


### PR DESCRIPTION
## Summary
- ignore SIGPIPE in the controller HTTP server
- use MSG_NOSIGNAL for controller socket writes where available
- prevents aborted WebUI polling/SSE connections from terminating the controller during plane delete/start flows

## Tests
- cmake --build build/codex-debug --target naim-controller -j 6
- cmake --build build/codex-debug --target naim-controller-plane-deletion-tests naim-hostd-http-tests -j 6
- ./build/codex-debug/naim-controller-plane-deletion-tests
- ./build/codex-debug/naim-hostd-http-tests