### PR TITLE
Retry Harbor login and push

### DIFF
--- a/scripts/ci/hpc1-build-push-harbor.sh
+++ b/scripts/ci/hpc1-build-push-harbor.sh
@@ -23,12 +23,32 @@ cleanup() {
 trap cleanup EXIT
 rm -f "${HOME}/.docker/config.json" 2>/dev/null || true
 
+docker_login_with_retry() {
+  local attempt=1
+  local max_attempts="${NAIM_REGISTRY_LOGIN_ATTEMPTS:-5}"
+  local delay_sec="${NAIM_REGISTRY_LOGIN_RETRY_DELAY_SEC:-5}"
+
+  while (( attempt <= max_attempts )); do
+    if docker login "${NAIM_REGISTRY}" \
+      -u "${NAIM_REGISTRY_USERNAME}" \
+      --password-stdin < "${NAIM_REGISTRY_PASSWORD_FILE}" >/dev/null; then
+      return 0
+    fi
+    if (( attempt == max_attempts )); then
+      echo "error: docker login failed after ${max_attempts} attempts" >&2
+      return 1
+    fi
+    echo "warning: docker login failed on attempt ${attempt}/${max_attempts}; retrying in ${delay_sec}s" >&2
+    sleep "${delay_sec}"
+    delay_sec=$(( delay_sec * 2 ))
+    attempt=$(( attempt + 1 ))
+  done
+}
+
 if [[ -n "${NAIM_REGISTRY_USERNAME:-}" && -n "${NAIM_REGISTRY_PASSWORD_FILE:-}" ]]; then
   docker_config="$(mktemp -d)"
   export DOCKER_CONFIG="${docker_config}"
-  docker login "${NAIM_REGISTRY}" \
-    -u "${NAIM_REGISTRY_USERNAME}" \
-    --password-stdin < "${NAIM_REGISTRY_PASSWORD_FILE}" >/dev/null
+  docker_login_with_retry
 fi
 
 manifest_path="${NAIM_RELEASE_MANIFEST_PATH:-$(pwd)/var/release-manifest-${NAIM_RELEASE_TAG}.json}"

--- a/scripts/release/build-and-push-images.sh
+++ b/scripts/release/build-and-push-images.sh
@@ -125,6 +125,27 @@ except urllib.error.HTTPError as error:
 PY
 }
 
+docker_push_with_retry() {
+  local ref="$1"
+  local attempt=1
+  local max_attempts="${NAIM_REGISTRY_PUSH_ATTEMPTS:-5}"
+  local delay_sec="${NAIM_REGISTRY_PUSH_RETRY_DELAY_SEC:-5}"
+
+  while (( attempt <= max_attempts )); do
+    if docker push "${ref}"; then
+      return 0
+    fi
+    if (( attempt == max_attempts )); then
+      echo "error: docker push failed after ${max_attempts} attempts: ${ref}" >&2
+      return 1
+    fi
+    echo "warning: docker push failed on attempt ${attempt}/${max_attempts}; retrying in ${delay_sec}s: ${ref}" >&2
+    sleep "${delay_sec}"
+    delay_sec=$(( delay_sec * 2 ))
+    attempt=$(( attempt + 1 ))
+  done
+}
+
 base_ref="$(image_ref base-runtime)"
 infer_ref="$(image_ref infer-runtime)"
 worker_ref="$(image_ref worker-runtime)"
@@ -177,7 +198,7 @@ json_entries=()
 for image in "${image_names[@]}"; do
   ref="$(image_ref "${image}")"
   echo "pushing ${ref}"
-  docker push "${ref}"
+  docker_push_with_retry "${ref}"
   repo_digest="$(docker image inspect \
     --format '{{range .RepoDigests}}{{println .}}{{end}}' \
     "${ref}" | grep -F "${registry}/${project}/${image}@" | head -n1 || true)"
@@ -189,7 +210,7 @@ for image in "${image_names[@]}"; do
   echo "moving ${latest_ref} to ${ref}"
   delete_remote_latest_tag "${image}"
   docker tag "${ref}" "${latest_ref}"
-  docker push "${latest_ref}"
+  docker_push_with_retry "${latest_ref}"
 done
 
 {


### PR DESCRIPTION
Adds bounded retries around docker login and image pushes to tolerate transient Harbor 502 errors.\n\nValidation:\n- bash -n scripts/ci/hpc1-build-push-harbor.sh scripts/release/build-and-push-images.sh\n- rg -n "/mnt/shared-storage" -S .