### PR TITLE
Refactor release storage cleanup

### DIFF
--- a/.github/workflows/naim-pr-ci.yml
+++ b/.github/workflows/naim-pr-ci.yml
@@ -151,8 +151,9 @@ jobs:
         run: |
           set -euo pipefail
           repo_q="$(printf '%q' "${{ needs.hpc1-checkout.outputs.pr_repo_path }}")"
+          vcpkg_root_q="$(printf '%q' "${NAIM_HPC1_VCPKG_ROOT}")"
           ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
-            "cd ${repo_q} && VCPKG_ROOT='${NAIM_HPC1_VCPKG_ROOT}' NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build.sh"
+            "cd ${repo_q} && VCPKG_ROOT=${vcpkg_root_q} NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build.sh"
 
   ui-checks:
     name: operator UI checks
@@ -219,8 +220,9 @@ jobs:
         run: |
           set -euo pipefail
           repo_q="$(printf '%q' "${{ needs.hpc1-checkout.outputs.pr_repo_path }}")"
+          vcpkg_root_q="$(printf '%q' "${NAIM_HPC1_VCPKG_ROOT}")"
           ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
-            "cd ${repo_q} && VCPKG_ROOT='${NAIM_HPC1_VCPKG_ROOT}' NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build-turboquant.sh"
+            "cd ${repo_q} && VCPKG_ROOT=${vcpkg_root_q} NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build-turboquant.sh"
 
   summary:
     name: summary

--- a/.github/workflows/naim-production-release.yml
+++ b/.github/workflows/naim-production-release.yml
@@ -36,18 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Install SSH key
-        shell: bash
-        run: |
-          set -euo pipefail
-          install -m 0700 -d "${HOME}/.ssh"
-          key_path="${HOME}/.ssh/naim_ci_deploy"
-          printf '%s\n' "${{ secrets.NAIM_DEPLOY_SSH_KEY }}" > "${key_path}"
-          chmod 0600 "${key_path}"
-          {
-            echo "NAIM_CI_SSH_KEY=${key_path}"
-            echo "NAIM_CI_SSH_OPTS=-i ${key_path} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=6"
-          } >> "${GITHUB_ENV}"
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
       - name: Pull commit on hpc1
         shell: bash
         run: |
@@ -159,25 +151,18 @@ jobs:
       - hpc1-pull
       - detect-release-scope
     steps:
-      - name: Install SSH key
-        shell: bash
-        run: |
-          set -euo pipefail
-          install -m 0700 -d "${HOME}/.ssh"
-          key_path="${HOME}/.ssh/naim_ci_deploy"
-          printf '%s\n' "${{ secrets.NAIM_DEPLOY_SSH_KEY }}" > "${key_path}"
-          chmod 0600 "${key_path}"
-          {
-            echo "NAIM_CI_SSH_KEY=${key_path}"
-            echo "NAIM_CI_SSH_OPTS=-i ${key_path} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=6"
-          } >> "${GITHUB_ENV}"
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
       - name: Build on hpc1
         shell: bash
         run: |
           set -euo pipefail
           repo_q="$(printf '%q' "${NAIM_HPC1_REPO_PATH}")"
+          vcpkg_root_q="$(printf '%q' "${NAIM_HPC1_VCPKG_ROOT}")"
           ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
-            "cd ${repo_q} && VCPKG_ROOT='${NAIM_HPC1_VCPKG_ROOT}' NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build.sh"
+            "cd ${repo_q} && VCPKG_ROOT=${vcpkg_root_q} NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build.sh"
 
   hpc1-build-turboquant:
     name: 2b. hpc1 TurboQuant build
@@ -188,25 +173,18 @@ jobs:
       - detect-release-scope
     if: needs.detect-release-scope.outputs.turboquant_required == 'true'
     steps:
-      - name: Install SSH key
-        shell: bash
-        run: |
-          set -euo pipefail
-          install -m 0700 -d "${HOME}/.ssh"
-          key_path="${HOME}/.ssh/naim_ci_deploy"
-          printf '%s\n' "${{ secrets.NAIM_DEPLOY_SSH_KEY }}" > "${key_path}"
-          chmod 0600 "${key_path}"
-          {
-            echo "NAIM_CI_SSH_KEY=${key_path}"
-            echo "NAIM_CI_SSH_OPTS=-i ${key_path} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=6"
-          } >> "${GITHUB_ENV}"
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
       - name: Build TurboQuant runtime on hpc1
         shell: bash
         run: |
           set -euo pipefail
           repo_q="$(printf '%q' "${NAIM_HPC1_REPO_PATH}")"
