### PR TITLE
Fix plane-scoped telemetry aggregation

### DIFF
--- a/common/include/naim/runtime/runtime_status.h
+++ b/common/include/naim/runtime/runtime_status.h
@@ -19,6 +19,7 @@ struct RuntimeProcessStatus {
   int runtime_pid = 0;
   int engine_pid = 0;
   bool ready = false;
+  std::string plane_name;
 };
 
 struct GpuProcessTelemetry {

--- a/common/src/runtime/runtime_status.cpp
+++ b/common/src/runtime/runtime_status.cpp
@@ -26,6 +26,7 @@ json ToJson(const RuntimeProcessStatus& status) {
       {"runtime_pid", status.runtime_pid},
       {"engine_pid", status.engine_pid},
       {"ready", status.ready},
+      {"plane_name", status.plane_name},
   };
 }
 
@@ -42,6 +43,7 @@ RuntimeProcessStatus RuntimeProcessStatusFromJson(const json& value) {
   status.runtime_pid = value.value("runtime_pid", 0);
   status.engine_pid = value.value("engine_pid", 0);
   status.ready = value.value("ready", false);
+  status.plane_name = value.value("plane_name", std::string{});
   return status;
 }
 

--- a/controller/include/telemetry/telemetry_frame_matcher.h
+++ b/controller/include/telemetry/telemetry_frame_matcher.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "naim/runtime/runtime_status.h"
 
@@ -12,11 +13,18 @@ class TelemetryFrameMatcher final {
   bool MatchesPlane(
       const naim::HostTelemetryFrame& frame,
       const std::optional<std::string>& plane_name) const;
+  bool RuntimeStatusMatchesPlane(
+      const naim::RuntimeProcessStatus& status,
+      const std::string& plane_name) const;
   std::string PlaneKeyForFrame(const naim::HostTelemetryFrame& frame) const;
+  std::vector<std::string> PlaneKeysForFrame(const naim::HostTelemetryFrame& frame) const;
   double GpuUtilizationAverage(const naim::HostTelemetryFrame& frame) const;
   std::uint64_t ControllerIngestDelayMs(
       const naim::HostTelemetryFrame& frame,
       std::uint64_t now_ms) const;
+
+ private:
+  const std::vector<std::string>& RuntimeInstancePrefixes() const;
 };
 
 }  // namespace naim::controller

