### PR TITLE
Prefer storage roots in model library

### DIFF
--- a/controller/src/model/model_library_service.cpp
+++ b/controller/src/model/model_library_service.cpp
@@ -89,6 +89,10 @@ bool IsDownloadJobComplete(
   return true;
 }
 
+bool AllowsModelLibraryStorageRoot(const ModelLibraryNodeSummary& summary) {
+  return summary.storage_role_enabled || summary.derived_role == "storage";
+}
+
 std::uintmax_t ExistingDownloadBytesForTarget(
     const std::filesystem::path& target_path) {
   std::error_code error;
@@ -141,10 +145,7 @@ json ModelLibraryService::BuildPayload(const std::string& db_path) const {
       if (summary.storage_root.empty()) {
         continue;
       }
-      if (!ModelLibraryNodePlacement::AllowsModelPlacementRole(
-              summary.derived_role,
-              summary.storage_role_enabled,
-              false)) {
+      if (!AllowsModelLibraryStorageRoot(summary)) {
         continue;
       }
       if (NormalizePathString(std::filesystem::path(summary.storage_root)) == entry.root) {
@@ -1361,10 +1362,7 @@ std::vector<std::string> ModelLibraryService::DiscoverRoots(
   std::set<std::string> roots;
   for (const auto& host : store.LoadRegisteredHosts()) {
     const auto summary = ModelLibraryNodePlacement::BuildSummary(host);
-    if (!ModelLibraryNodePlacement::AllowsModelPlacementRole(
-            summary.derived_role,
-            summary.storage_role_enabled,
-            false)) {
+    if (!AllowsModelLibraryStorageRoot(summary)) {
       continue;
     }
     if (IsUsableAbsoluteHostPath(summary.storage_root)) {


### PR DESCRIPTION
## Summary
- stop treating worker storage_root as a Model Library source root
- keep explicit storage-role nodes and env-configured roots as discovery sources
- keep worker model placement paths available for explicit operations without making them default source roots

## Tests
- cmake --build build/codex-debug --target naim-model-library-tests -j 6
- ./build/codex-debug/naim-model-library-tests