### PR TITLE
Require applied observations for assignment reconciliation

### DIFF
--- a/controller/src/host/host_assignment_reconciliation_service.cpp
+++ b/controller/src/host/host_assignment_reconciliation_service.cpp
@@ -131,7 +131,7 @@ bool HostAssignmentReconciliationService::ShouldMarkClaimedAssignmentApplied(
   }
   if (!observation.has_value() ||
       observation->plane_name != assignment.plane_name ||
-      observation->status == naim::HostObservationStatus::Failed) {
+      observation->status != naim::HostObservationStatus::Applied) {
     return false;
   }
   if (!observation->last_assignment_id.has_value() ||

--- a/controller/src/plane/plane_deletion_support_tests.cpp
+++ b/controller/src/plane/plane_deletion_support_tests.cpp
@@ -322,6 +322,41 @@ int main() {
       store.Initialize();
       const naim::controller::HostAssignmentReconciliationService reconciliation_service;
 
+      store.ReplaceDesiredState(BuildDesiredState("plane-c-applying", {"node-c-applying"}), 2);
+      Expect(
+          store.UpdatePlaneAppliedGeneration("plane-c-applying", 2),
+          "plane-c-applying applied generation should update");
+      store.ReplaceHostAssignments(
+          {BuildHostAssignment(
+              "plane-c-applying",
+              "node-c-applying",
+              2,
+              naim::HostAssignmentStatus::Claimed)});
+      const auto inserted_assignments =
+          store.LoadHostAssignments(std::nullopt, std::nullopt, "plane-c-applying");
+      Expect(inserted_assignments.size() == 1, "plane-c-applying should have one assignment");
+      store.UpsertHostObservation(BuildHostObservation(
+          "plane-c-applying",
+          "node-c-applying",
+          999,
+          naim::HostObservationStatus::Applying,
+          inserted_assignments.front().id));
+
+      const auto result = reconciliation_service.Reconcile(store, "plane-c-applying");
+      const auto assignment = store.LoadHostAssignments(
+          std::nullopt, std::nullopt, "plane-c-applying");
+      Expect(result.applied == 0, "controller should not mark applying observation applied");
+      Expect(assignment.size() == 1, "plane-c-applying should still have one assignment");
+      Expect(
+          assignment.front().status == naim::HostAssignmentStatus::Claimed,
+          "applying observation claimed assignment should remain claimed");
+    }
+
+    {
+      naim::ControllerStore store(db_path.string());
+      store.Initialize();
+      const naim::controller::HostAssignmentReconciliationService reconciliation_service;
+
       store.ReplaceDesiredState(BuildDesiredState("plane-c-stale", {"node-c-stale"}), 7);
       Expect(
           store.UpdatePlaneAppliedGeneration("plane-c-stale", 7),

--- a/hostd/src/state_apply/hostd_assignment_service.cpp
+++ b/hostd/src/state_apply/hostd_assignment_service.cpp
@@ -59,6 +59,11 @@ naim::HostObservation BuildAssignmentObservation(
   if (!assignment.plane_name.empty()) {
     observation.plane_name = assignment.plane_name;
   }
+  if (status == naim::HostObservationStatus::Applied) {
+    observation.applied_generation = assignment.desired_generation;
+  } else {
+    observation.applied_generation = std::nullopt;
+  }
   return observation;
 }
 


### PR DESCRIPTION
## Summary
- require Applied host observations before controller reconciliation marks claimed apply assignments as applied
- clear non-applied assignment observation generations and pin applied observations to the assignment generation
- cover the applying-observation case that previously caused false convergence

## Tests
- cmake --build build/codex-debug --target naim-controller-plane-deletion-tests naim-runtime-status-tests -j 6
- ./build/codex-debug/naim-controller-plane-deletion-tests
- ./build/codex-debug/naim-runtime-status-tests