--- a/controller/include/telemetry/telemetry_snapshot_builder.h
+++ b/controller/include/telemetry/telemetry_snapshot_builder.h
@@ -36,6 +36,9 @@ class TelemetrySnapshotBuilder final {
  private:
   bool HasActiveBackpressure(const nlohmann::json& alerts) const;
   std::string StatusFromAlerts(const nlohmann::json& alerts, bool overloaded) const;
+  naim::HostTelemetryFrame ScopeFrameToPlane(
+      const naim::HostTelemetryFrame& frame,
+      const std::optional<std::string>& plane_name) const;
 
   TelemetryAlertBuilder alert_builder_;
   TelemetryFrameMatcher matcher_;

--- a/controller/src/telemetry/telemetry_frame_matcher.cpp
+++ b/controller/src/telemetry/telemetry_frame_matcher.cpp
@@ -1,5 +1,8 @@
 #include "telemetry/telemetry_frame_matcher.h"
 
+#include <algorithm>
+#include <set>
+
 namespace naim::controller {
 
 bool TelemetryFrameMatcher::MatchesPlane(
@@ -11,9 +14,26 @@ bool TelemetryFrameMatcher::MatchesPlane(
   if (frame.plane_name == *plane_name) {
     return true;
   }
-  const std::string prefix = *plane_name + "-";
   for (const auto& status : frame.instance_runtime) {
-    if (status.instance_name.rfind(prefix, 0) == 0) {
+    if (RuntimeStatusMatchesPlane(status, *plane_name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool TelemetryFrameMatcher::RuntimeStatusMatchesPlane(
+    const naim::RuntimeProcessStatus& status,
+    const std::string& plane_name) const {
+  if (plane_name.empty()) {
+    return true;
+  }
+  if (status.plane_name == plane_name) {
+    return true;
+  }
+  for (const auto& prefix : RuntimeInstancePrefixes()) {
+    const std::string stem = prefix + plane_name;
+    if (status.instance_name == stem || status.instance_name.rfind(stem + "-", 0) == 0) {
       return true;
     }
   }
@@ -23,6 +43,23 @@ bool TelemetryFrameMatcher::MatchesPlane(
 std::string TelemetryFrameMatcher::PlaneKeyForFrame(
     const naim::HostTelemetryFrame& frame) const {
   return frame.plane_name.empty() ? std::string{"unassigned"} : frame.plane_name;
+}
+
+std::vector<std::string> TelemetryFrameMatcher::PlaneKeysForFrame(
+    const naim::HostTelemetryFrame& frame) const {
+  if (!frame.plane_name.empty()) {
+    return {frame.plane_name};
+  }
+  std::set<std::string> plane_names;
+  for (const auto& status : frame.instance_runtime) {
+    if (!status.plane_name.empty()) {
+      plane_names.insert(status.plane_name);
+    }
+  }
+  if (plane_names.empty()) {
+    return {"unassigned"};
+  }
+  return {plane_names.begin(), plane_names.end()};
 }
 
 double TelemetryFrameMatcher::GpuUtilizationAverage(
@@ -41,6 +78,20 @@ std::uint64_t TelemetryFrameMatcher::ControllerIngestDelayMs(
     const naim::HostTelemetryFrame& frame,
     const std::uint64_t now_ms) const {
   return frame.sequence > 0 && now_ms >= frame.sequence ? now_ms - frame.sequence : 0;
+}
+
+const std::vector<std::string>& TelemetryFrameMatcher::RuntimeInstancePrefixes() const {
+  static const std::vector<std::string> prefixes = {
+      "infer-",
+      "worker-",
+      "skills-",
+      "app-",
+      "webgateway-",
+      "browsing-",
+      "voice-module-",
+      "interaction-",
+  };
+  return prefixes;
 }
 
 }  // namespace naim::controller

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -240,6 +240,76 @@ void TestPlaneAggregatesAndDownsampling() {
   std::cout << "ok: telemetry-live-store-plane-aggregates-downsampling\n";
 }
 
+void TestMultiPlaneNodeTelemetryIsPlaneScoped() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  store.ResetForTests();
+  auto frame = MakeFrame("node-multi-plane", "", CurrentMillis());
+  frame.ttl_ms = 60000;
+  frame.instance_runtime = {
+      naim::RuntimeProcessStatus{
+          "worker-maglev-service",
+          "worker",
+          "node-multi-plane",
+          "/models/qwen",
+          "0",
+          "running",
+          "",
+          "",
+          0,
+          0,
+          true,
+          "maglev-service",
+      },
+      naim::RuntimeProcessStatus{
+          "worker-lt-cypher-ai",
+          "worker",
+          "node-multi-plane",
+          "/models/qwen",
+          "1",
+          "running",
+          "",
+          "",
+          0,
+          0,
+          false,
+          "lt-cypher-ai",
+      },
+  };
+  frame.plane_instance_count = frame.instance_runtime.size();
+  frame.plane_ready_instance_count = 1;
+  frame.plane_not_ready_instance_count = 1;
+  Expect(store.Upsert(frame), "multi-plane node frame should update");
+
+  const auto maglev = store.BuildSnapshot(std::string("maglev-service"), 0);
+  Expect(maglev.at("nodes").size() == 1, "maglev snapshot should match aggregate node frame");
+  Expect(
+      maglev.at("nodes").at(0).at("plane_name").get<std::string>() == "maglev-service",
+      "maglev node frame should be scoped to selected plane");
+  Expect(
+      maglev.at("nodes").at(0).at("instance_runtime").size() == 1,
+      "maglev node frame should include only maglev runtime");
+  Expect(
+      maglev.at("planes").at(0).at("plane_name").get<std::string>() == "maglev-service",
+      "maglev aggregate should be keyed by runtime plane");
+  Expect(
+      maglev.at("planes").at(0).at("runtime").at("instance_count").get<std::uint64_t>() == 1,
+      "maglev aggregate should count only maglev instances");
+  Expect(
+      maglev.at("planes").at(0).at("runtime").at("ready_instance_count").get<std::uint64_t>() == 1,
+      "maglev aggregate should count only maglev ready instances");
+
+  const auto cypher = store.BuildSnapshot(std::string("lt-cypher-ai"), 0);
+  Expect(cypher.at("nodes").size() == 1, "lt-cypher snapshot should match aggregate node frame");
+  Expect(
+      cypher.at("planes").at(0).at("runtime").at("instance_count").get<std::uint64_t>() == 1,
+      "lt-cypher aggregate should count only lt-cypher instances");
+  Expect(
+      cypher.at("planes").at(0).at("runtime").at("ready_instance_count").get<std::uint64_t>() == 0,
+      "lt-cypher aggregate should preserve not-ready status");
+  store.ResetForTests();
+  std::cout << "ok: telemetry-live-store-multi-plane-node-scoping\n";
+}
+
 void TestSqlitePersistenceReplayAndHealth() {
   auto& store = naim::controller::TelemetryLiveStore::Instance();
   const auto db_path =
@@ -417,6 +487,7 @@ void TestGpuUnavailableStorageNodeDoesNotDegradeHealth() {
       0,
       0,
       false,
+      "plane-gpu-runtime",
   });
   Expect(store.Upsert(gpu_runtime_frame), "gpu-bound runtime frame should update");
   const auto gpu_runtime_health = store.BuildHealth(std::string("plane-gpu-runtime"));
@@ -480,6 +551,7 @@ int main() {
     TestCoherenceFieldsAndStaleProjection();
     TestBackpressureProjection();
     TestPlaneAggregatesAndDownsampling();
+    TestMultiPlaneNodeTelemetryIsPlaneScoped();
     TestSqlitePersistenceReplayAndHealth();
     TestConfigurableRetentionAndMetrics();
     TestRecoveredTelemetryCountersDoNotDegradeHealth();

--- a/controller/src/telemetry/telemetry_plane_aggregate_builder.cpp
+++ b/controller/src/telemetry/telemetry_plane_aggregate_builder.cpp
@@ -8,6 +8,43 @@
 
 namespace naim::controller {
 
+namespace {
+
+void AddFrameToPlane(
+    TelemetryPlaneAccumulator& plane,
+    const std::string& plane_name,
+    const naim::HostTelemetryFrame& frame,
+    const TelemetryNodeBuffer& buffer,
+    const nlohmann::json& health,
+    const std::uint64_t ingest_ms,
+    const std::uint64_t scoped_instance_count,
+    const std::uint64_t scoped_ready_instance_count,
+    const std::uint64_t scoped_gpu_count,
+    const double gpu_utilization_average) {
+  if (plane.plane_name.empty()) {
+    plane.plane_name = plane_name;
+  }
+  plane.node_count += 1;
+  plane.latest_sequence = std::max(plane.latest_sequence, frame.sequence);
+  plane.dropped_frames_total += buffer.dropped_frames_total;
+  plane.max_last_frame_age_ms = std::max(plane.max_last_frame_age_ms, ingest_ms);
+  plane.max_queue_delay_ms = std::max(plane.max_queue_delay_ms, frame.publisher_queue_delay_ms);
+  plane.max_publish_ms = std::max(plane.max_publish_ms, frame.publish_duration_ms);
+  plane.max_controller_ingest_ms = std::max(plane.max_controller_ingest_ms, ingest_ms);
+  plane.gpu_count += scoped_gpu_count;
+  plane.plane_instance_count += scoped_instance_count;
+  plane.plane_ready_instance_count += scoped_ready_instance_count;
+  plane.plane_not_ready_instance_count += scoped_instance_count - scoped_ready_instance_count;
+  plane.gpu_utilization_sum += gpu_utilization_average;
+  if (health.value("status", std::string{"ok"}) == "stale") {
+    plane.stale_nodes += 1;
+  } else if (health.value("status", std::string{"ok"}) == "degraded") {
+    plane.degraded_nodes += 1;
+  }
+}
+
+}  // namespace
+
 nlohmann::json TelemetryPlaneAggregateBuilder::Build(
     const std::vector<const TelemetryNodeBuffer*>& buffers,
     const std::uint64_t now_ms) const {
@@ -17,28 +54,36 @@ nlohmann::json TelemetryPlaneAggregateBuilder::Build(
       continue;
     }
     const auto& frame = buffer->latest;
-    auto& plane = planes[matcher_.PlaneKeyForFrame(frame)];
-    if (plane.plane_name.empty()) {
-      plane.plane_name = matcher_.PlaneKeyForFrame(frame);
-    }
     const auto ingest_ms = matcher_.ControllerIngestDelayMs(frame, now_ms);
     const auto health = node_health_builder_.Build(frame, *buffer, now_ms, ingest_ms);
-    plane.node_count += 1;
-    plane.latest_sequence = std::max(plane.latest_sequence, frame.sequence);
-    plane.dropped_frames_total += buffer->dropped_frames_total;
-    plane.max_last_frame_age_ms = std::max(plane.max_last_frame_age_ms, ingest_ms);
-    plane.max_queue_delay_ms = std::max(plane.max_queue_delay_ms, frame.publisher_queue_delay_ms);
-    plane.max_publish_ms = std::max(plane.max_publish_ms, frame.publish_duration_ms);
-    plane.max_controller_ingest_ms = std::max(plane.max_controller_ingest_ms, ingest_ms);
-    plane.gpu_count += frame.gpu.devices.size();
-    plane.plane_instance_count += frame.plane_instance_count;
-    plane.plane_ready_instance_count += frame.plane_ready_instance_count;
-    plane.plane_not_ready_instance_count += frame.plane_not_ready_instance_count;
-    plane.gpu_utilization_sum += matcher_.GpuUtilizationAverage(frame);
-    if (health.value("status", std::string{"ok"}) == "stale") {
-      plane.stale_nodes += 1;
-    } else if (health.value("status", std::string{"ok"}) == "degraded") {
-      plane.degraded_nodes += 1;
+    const auto plane_keys = matcher_.PlaneKeysForFrame(frame);
+    for (const auto& plane_key : plane_keys) {
+      std::uint64_t scoped_instance_count = frame.plane_instance_count;
+      std::uint64_t scoped_ready_instance_count = frame.plane_ready_instance_count;
+      if (frame.plane_name.empty() && plane_key != "unassigned") {
+        scoped_instance_count = 0;
+        scoped_ready_instance_count = 0;
+        for (const auto& status : frame.instance_runtime) {
+          if (!matcher_.RuntimeStatusMatchesPlane(status, plane_key)) {
+            continue;
+          }
+          ++scoped_instance_count;
+          if (status.ready) {
+            ++scoped_ready_instance_count;
+          }
+        }
+      }
+      AddFrameToPlane(
+          planes[plane_key],
+          plane_key,
+          frame,
+          *buffer,
+          health,
+          ingest_ms,
+          scoped_instance_count,
+          scoped_ready_instance_count,
+          frame.gpu.devices.size(),
+          matcher_.GpuUtilizationAverage(frame));
     }
   }
   nlohmann::json result = nlohmann::json::array();

--- a/controller/src/telemetry/telemetry_snapshot_builder.cpp
+++ b/controller/src/telemetry/telemetry_snapshot_builder.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <string>
+#include <utility>
 
 namespace naim::controller {
 
@@ -33,6 +34,52 @@ std::string TelemetrySnapshotBuilder::StatusFromAlerts(
   return status;
 }
 
+naim::HostTelemetryFrame TelemetrySnapshotBuilder::ScopeFrameToPlane(
+    const naim::HostTelemetryFrame& frame,
+    const std::optional<std::string>& plane_name) const {
+  if (!plane_name.has_value() || plane_name->empty() || frame.plane_name == *plane_name) {
+    return frame;
+  }
+  naim::HostTelemetryFrame scoped = frame;
+  scoped.plane_name = *plane_name;
+  scoped.plane_id = *plane_name;
+  scoped.instance_runtime.clear();
+  for (const auto& status : frame.instance_runtime) {
+    if (!matcher_.RuntimeStatusMatchesPlane(status, *plane_name)) {
+      continue;
+    }
+    auto scoped_status = status;
+    if (scoped_status.plane_name.empty()) {
+      scoped_status.plane_name = *plane_name;
+    }
+    scoped.instance_runtime.push_back(std::move(scoped_status));
+  }
+  scoped.plane_instance_count = scoped.instance_runtime.size();
+  scoped.plane_ready_instance_count = 0;
+  for (const auto& status : scoped.instance_runtime) {
+    if (status.ready) {
+      ++scoped.plane_ready_instance_count;
+    }
+  }
+  scoped.plane_not_ready_instance_count =
+      scoped.plane_instance_count - scoped.plane_ready_instance_count;
+  if (scoped.plane_instance_count == 0) {
+    scoped.plane_runtime_health = "no-runtime";
+  } else {
+    scoped.plane_runtime_health =
+        scoped.plane_not_ready_instance_count > 0 ? "changing" : "ready";
+  }
+  scoped.disk.items.erase(
+      std::remove_if(
+          scoped.disk.items.begin(),
+          scoped.disk.items.end(),
+          [&](const naim::DiskTelemetryRecord& item) {
+            return !item.plane_name.empty() && item.plane_name != *plane_name;
+          }),
+      scoped.disk.items.end());
+  return scoped;
+}
+
 nlohmann::json TelemetrySnapshotBuilder::BuildSnapshot(
     const std::vector<TelemetryNodeBuffer>& nodes,
     const TelemetryRetentionConfig& retention,
@@ -45,23 +92,35 @@ nlohmann::json TelemetrySnapshotBuilder::BuildSnapshot(
     const int history_seconds,
     const std::uint64_t now_ms) const {
   std::vector<const TelemetryNodeBuffer*> matched_buffers;
+  std::vector<TelemetryNodeBuffer> scoped_buffers;
+  scoped_buffers.reserve(nodes.size());
   nlohmann::json node_payloads = nlohmann::json::array();
   nlohmann::json history = nlohmann::json::array();
   for (const auto& buffer : nodes) {
     if (!matcher_.MatchesPlane(buffer.latest, plane_name)) {
       continue;
     }
-    matched_buffers.push_back(&buffer);
-    auto node = frame_json_builder_.Build(buffer.latest, now_ms);
+    const auto scoped_latest = ScopeFrameToPlane(buffer.latest, plane_name);
+    const TelemetryNodeBuffer* matched_buffer = &buffer;
+    if (plane_name.has_value() && !plane_name->empty()) {
+      scoped_buffers.push_back(buffer);
+      scoped_buffers.back().latest = scoped_latest;
+      for (auto& history_frame : scoped_buffers.back().history) {
+        history_frame = ScopeFrameToPlane(history_frame, plane_name);
+      }
+      matched_buffer = &scoped_buffers.back();
+    }
+    matched_buffers.push_back(matched_buffer);
+    auto node = frame_json_builder_.Build(matched_buffer->latest, now_ms);
     const auto controller_ingest_delay_ms =
-        matcher_.ControllerIngestDelayMs(buffer.latest, now_ms);
+        matcher_.ControllerIngestDelayMs(matched_buffer->latest, now_ms);
     node["telemetry_health"] = node_health_builder_.Build(
-        buffer.latest,
-        buffer,
+        matched_buffer->latest,
+        *matched_buffer,
         now_ms,
         controller_ingest_delay_ms);
-    node["controller_dropped_frames_total"] = buffer.dropped_frames_total;
-    node["controller_last_pruned_sequence"] = buffer.last_pruned_sequence;
+    node["controller_dropped_frames_total"] = matched_buffer->dropped_frames_total;
+    node["controller_last_pruned_sequence"] = matched_buffer->last_pruned_sequence;
     node_payloads.push_back(std::move(node));
     if (history_seconds <= 0) {
       continue;
@@ -69,9 +128,11 @@ nlohmann::json TelemetrySnapshotBuilder::BuildSnapshot(
     const std::size_t max_samples =
         static_cast<std::size_t>(std::max(1, history_seconds / 2));
     const std::size_t begin =
-        buffer.history.size() > max_samples ? buffer.history.size() - max_samples : 0;
-    for (std::size_t index = begin; index < buffer.history.size(); ++index) {
-      history.push_back(frame_json_builder_.Build(buffer.history[index], now_ms));
+        matched_buffer->history.size() > max_samples
+            ? matched_buffer->history.size() - max_samples
+            : 0;
+    for (std::size_t index = begin; index < matched_buffer->history.size(); ++index) {
+      history.push_back(frame_json_builder_.Build(matched_buffer->history[index], now_ms));
     }
   }
   const auto alerts = alert_builder_.Build(

--- a/hostd/src/app/hostd_runtime_telemetry_support.cpp
+++ b/hostd/src/app/hostd_runtime_telemetry_support.cpp
@@ -231,6 +231,9 @@ naim::RuntimeProcessStatus HostdRuntimeTelemetrySupport::ToProcessStatus(
   if (status.node_name.empty()) {
     status.node_name = instance.node_name;
   }
+  if (status.plane_name.empty()) {
+    status.plane_name = instance.plane_name;
+  }
   if (status.gpu_device.empty() && instance.gpu_device.has_value()) {
     status.gpu_device = *instance.gpu_device;
   }
@@ -246,6 +249,7 @@ naim::RuntimeProcessStatus HostdRuntimeTelemetrySupport::ToProcessStatus(
   process.runtime_pid = status.runtime_pid;
   process.engine_pid = status.engine_pid;
   process.ready = status.ready || status.launch_ready || status.inference_ready;
+  process.plane_name = status.plane_name;
   return process;
 }
 

--- a/ui/operator-react/src/telemetryHostObservations.js
+++ b/ui/operator-react/src/telemetryHostObservations.js
@@ -1,3 +1,5 @@
+import { scopeTelemetryFrameToPlane } from "./telemetryStore.js";
+
 export function hostObservationItemsFromPayload(payload) {
   if (Array.isArray(payload?.observations)) {
     return payload.observations.map((item) => ({
@@ -147,10 +149,8 @@ export function mergeTelemetryIntoObservationPayload(currentPayload, frames, pla
     currentItems.filter((item) => item?.node_name).map((item) => [item.node_name, item]),
   );
   let changed = false;
-  for (const frame of frames || []) {
-    if (planeName && frame?.plane_name && frame.plane_name !== planeName) {
-      continue;
-    }
+  for (const rawFrame of frames || []) {
+    const frame = scopeTelemetryFrameToPlane(rawFrame, planeName);
     const telemetryItem = hostObservationFromTelemetryFrame(frame);
     if (!telemetryItem?.node_name) {
       continue;

--- a/ui/operator-react/src/telemetryHostObservations.test.js
+++ b/ui/operator-react/src/telemetryHostObservations.test.js
@@ -49,4 +49,26 @@ describe("telemetryHostObservations", () => {
       "existing",
     );
   });
+
+  it("merges only selected plane runtime from aggregate telemetry frames", () => {
+    const merged = mergeTelemetryIntoObservationPayload(
+      { observations: [] },
+      [
+        {
+          node_name: "hpc1",
+          sequence: 20,
+          instance_runtime: [
+            { instance_name: "worker-maglev-service", plane_name: "maglev-service", ready: true },
+            { instance_name: "worker-lt-cypher-ai", plane_name: "lt-cypher-ai", ready: true },
+          ],
+        },
+      ],
+      "maglev-service",
+    );
+
+    const item = hostObservationItemsFromPayload(merged)[0];
+    expect(item.plane_name).toBe("maglev-service");
+    expect(item.instance_runtimes.items).toHaveLength(1);
+    expect(item.instance_runtimes.items[0].instance_name).toBe("worker-maglev-service");
+  });
 });

--- a/ui/operator-react/src/telemetryStore.js
+++ b/ui/operator-react/src/telemetryStore.js
@@ -27,17 +27,97 @@ function shouldAcceptFrame(previous, frame) {
   return previousSequence <= 0 || nextSequence > previousSequence;
 }
 
+function runtimeInstanceMatchesPlane(status, planeName) {
+  if (!planeName) {
+    return true;
+  }
+  if (status?.plane_name === planeName) {
+    return true;
+  }
+  const instanceName = status?.instance_name || "";
+  return [
+    "infer-",
+    "worker-",
+    "skills-",
+    "app-",
+    "webgateway-",
+    "browsing-",
+    "voice-module-",
+    "interaction-",
+  ].some((prefix) => {
+    const stem = `${prefix}${planeName}`;
+    return instanceName === stem || instanceName.startsWith(`${stem}-`);
+  });
+}
+
+function gpuProcessMatchesInstances(process, instanceNames) {
+  return !process?.instance_name ||
+    process.instance_name === "unknown" ||
+    instanceNames.has(process.instance_name);
+}
+
+export function scopeTelemetryFrameToPlane(frame, planeName = "") {
+  if (!planeName || !frame?.node_name) {
+    return frame;
+  }
+  if (frame?.plane_name && frame.plane_name !== planeName) {
+    return null;
+  }
+  const scopedRuntime = (Array.isArray(frame?.instance_runtime) ? frame.instance_runtime : [])
+    .filter((status) => runtimeInstanceMatchesPlane(status, planeName))
+    .map((status) => ({ ...status, plane_name: status?.plane_name || planeName }));
+  if (!frame?.plane_name && scopedRuntime.length === 0) {
+    return null;
+  }
+  const instanceNames = new Set(scopedRuntime.map((status) => status?.instance_name).filter(Boolean));
+  const scopedGpu = frame?.gpu
+    ? {
+        ...frame.gpu,
+        devices: (Array.isArray(frame.gpu.devices) ? frame.gpu.devices : []).map((device) => ({
+          ...device,
+          processes: (Array.isArray(device?.processes) ? device.processes : []).filter((process) =>
+            gpuProcessMatchesInstances(process, instanceNames),
+          ),
+        })),
+      }
+    : frame?.gpu;
+  const scopedDisk = frame?.disk
+    ? {
+        ...frame.disk,
+        items: (Array.isArray(frame.disk.items) ? frame.disk.items : []).filter(
+          (item) => !item?.plane_name || item.plane_name === planeName,
+        ),
+      }
+    : frame?.disk;
+  const readyCount = scopedRuntime.filter((status) => status?.ready === true).length;
+  return {
+    ...frame,
+    plane_name: planeName,
+    plane_id: planeName,
+    instance_runtime: scopedRuntime,
+    gpu: scopedGpu,
+    disk: scopedDisk,
+    plane_instance_count: scopedRuntime.length,
+    plane_ready_instance_count: readyCount,
+    plane_not_ready_instance_count: Math.max(0, scopedRuntime.length - readyCount),
+    plane_runtime_health:
+      scopedRuntime.length === 0
+        ? "no-runtime"
+        : readyCount === scopedRuntime.length
+          ? "ready"
+          : "changing",
+  };
+}
+
 export function reduceTelemetryStore(store, frames, planeName = "") {
   const current = store || createTelemetryStore();
   let changed = false;
   const acceptedFrames = [];
   const nextByNode = { ...(current.byNode || {}) };
 
-  for (const frame of frames || []) {
+  for (const rawFrame of frames || []) {
+    const frame = scopeTelemetryFrameToPlane(rawFrame, planeName);
     if (!frame?.node_name) {
-      continue;
-    }
-    if (planeName && frame?.plane_name && frame.plane_name !== planeName) {
       continue;
     }
     const previous = nextByNode[frame.node_name];

--- a/ui/operator-react/src/telemetryStore.test.js
+++ b/ui/operator-react/src/telemetryStore.test.js
@@ -5,6 +5,7 @@ import {
   createTelemetryStore,
   enrichTelemetryFrames,
   reduceTelemetryStore,
+  scopeTelemetryFrameToPlane,
   updateTelemetryBrowserLatency,
 } from "./telemetryStore.js";
 
@@ -83,5 +84,40 @@ describe("telemetryStore", () => {
 
     expect(recovered.droppedFramesTotal).toBe(12);
     expect(recovered.overloaded).toBe(false);
+  });
+
+  it("scopes aggregate node frames to a selected plane", () => {
+    const frame = {
+      node_name: "hpc1",
+      sequence: 1000,
+      instance_runtime: [
+        { instance_name: "worker-maglev-service", plane_name: "maglev-service", ready: true },
+        { instance_name: "worker-lt-cypher-ai", plane_name: "lt-cypher-ai", ready: false },
+      ],
+      gpu: {
+        devices: [
+          {
+            gpu_device: "0",
+            processes: [
+              { instance_name: "worker-maglev-service", used_vram_mb: 100 },
+              { instance_name: "worker-lt-cypher-ai", used_vram_mb: 200 },
+            ],
+          },
+        ],
+      },
+    };
+
+    const scoped = scopeTelemetryFrameToPlane(frame, "maglev-service");
+    expect(scoped.plane_name).toBe("maglev-service");
+    expect(scoped.instance_runtime).toHaveLength(1);
+    expect(scoped.plane_ready_instance_count).toBe(1);
+    expect(scoped.gpu.devices[0].processes).toHaveLength(1);
+
+    const result = reduceTelemetryStore(createTelemetryStore(), [frame], "maglev-service");
+    expect(result.changed).toBe(true);
+    expect(result.store.byNode.hpc1.plane_name).toBe("maglev-service");
+    expect(result.store.byNode.hpc1.instance_runtime[0].instance_name).toBe(
+      "worker-maglev-service",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- tag runtime process telemetry with plane names from hostd local state
- aggregate multi-plane node telemetry per plane instead of unassigned
- scope selected-plane telemetry frames in the WebUI reducer

## Tests
- cmake --build build/codex-debug --target naim-controller naim-hostd naim-telemetry-live-store-tests -j 6
- ./build/codex-debug/naim-telemetry-live-store-tests
- npm test -- --run
- npm run build