### PR TITLE
Fix WebUI e2e model path defaults

### DIFF
--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -1909,7 +1909,7 @@ int main() {
                       {{{"name", "whisper"},
                         {"source",
                          {{"type", "library"},
-                          {"path", "/mnt/shared-storage/models/whisper/ggml-base.bin"}}},
+                          {"path", "/models/whisper/ggml-base.bin"}}},
                         {"mount_path", "/models/whisper/ggml-base.bin"},
                         {"env", "WHISPER_MODEL_PATH"},
                         {"required", true}}})}}})},
@@ -1921,7 +1921,7 @@ int main() {
       Expect(voice.environment.at("WHISPER_MODEL_PATH") == "/models/whisper/ggml-base.bin",
              "app-model-plane: model env should point to container mount path");
       Expect(voice.app_model_mounts.front().source_path ==
-                 "/mnt/shared-storage/models/whisper/ggml-base.bin",
+                 "/models/whisper/ggml-base.bin",
              "app-model-plane: source path should be retained");
       const auto compose_plans = naim::BuildNodeComposePlans(state);
       const auto& service = *std::find_if(
@@ -1974,9 +1974,9 @@ int main() {
                {{"name", "whisper"},
                 {"source",
                  {{"type", "library"},
-                  {"path", "/mnt/shared-storage/models/whisper/ggml-base.bin"},
+                  {"path", "/models/whisper/ggml-base.bin"},
                   {"node", "storage1"},
-                  {"paths", json::array({"/mnt/shared-storage/models/whisper/ggml-base.bin"})}}},
+                  {"paths", json::array({"/models/whisper/ggml-base.bin"})}}},
                 {"mount_path", "/models/whisper/ggml-base.bin"},
                 {"env", "WHISPER_MODEL_PATH"},
                 {"required", true}}}}}}}
@@ -2037,7 +2037,7 @@ int main() {
                {{"name", "whisper"},
                 {"source",
                  {{"type", "library"},
-                  {"path", "/mnt/shared-storage/models/whisper/ggml-base.bin"}}},
+                  {"path", "/models/whisper/ggml-base.bin"}}},
                 {"mount_path", "/models/whisper/ggml-base.bin"},
                 {"env", "WHISPER_MODEL_PATH"},
                 {"required", true}}}}}}},

--- a/config/naim-node-config.json
+++ b/config/naim-node-config.json
@@ -1,6 +1,6 @@
 {
   "paths": {
     "storage_root": "/mnt/shared-storage/naim",
-    "model_cache_root": "/mnt/shared-storage/models"
+    "model_cache_root": "/var/lib/naim/models"
   }
 }

--- a/config/v2-llama-rpc-backend/desired-state.v2.json
+++ b/config/v2-llama-rpc-backend/desired-state.v2.json
@@ -6,12 +6,12 @@
   "model": {
     "source": {
       "type": "local",
-      "path": "/mnt/shared-storage/models/gguf/Qwen3.5-9B",
+      "path": "/models/gguf/Qwen3.5-9B",
       "ref": "Qwen/Qwen3.5-9B"
     },
     "materialization": {
       "mode": "reference",
-      "local_path": "/mnt/shared-storage/models/gguf/Qwen3.5-9B"
+      "local_path": "/models/gguf/Qwen3.5-9B"
     },
     "served_model_name": "qwen3.5-9b-rpc"
   },

--- a/config/v2-llama-rpc-replicas/desired-state.v2.json
+++ b/config/v2-llama-rpc-replicas/desired-state.v2.json
@@ -6,12 +6,12 @@
   "model": {
     "source": {
       "type": "local",
-      "path": "/mnt/shared-storage/models/gguf/Qwen3.5-9B",
+      "path": "/models/gguf/Qwen3.5-9B",
       "ref": "Qwen/Qwen3.5-9B"
     },
     "materialization": {
       "mode": "reference",
-      "local_path": "/mnt/shared-storage/models/gguf/Qwen3.5-9B"
+      "local_path": "/models/gguf/Qwen3.5-9B"
     },
     "served_model_name": "qwen3.5-9b-rpc-replicas"
   },

--- a/config/v2-llm-backend-only/desired-state.v2.json
+++ b/config/v2-llm-backend-only/desired-state.v2.json
@@ -5,12 +5,12 @@
   "model": {
     "source": {
       "type": "local",
-      "path": "/mnt/shared-storage/models/gguf/Qwen/Qwen3.5-9B-Q4_K_M.gguf",
+      "path": "/models/gguf/Qwen/Qwen3.5-9B-Q4_K_M.gguf",
       "ref": "Qwen/Qwen3.5-9B"
     },
     "materialization": {
       "mode": "reference",
-      "local_path": "/mnt/shared-storage/models/gguf/Qwen/Qwen3.5-9B-Q4_K_M.gguf"
+      "local_path": "/models/gguf/Qwen/Qwen3.5-9B-Q4_K_M.gguf"
     },
     "served_model_name": "qwen3.5-9b-maglev"
   },

--- a/config/v2-llm-with-app/desired-state.v2.json
+++ b/config/v2-llm-with-app/desired-state.v2.json
@@ -5,12 +5,12 @@
   "model": {
     "source": {
       "type": "local",
-      "path": "/mnt/shared-storage/models/gguf/Qwen/Qwen3.5-9B-Q4_K_M.gguf",
+      "path": "/models/gguf/Qwen/Qwen3.5-9B-Q4_K_M.gguf",
       "ref": "Qwen/Qwen3.5-9B"
     },
     "materialization": {
       "mode": "reference",
-      "local_path": "/mnt/shared-storage/models/gguf/Qwen/Qwen3.5-9B-Q4_K_M.gguf"
+      "local_path": "/models/gguf/Qwen/Qwen3.5-9B-Q4_K_M.gguf"
     },
     "served_model_name": "qwen3.5-9b-app"
   },

