### PR TITLE
Handle runtime status read races

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,14 @@ target_link_libraries(naim-model-adapter-tests PRIVATE naim-common)
 naim_enable_strict_warnings(naim-model-adapter-tests)
 
 add_executable(
+  naim-runtime-status-tests
+  common/src/runtime/runtime_status_tests.cpp
+)
+target_include_directories(naim-runtime-status-tests PRIVATE common/include)
+target_link_libraries(naim-runtime-status-tests PRIVATE naim-common)
+naim_enable_strict_warnings(naim-runtime-status-tests)
+
+add_executable(
   naim-state-v2-tests
   common/src/state/desired_state_v2_validator_tests.cpp
 )

--- a/common/src/runtime/runtime_status.cpp
+++ b/common/src/runtime/runtime_status.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <stdexcept>
 
 #include <nlohmann/json.hpp>
@@ -756,8 +757,20 @@ std::optional<RuntimeStatus> RuntimeStatusFileStore::Load(const std::string& pat
     throw std::runtime_error("failed to open runtime status file: " + path);
   }
 
-  json value;
-  input >> value;
+  std::string text(
+      (std::istreambuf_iterator<char>(input)),
+      std::istreambuf_iterator<char>());
+  if (!input.good() && !input.eof()) {
+    throw std::runtime_error("failed to read runtime status file: " + path);
+  }
+  const auto first_non_space = text.find_first_not_of(" \t\r\n");
+  if (first_non_space == std::string::npos) {
+    return std::nullopt;
+  }
+  const json value = json::parse(text, nullptr, false);
+  if (value.is_discarded()) {
+    return std::nullopt;
+  }
   return RuntimeStatusFromJson(value);
 }
 

--- a/common/src/runtime/runtime_status_tests.cpp
+++ b/common/src/runtime/runtime_status_tests.cpp
@@ -1,0 +1,79 @@
+#include "naim/runtime/runtime_status.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void Expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+std::filesystem::path TempPath(const std::string& name) {
+  const auto suffix =
+      std::chrono::steady_clock::now().time_since_epoch().count();
+  return std::filesystem::temp_directory_path() /
+         (name + "-" + std::to_string(suffix) + ".json");
+}
+
+void WriteText(const std::filesystem::path& path, const std::string& text) {
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  if (!output.is_open()) {
+    throw std::runtime_error("failed to open temp file");
+  }
+  output << text;
+}
+
+void EmptyRuntimeStatusFilesAreTreatedAsMissing() {
+  const auto path = TempPath("naim-runtime-status-empty-test");
+  WriteText(path, "");
+  const auto status = naim::LoadRuntimeStatusJson(path.string());
+  Expect(!status.has_value(), "empty runtime status should be treated as missing");
+  std::filesystem::remove(path);
+  std::cout << "ok: empty-runtime-status-is-missing\n";
+}
+
+void PartialRuntimeStatusFilesAreTreatedAsMissing() {
+  const auto path = TempPath("naim-runtime-status-partial-test");
+  WriteText(path, "{");
+  const auto status = naim::LoadRuntimeStatusJson(path.string());
+  Expect(!status.has_value(), "partial runtime status should be treated as missing");
+  std::filesystem::remove(path);
+  std::cout << "ok: partial-runtime-status-is-missing\n";
+}
+
+void ValidRuntimeStatusFilesStillLoad() {
+  const auto path = TempPath("naim-runtime-status-valid-test");
+  naim::RuntimeStatus source;
+  source.ready = true;
+  source.launch_ready = true;
+  source.inference_ready = true;
+  source.runtime_phase = "running";
+  naim::SaveRuntimeStatusJson(source, path.string());
+  const auto status = naim::LoadRuntimeStatusJson(path.string());
+  Expect(status.has_value(), "valid runtime status should load");
+  Expect(status->ready, "valid runtime status should preserve ready flag");
+  Expect(status->runtime_phase == "running", "valid runtime status should preserve phase");
+  std::filesystem::remove(path);
+  std::cout << "ok: valid-runtime-status-loads\n";
+}
+
+}  // namespace
+
+int main() {
+  try {
+    EmptyRuntimeStatusFilesAreTreatedAsMissing();
+    PartialRuntimeStatusFilesAreTreatedAsMissing();
+    ValidRuntimeStatusFilesStillLoad();
+    return 0;
+  } catch (const std::exception& error) {
+    std::cerr << "runtime_status_tests failed: " << error.what() << "\n";
+    return 1;
+  }
+}

