### PR TITLE
Skip build artifacts in storage gate

### DIFF
--- a/scripts/ci/knowledge-vault-release-gate.py
+++ b/scripts/ci/knowledge-vault-release-gate.py
@@ -470,7 +470,10 @@ def scan_repo_for_forbidden_defaults(repo_root):
     for path in repo_root.rglob("*"):
         if not path.is_file():
             continue
-        if excluded_dirs.intersection(path.relative_to(repo_root).parts):
+        relative_parts = path.relative_to(repo_root).parts
+        if excluded_dirs.intersection(relative_parts):
+            continue
+        if any(part.startswith("build-") for part in relative_parts):
             continue
         try:
             content = path.read_text(encoding="utf-8")


### PR DESCRIPTION
Updates the repository storage-path scan to skip generated build-* trees, so the gate checks source defaults without failing on hpc1 CMake/vcpkg build artifacts.\n\nValidation:\n- python3 -m py_compile scripts/ci/knowledge-vault-release-gate.py\n- python3 -c import/source scan for forbidden shared-storage defaults\n- rg -n "/mnt/shared-storage" -S .