+          vcpkg_root_q="$(printf '%q' "${NAIM_HPC1_VCPKG_ROOT}")"
           ssh ${NAIM_CI_SSH_OPTS} -p "${NAIM_HPC1_SSH_PORT}" "${NAIM_HPC1_SSH}" \
-            "cd ${repo_q} && VCPKG_ROOT='${NAIM_HPC1_VCPKG_ROOT}' NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build-turboquant.sh"
+            "cd ${repo_q} && VCPKG_ROOT=${vcpkg_root_q} NAIM_RELEASE_SHA='${NAIM_RELEASE_SHA}' NAIM_BUILD_TYPE='${NAIM_BUILD_TYPE}' NAIM_CUDA_ARCHITECTURES='${NAIM_CUDA_ARCHITECTURES}' NAIM_CUDA_NVCC_JOBS='${NAIM_CUDA_NVCC_JOBS}' NAIM_COMPILER_CACHE='${NAIM_COMPILER_CACHE}' NAIM_CMAKE_ARGS='${NAIM_CMAKE_ARGS}' bash scripts/ci/hpc1-build-turboquant.sh"
 
   hpc1-knowledge-vault-release-gate:
     name: 2a. hpc1 Knowledge Vault release gate
@@ -214,18 +192,10 @@ jobs:
     timeout-minutes: 30
     needs: hpc1-build
     steps:
-      - name: Install SSH key
-        shell: bash
-        run: |
-          set -euo pipefail
-          install -m 0700 -d "${HOME}/.ssh"
-          key_path="${HOME}/.ssh/naim_ci_deploy"
-          printf '%s\n' "${{ secrets.NAIM_DEPLOY_SSH_KEY }}" > "${key_path}"
-          chmod 0600 "${key_path}"
-          {
-            echo "NAIM_CI_SSH_KEY=${key_path}"
-            echo "NAIM_CI_SSH_OPTS=-i ${key_path} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=6"
-          } >> "${GITHUB_ENV}"
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
       - name: Run Knowledge Vault release gate on hpc1
         shell: bash
         run: |
@@ -248,18 +218,10 @@ jobs:
       needs.hpc1-knowledge-vault-release-gate.result == 'success' &&
       (needs.hpc1-build-turboquant.result == 'success' || needs.hpc1-build-turboquant.result == 'skipped')
     steps:
-      - name: Install SSH key
-        shell: bash
-        run: |
-          set -euo pipefail
-          install -m 0700 -d "${HOME}/.ssh"
-          key_path="${HOME}/.ssh/naim_ci_deploy"
-          printf '%s\n' "${{ secrets.NAIM_DEPLOY_SSH_KEY }}" > "${key_path}"
-          chmod 0600 "${key_path}"
-          {
-            echo "NAIM_CI_SSH_KEY=${key_path}"
-            echo "NAIM_CI_SSH_OPTS=-i ${key_path} -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=30 -o ServerAliveCountMax=6"
-          } >> "${GITHUB_ENV}"
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-naim-ssh
+        with:
+          ssh-private-key: ${{ secrets.NAIM_DEPLOY_SSH_KEY }}
       - name: Build and push images from hpc1
         shell: bash
         env:

--- a/scripts/check-live-storage.sh
+++ b/scripts/check-live-storage.sh
@@ -37,6 +37,17 @@ run_hostd_apply_as_root() {
   run_as_root "${command}" || { sleep 1; run_as_root "${command}"; }
 }
 
+plane_shared_disk_path() {
+  local plane_name="$1"
+  printf '%s/tmp/naim/disks/planes/%s/shared\n' "${runtime_root}" "${plane_name}"
+}
+
+worker_private_disk_path() {
+  local node_name="$1"
+  local instance_name="$2"
+  printf '%s/nodes/%s/tmp/naim/disks/instances/%s/private\n' "${runtime_root}" "${node_name}" "${instance_name}"
+}
+
 command -v docker >/dev/null 2>&1 || { echo "live-storage: docker is required" >&2; exit 1; }
 command -v mountpoint >/dev/null 2>&1 || { echo "live-storage: mountpoint is required" >&2; exit 1; }
 