--- a/hostd/src/state_apply/hostd_assignment_service.cpp
+++ b/hostd/src/state_apply/hostd_assignment_service.cpp
@@ -41,6 +41,27 @@ void RunBestEffort(const std::string& label, Fn&& fn) {
   }
 }
 
+naim::HostObservation BuildAssignmentObservation(
+    const IHostdAssignmentSupport& support,
+    const naim::HostAssignment& assignment,
+    const std::string& node_name,
+    const std::string& storage_root,
+    const std::string& state_root,
+    naim::HostObservationStatus status,
+    const std::string& status_message) {
+  auto observation = support.BuildObservedStateSnapshot(
+      node_name,
+      storage_root,
+      state_root,
+      status,
+      status_message,
+      assignment.id);
+  if (!assignment.plane_name.empty()) {
+    observation.plane_name = assignment.plane_name;
+  }
+  return observation;
+}
+
 }  // namespace
 
 HostdAssignmentService::HostdAssignmentService(
@@ -380,13 +401,14 @@ void HostdAssignmentService::ApplyNextAssignment(
     RunBestEffort("report applying observed state", [&]() {
       observation_service_.ReportObservedState(
           *backend,
-          support_.BuildObservedStateSnapshot(
+          BuildAssignmentObservation(
+              support_,
+              *assignment,
               node_name,
               storage_root,
               state_root,
               naim::HostObservationStatus::Applying,
-              applying_status_message,
-              assignment->id),
+              applying_status_message),
           "hostd observed-state-update");
     });
 
@@ -416,7 +438,9 @@ void HostdAssignmentService::ApplyNextAssignment(
     RunBestEffort("report applied observed state", [&]() {
       observation_service_.ReportObservedState(
           *backend,
-          support_.BuildObservedStateSnapshot(
+          BuildAssignmentObservation(
+              support_,
+              *assignment,
               node_name,
               storage_root,
               state_root,
@@ -427,8 +451,7 @@ void HostdAssignmentService::ApplyNextAssignment(
                                    : (is_eviction_assignment
                                           ? "evicted rollout workers for desired generation "
                                           : "applied desired generation "))) +
-                  std::to_string(assignment->desired_generation) + assignment_context,
-              assignment->id),
+                  std::to_string(assignment->desired_generation) + assignment_context),
           "hostd observed-state-update");
     });
 
@@ -481,13 +504,14 @@ void HostdAssignmentService::ApplyNextAssignment(
     RunBestEffort("report failed observed state", [&]() {
       observation_service_.ReportObservedState(
           *backend,
-          support_.BuildObservedStateSnapshot(
+          BuildAssignmentObservation(
+              support_,
+              *assignment,
               node_name,
               storage_root,
               state_root,
               naim::HostObservationStatus::Failed,
-              error_message,
-              assignment->id),
+              error_message),
           "hostd observed-state-update");
     });
     if (assignment->attempt_count < assignment->max_attempts) {


### PR DESCRIPTION
## Summary
- treat empty or partially written runtime-status JSON files as not-yet-ready instead of failing host assignments
- keep assignment-scoped host observations attributed to the assignment plane while local aggregate state still points at another plane
- add runtime status file-store coverage for empty, partial, and valid status files

## Tests
- cmake --build build/codex-debug --target naim-runtime-status-tests naim-assignment-repository-tests naim-hostd-http-tests -j 6
- ./build/codex-debug/naim-runtime-status-tests
- ./build/codex-debug/naim-assignment-repository-tests
- ./build/codex-debug/naim-hostd-http-tests
- npm test -- --run
- npm run build