--- a/config/v2-maglev-35b-2gpu/desired-state.v2.json
+++ b/config/v2-maglev-35b-2gpu/desired-state.v2.json
@@ -6,12 +6,12 @@
   "model": {
     "source": {
       "type": "local",
-      "path": "/mnt/shared-storage/models/Google/Gemma-4-31B-it/Gemma-4-31B-it-Q8_0.gguf",
+      "path": "/models/Google/Gemma-4-31B-it/Gemma-4-31B-it-Q8_0.gguf",
       "ref": "Google/Gemma-4-31B-it"
     },
     "materialization": {
       "mode": "reference",
-      "local_path": "/mnt/shared-storage/models/Google/Gemma-4-31B-it/Gemma-4-31B-it-Q8_0.gguf"
+      "local_path": "/models/Google/Gemma-4-31B-it/Gemma-4-31B-it-Q8_0.gguf"
     },
     "served_model_name": "gemma-4-31b-it-maglev"
   },

--- a/controller/src/model/model_library_service.cpp
+++ b/controller/src/model/model_library_service.cpp
@@ -67,16 +67,6 @@ bool LooksLikeJobMetadataFilename(const std::string& filename) {
              kJobMetadataSuffix.data()) == 0;
 }
 
-bool ShouldScanDefaultModelRoots(const std::string& db_path) {
-  std::error_code error;
-  const auto normalized = std::filesystem::weakly_canonical(db_path, error);
-  if (error) {
-    return false;
-  }
-  return normalized == "/var/lib/naim-node/hostd-state/controller.sqlite" ||
-         normalized == "/var/lib/naim-node/controller.sqlite";
-}
-
 bool IsDownloadJobComplete(
     const naim::ModelLibraryDownloadJobRecord& job) {
   if (job.status != "completed") {
@@ -1379,16 +1369,6 @@ std::vector<std::string> ModelLibraryService::DiscoverRoots(
     }
     if (IsUsableAbsoluteHostPath(summary.storage_root)) {
       roots.insert(NormalizePathString(std::filesystem::path(summary.storage_root)));
-    }
-  }
-  if (ShouldScanDefaultModelRoots(db_path)) {
-    for (const std::string& candidate : {
-             std::string("/mnt/shared-storage/models"),
-             std::string("/mnt/shared-storage/models/gguf"),
-         }) {
-      if (IsUsableAbsoluteHostPath(candidate)) {
-        roots.insert(NormalizePathString(candidate));
-      }
     }
   }
   if (const char* env_value = std::getenv("NAIM_NODE_MODEL_LIBRARY_ROOTS");

--- a/scripts/llama-rpc-replica-benchmark.sh
+++ b/scripts/llama-rpc-replica-benchmark.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="${BUILD_DIR:-$ROOT_DIR/build/local-debug}"
-MODEL_PATH="${MODEL_PATH:-/mnt/shared-storage/models/gguf/Qwen/Qwen3.5-9B/Qwen3.5-9B-Q4_K_M.gguf}"
+MODEL_PATH="${MODEL_PATH:-}"
 SERVED_MODEL="${SERVED_MODEL:-qwen3.5-9b-q4km-rpc}"
 THREADS="${THREADS:-8}"
 CTX_SIZE="${CTX_SIZE:-8192}"
@@ -39,6 +39,11 @@ WORKER_BIN="$BUILD_DIR/naim-workerd"
 INFER_BIN="$BUILD_DIR/naim-inferctl"
 BENCH_BIN="$ROOT_DIR/scripts/benchmark-openai-multi-base.sh"
 DEVTOOL_BIN="$ROOT_DIR/scripts/naim-devtool.sh"
+
+if [[ -z "$MODEL_PATH" ]]; then
+  echo "MODEL_PATH must point to a GGUF model artifact" >&2
+  exit 2
+fi
 
 cleanup() {
   set +e

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -3910,10 +3910,7 @@ function App() {
     const source = new EventSource(
       queryPath("/api/v1/live/stream", {
         limit: EVENT_LIMIT,
-        plane: selectedPlane || undefined,
-        since_sequence: selectedPlane
-          ? planeTelemetryStoreRef.current?.latestSequence || undefined
-          : globalTelemetryStoreRef.current?.latestSequence || undefined,
+        since_sequence: globalTelemetryStoreRef.current?.latestSequence || undefined,
       }),
     );
     telemetrySourceRef.current = source;
@@ -3963,7 +3960,7 @@ function App() {
         telemetrySourceRef.current = null;
       }
     };
-  }, [authState.authenticated, selectedPlane]);
+  }, [authState.authenticated]);
 
   useEffect(() => {
     if (!authState.authenticated || telemetryHealthy) {


### PR DESCRIPTION
## Summary
- remove private default model library roots from controller discovery
- stop reconnecting telemetry SSE when selecting a plane in WebUI
- replace sample model paths with neutral paths and require MODEL_PATH for replica benchmark

## Tests
- npm test
- npm run build
- cmake --build build/codex-debug --target naim-model-library-tests naim-state-v2-tests -j 6
- ./build/codex-debug/naim-model-library-tests
- ./build/codex-debug/naim-state-v2-tests