@@ -89,9 +100,9 @@ echo "[live-storage] hostd apply on node-a and node-b as root"
 run_hostd_apply_as_root "'${build_dir}/naim-hostd' apply-next-assignment --db '${db_path}' --node node-a --runtime-root '${runtime_root}' --state-root '${state_root}' --compose-mode skip >/dev/null"
 run_hostd_apply_as_root "'${build_dir}/naim-hostd' apply-next-assignment --db '${db_path}' --node node-b --runtime-root '${runtime_root}' --state-root '${state_root}' --compose-mode skip >/dev/null"
 
-shared_a="${runtime_root}/tmp/naim/disks/planes/storage-v2/shared"
-private_worker_a="${runtime_root}/nodes/node-a/tmp/naim/disks/instances/worker-storage-v2-a/private"
-private_worker_b="${runtime_root}/nodes/node-b/tmp/naim/disks/instances/worker-storage-v2-b/private"
+shared_a="$(plane_shared_disk_path storage-v2)"
+private_worker_a="$(worker_private_disk_path node-a worker-storage-v2-a)"
+private_worker_b="$(worker_private_disk_path node-b worker-storage-v2-b)"
 
 echo "[live-storage] verify mounted runtime state"
 "${build_dir}/naim-controller" show-disk-state --db "${db_path}" | grep -F "disk=plane-storage-v2-shared kind=plane-shared node=node-a" | grep -F "realized_state=mounted" >/dev/null
@@ -134,7 +145,7 @@ naim_live_write_compute_state "${renamed_state_path}" storage-v2-renamed 1
 naim_live_apply_v2_state "${build_dir}" "${db_path}" "${artifacts_root}" "${renamed_state_path}"
 run_hostd_apply_as_root "'${build_dir}/naim-hostd' apply-next-assignment --db '${db_path}' --node node-a --runtime-root '${runtime_root}' --state-root '${state_root}' --compose-mode skip >/dev/null"
 "${build_dir}/naim-controller" show-disk-state --db "${db_path}" | grep -F "disk=plane-storage-v2-renamed-shared" | grep -F "realized_state=mounted" >/dev/null
-shared_renamed="${runtime_root}/tmp/naim/disks/planes/storage-v2-renamed/shared"
+shared_renamed="$(plane_shared_disk_path storage-v2-renamed)"
 if run_as_root "mountpoint -q '${shared_a}'"; then
   echo "live-storage: expected old shared mount to be removed" >&2
   exit 1

--- a/scripts/ci/hpc1-build-common.sh
+++ b/scripts/ci/hpc1-build-common.sh
@@ -59,12 +59,19 @@ naim_ci_prepare_shared_vcpkg_cache() {
   done
 }
 
+naim_ci_default_compiler_cache_root() {
+  printf '%s\n' "${XDG_CACHE_HOME:-${HOME:-/tmp}/.cache}"
+}
+
 naim_ci_prepare_compiler_cache() {
   local repo_root="$1"
-  local default_cache_root="${XDG_CACHE_HOME:-${HOME:-/tmp}/.cache}"
-  local cache_dir="${NAIM_CCACHE_DIR:-${default_cache_root}/naim/ccache/naim-node}"
+  local default_cache_root=""
+  local cache_dir=""
   local cache_dir_explicit="0"
   local fallback_cache_dir="/tmp/naim-ccache/naim-node"
+
+  default_cache_root="$(naim_ci_default_compiler_cache_root)"
+  cache_dir="${NAIM_CCACHE_DIR:-${default_cache_root}/naim/ccache/naim-node}"
 
   if [[ -n "${NAIM_CCACHE_DIR:-}" ]]; then
     cache_dir_explicit="1"

--- a/scripts/ci/hpc1-build-push-harbor.sh
+++ b/scripts/ci/hpc1-build-push-harbor.sh
@@ -6,13 +6,8 @@ set -euo pipefail
 : "${NAIM_REGISTRY:=chainzano.com}"
 : "${NAIM_REGISTRY_PROJECT:=naim}"
 
-current_sha="$(git rev-parse HEAD)"
-if [[ "${current_sha}" != "${NAIM_RELEASE_SHA}" ]]; then
-  echo "error: hpc1 workspace is at ${current_sha}, expected ${NAIM_RELEASE_SHA}" >&2
-  exit 1
-fi
-
 docker_config=""
+manifest_path=""
 cleanup() {
   if [[ -n "${docker_config}" ]]; then
     rm -rf "${docker_config}"
@@ -22,6 +17,16 @@ cleanup() {
 }
 trap cleanup EXIT
 rm -f "${HOME}/.docker/config.json" 2>/dev/null || true
+
+require_release_sha() {
+  local current_sha=""
+
+  current_sha="$(git rev-parse HEAD)"
+  if [[ "${current_sha}" != "${NAIM_RELEASE_SHA}" ]]; then
+    echo "error: hpc1 workspace is at ${current_sha}, expected ${NAIM_RELEASE_SHA}" >&2
+    exit 1
+  fi
+}
 
 docker_login_with_retry() {
   local attempt=1
@@ -45,17 +50,30 @@ docker_login_with_retry() {
   done
 }
 
-if [[ -n "${NAIM_REGISTRY_USERNAME:-}" && -n "${NAIM_REGISTRY_PASSWORD_FILE:-}" ]]; then
+prepare_docker_auth() {
+  if [[ -z "${NAIM_REGISTRY_USERNAME:-}" || -z "${NAIM_REGISTRY_PASSWORD_FILE:-}" ]]; then
+    return 0
+  fi
+
   docker_config="$(mktemp -d)"
   export DOCKER_CONFIG="${docker_config}"
   docker_login_with_retry
-fi
+}
+
+build_and_push_images() {
+  local manifest_path="$1"
+
+  "$(pwd)/scripts/release/build-and-push-images.sh" \
+    --registry "${NAIM_REGISTRY}" \
+    --project "${NAIM_REGISTRY_PROJECT}" \
+    --tag "${NAIM_RELEASE_TAG}" \
+    --manifest "${manifest_path}"
+}
+
+require_release_sha
+prepare_docker_auth
 
 manifest_path="${NAIM_RELEASE_MANIFEST_PATH:-$(pwd)/var/release-manifest-${NAIM_RELEASE_TAG}.json}"
-"$(pwd)/scripts/release/build-and-push-images.sh" \
-  --registry "${NAIM_REGISTRY}" \
-  --project "${NAIM_REGISTRY_PROJECT}" \
-  --tag "${NAIM_RELEASE_TAG}" \
-  --manifest "${manifest_path}"
+build_and_push_images "${manifest_path}"
 
 echo "harbor manifest=${manifest_path}"

--- a/scripts/ci/knowledge-vault-release-gate.py
+++ b/scripts/ci/knowledge-vault-release-gate.py
@@ -37,6 +37,23 @@ LEAK_PATTERNS = [
     ("private control-plane address", "51.68."),
 ]
 
+FORBIDDEN_SOURCE_DEFAULT_PATHS = [
+    "/mnt/" + "shared-storage/",
+]
+
+SOURCE_SCAN_EXCLUDED_DIRS = {
+    ".git",
+    ".cache",
+    ".tools",
+    "build",
+    "node_modules",
+    "var",
+}
+
+SOURCE_SCAN_EXCLUDED_PREFIXES = (
+    "build-",
+)
+
 
 def log(message):
     print(f"[knowledge-release-gate] {message}", flush=True)
@@ -456,31 +473,28 @@ def scan_artifacts(paths):
     }
 
 
-def scan_repo_for_forbidden_defaults(repo_root):
-    forbidden_path = "/mnt/" + "shared-storage/"
-    excluded_dirs = {
-        ".git",
-        ".cache",
-        ".tools",
-        "build",
-        "node_modules",
-        "var",
-    }
+def is_generated_or_untracked_artifact_path(relative_parts):
+    if SOURCE_SCAN_EXCLUDED_DIRS.intersection(relative_parts):
+        return True
+    return any(part.startswith(SOURCE_SCAN_EXCLUDED_PREFIXES) for part in relative_parts)
+
+
+def scan_source_tree_for_forbidden_defaults(repo_root):
     findings = []
     for path in repo_root.rglob("*"):
         if not path.is_file():
             continue
         relative_parts = path.relative_to(repo_root).parts
-        if excluded_dirs.intersection(relative_parts):
-            continue
-        if any(part.startswith("build-") for part in relative_parts):
+        if is_generated_or_untracked_artifact_path(relative_parts):
             continue
         try:
             content = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        if forbidden_path in content:
-            findings.append(str(path.relative_to(repo_root)))
+        for forbidden_path in FORBIDDEN_SOURCE_DEFAULT_PATHS:
+            if forbidden_path in content:
+                findings.append(str(path.relative_to(repo_root)))
+                break
     expect(not findings, f"repository contains forbidden shared-storage defaults: {findings}")
 
 
@@ -512,7 +526,7 @@ def run_gate(args):
         raise RuntimeError(f"missing built Knowledge Vault release-gate binaries: {rendered}")
 
     started = time.perf_counter()
-    scan_repo_for_forbidden_defaults(repo_root)
+    scan_source_tree_for_forbidden_defaults(repo_root)
     run_binary(required_binaries["contract_tests"])
     run_binary(required_binaries["store_tests"])
     run_binary(required_binaries["service_tests"])

--- a/scripts/hpc1-dev-sandbox.sh
+++ b/scripts/hpc1-dev-sandbox.sh
@@ -4,10 +4,14 @@ set -euo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "${script_dir}/.." && pwd)"
 
+default_remote_base() {
+  printf '%s\n' "/tmp/naim-dev-sandboxes/${USER:-baal}"
+}
+
 remote_host="${NAIM_HPC1_HOST:-baal@195.168.22.186}"
 remote_port="${NAIM_HPC1_PORT:-2222}"
 sandbox_name="${NAIM_HPC1_SANDBOX_NAME:-naim-node-dev}"
-remote_base="${NAIM_HPC1_SANDBOX_BASE:-/tmp/naim-dev-sandboxes/${USER:-baal}}"
+remote_base="${NAIM_HPC1_SANDBOX_BASE:-$(default_remote_base)}"
 remote_root="${NAIM_HPC1_SANDBOX_ROOT:-${remote_base}/${sandbox_name}}"
 remote_repo="${remote_root}/repo"
 remote_build_root="${remote_root}/build-root"

--- a/scripts/llama-rpc-replica-benchmark.sh
+++ b/scripts/llama-rpc-replica-benchmark.sh
@@ -24,13 +24,19 @@ SCALED_CONCURRENCY="${SCALED_CONCURRENCY:-$((12 * REPLICA_COUNT))}"
 SCALED_REQUESTS_PER_WORKER="${SCALED_REQUESTS_PER_WORKER:-3}"
 SCALED_MAX_TOKENS="${SCALED_MAX_TOKENS:-128}"
 
-if [[ -n "${XDG_CACHE_HOME:-}" ]]; then
-  BENCH_ROOT_DEFAULT="${XDG_CACHE_HOME}/naim/tmp/llama-rpc-replicas"
-elif [[ -n "${HOME:-}" ]]; then
-  BENCH_ROOT_DEFAULT="${HOME}/.cache/naim/tmp/llama-rpc-replicas"
-else
-  BENCH_ROOT_DEFAULT="/tmp/naim/llama-rpc-replicas"
-fi
+default_bench_root() {
+  if [[ -n "${XDG_CACHE_HOME:-}" ]]; then
+    printf '%s\n' "${XDG_CACHE_HOME}/naim/tmp/llama-rpc-replicas"
+    return
+  fi
+  if [[ -n "${HOME:-}" ]]; then
+    printf '%s\n' "${HOME}/.cache/naim/tmp/llama-rpc-replicas"
+    return
+  fi
+  printf '%s\n' "/tmp/naim/llama-rpc-replicas"
+}
+
+BENCH_ROOT_DEFAULT="$(default_bench_root)"
 BENCH_ROOT="${BENCH_ROOT:-$BENCH_ROOT_DEFAULT}"
 
 RPC_SERVER_BIN="${NAIM_RPC_SERVER_BIN:-$BUILD_DIR/bin/rpc-server}"

--- a/scripts/release/build-and-push-images.sh
+++ b/scripts/release/build-and-push-images.sh
@@ -146,6 +146,59 @@ docker_push_with_retry() {
   done
 }
 
+build_runtime_images() {
+  if [[ "${skip_web_ui}" == "yes" ]]; then
+    "${repo_root}/scripts/build-runtime-images.sh" --skip-web-ui "$@"
+  else
+    "${repo_root}/scripts/build-runtime-images.sh" "$@"
+  fi
+}
+
+push_release_image() {
+  local image="$1"
+  local ref=""
+  local latest_ref=""
+  local repo_digest=""
+
+  ref="$(image_ref "${image}")"
+  echo "pushing ${ref}"
+  docker_push_with_retry "${ref}"
+  repo_digest="$(docker image inspect \
+    --format '{{range .RepoDigests}}{{println .}}{{end}}' \
+    "${ref}" | grep -F "${registry}/${project}/${image}@" | head -n1 || true)"
+  if [[ -z "${repo_digest}" ]]; then
+    repo_digest="${ref}"
+  fi
+  json_entries+=("$(printf '    \"%s\": \"%s\"' "${image}" "${repo_digest}")")
+
+  latest_ref="$(latest_image_ref "${image}")"
+  echo "moving ${latest_ref} to ${ref}"
+  delete_remote_latest_tag "${image}"
+  docker tag "${ref}" "${latest_ref}"
+  docker_push_with_retry "${latest_ref}"
+}
+
+write_manifest() {
+  local suffix=""
+
+  {
+    printf '{\n'
+    printf '  "registry": "%s",\n' "${registry}"
+    printf '  "project": "%s",\n' "${project}"
+    printf '  "tag": "%s",\n' "${tag}"
+    printf '  "images": {\n'
+    for index in "${!json_entries[@]}"; do
+      suffix=","
+      if [[ "${index}" -eq $((${#json_entries[@]} - 1)) ]]; then
+        suffix=""
+      fi
+      printf '%s%s\n' "${json_entries[index]}" "${suffix}"
+    done
+    printf '  }\n'
+    printf '}\n'
+  } > "${manifest_path}"
+}
+
 base_ref="$(image_ref base-runtime)"
 infer_ref="$(image_ref infer-runtime)"
 worker_ref="$(image_ref worker-runtime)"
@@ -172,11 +225,7 @@ build_args=(
   "${voice_module_ref}"
 )
 
-if [[ "${skip_web_ui}" == "yes" ]]; then
-  "${repo_root}/scripts/build-runtime-images.sh" --skip-web-ui "${build_args[@]}"
-else
-  "${repo_root}/scripts/build-runtime-images.sh" "${build_args[@]}"
-fi
+build_runtime_images "${build_args[@]}"
 
 declare -a image_names=(
   base-runtime
@@ -196,38 +245,9 @@ fi
 
 json_entries=()
 for image in "${image_names[@]}"; do
-  ref="$(image_ref "${image}")"
-  echo "pushing ${ref}"
-  docker_push_with_retry "${ref}"
-  repo_digest="$(docker image inspect \
-    --format '{{range .RepoDigests}}{{println .}}{{end}}' \
-    "${ref}" | grep -F "${registry}/${project}/${image}@" | head -n1 || true)"
-  if [[ -z "${repo_digest}" ]]; then
-    repo_digest="${ref}"
-  fi
-  json_entries+=("$(printf '    \"%s\": \"%s\"' "${image}" "${repo_digest}")")
-  latest_ref="$(latest_image_ref "${image}")"
-  echo "moving ${latest_ref} to ${ref}"
-  delete_remote_latest_tag "${image}"
-  docker tag "${ref}" "${latest_ref}"
-  docker_push_with_retry "${latest_ref}"
+  push_release_image "${image}"
 done
 
-{
-  printf '{\n'
-  printf '  "registry": "%s",\n' "${registry}"
-  printf '  "project": "%s",\n' "${project}"
-  printf '  "tag": "%s",\n' "${tag}"
-  printf '  "images": {\n'
-  for index in "${!json_entries[@]}"; do
-    suffix=","
-    if [[ "${index}" -eq $((${#json_entries[@]} - 1)) ]]; then
-      suffix=""
-    fi
-    printf '%s%s\n' "${json_entries[index]}" "${suffix}"
-  done
-  printf '  }\n'
-  printf '}\n'
-} > "${manifest_path}"
+write_manifest
 
 echo "release manifest written: ${manifest_path}"


### PR DESCRIPTION
Refactors the recent release/storage cleanup changes without changing CI contracts or release behavior.\n\nChanges:\n- Reuses the existing setup-naim-ssh action in production jobs.\n- Quotes explicit hpc1 VCPKG_ROOT before remote shell use.\n- Splits Harbor login/push helpers and manifest writing into named responsibilities.\n- Makes source-tree forbidden default scanning explicit.\n- Names cache, sandbox, benchmark, and live-storage path helpers.\n\nValidation:\n- git diff --check\n- rg -n "/mnt/shared-storage" -S .\n- bash -n affected shell scripts\n- python3 -m py_compile scripts/ci/knowledge-vault-release-gate.py\n- python3 -c import/source scan for forbidden shared-storage defaults\n- jq . config/naim-node-config.json\n- bash scripts/ci/pr-lightweight-checks.sh\n- cd ui/operator-react && npm test -- --run skillsFactory\n- scripts/release/build-and-push-images.sh --help