### PR TITLE
Fix WebUI telemetry dashboard refresh UX

### DIFF
--- a/ui/operator-react/e2e/plane-editor.spec.js
+++ b/ui/operator-react/e2e/plane-editor.spec.js
@@ -24,9 +24,19 @@ const hostdHosts = [
     capacity_summary: {
       gpu_count: 4,
       storage_free_bytes: 250_000_000_000,
+      storage_root: "/naim/storage",
       storage_total_bytes: 1_388_000_000_000,
       total_memory_bytes: 269_960_683_520,
     },
+    lan_peers: [
+      {
+        peer_node_name: "storage1",
+        peer_endpoint: "http://192.168.88.252:29999",
+        tcp_reachable: true,
+        seen_udp: true,
+        rtt_ms: 1,
+      },
+    ],
   },
   {
     node_name: "storage1",
@@ -36,9 +46,19 @@ const hostdHosts = [
     capacity_summary: {
       gpu_count: 0,
       storage_free_bytes: 17_000_000_000_000,
+      storage_root: "/naim/storage",
       storage_total_bytes: 18_927_043_346_432,
       total_memory_bytes: 64_891_473_920,
     },
+    lan_peers: [
+      {
+        peer_node_name: "hpc1",
+        peer_endpoint: "http://192.168.88.13:29999",
+        tcp_reachable: true,
+        seen_udp: true,
+        rtt_ms: 1,
+      },
+    ],
   },
 ];
 
@@ -86,7 +106,7 @@ async function mockApi(page) {
         body: JSON.stringify(payload),
       });
 
-    if (path === "/api/v1/events/stream") {
+    if (path === "/api/v1/events/stream" || path === "/api/v1/live/stream") {
       return route.fulfill({
         status: 200,
         contentType: "text/event-stream",
@@ -112,11 +132,64 @@ async function mockApi(page) {
         runtime: { ready_nodes: 0 },
         rollout: { total_actions: 0 },
         alerts: { total: 0 },
-        peer_links: { total: 2, direct: 2, partial: 0, stale: 0 },
+        peer_links: {
+          items: [
+            {
+              observer_node_name: "hpc1",
+              peer_node_name: "storage1",
+              state: "direct",
+              same_lan: true,
+              peer_endpoint: "http://192.168.88.252:29999",
+            },
+            {
+              observer_node_name: "storage1",
+              peer_node_name: "hpc1",
+              state: "direct",
+              same_lan: true,
+              peer_endpoint: "http://192.168.88.13:29999",
+            },
+          ],
+          summary: { total: 2, direct: 2, partial: 0, stale: 0 },
+        },
       });
     }
     if (path === "/api/v1/host-observations") {
-      return json({ items: [] });
+      return json({
+        observations: [
+          {
+            node_name: "hpc1",
+            status: "idle",
+            heartbeat_at: "2026-05-06 07:20:00",
+            runtime_status: { available: true, runtime: { runtime_phase: "running" } },
+            cpu_telemetry: {
+              summary: {
+                total_memory_bytes: 269_960_683_520,
+                used_memory_bytes: 80_000_000_000,
+              },
+            },
+            gpu_telemetry: {
+              summary: {
+                device_count: 4,
+                total_vram_mb: 391_548,
+                used_vram_mb: 78_218,
+              },
+            },
+          },
+          {
+            node_name: "storage1",
+            status: "idle",
+            heartbeat_at: "2026-05-06 07:20:00",
+            runtime_status: { available: false, runtime: null },
+            cpu_telemetry: {
+              summary: {
+                total_memory_bytes: 64_891_473_920,
+                used_memory_bytes: 4_900_000_000,
+              },
+            },
+            gpu_telemetry: { summary: { device_count: 0 } },
+          },
+        ],
+      });
     }
     if (path === "/api/v1/hostd/hosts") {
       return json({ items: hostdHosts });
@@ -151,6 +224,13 @@ async function mockApi(page) {
     }
     if (path === "/api/v1/skills-factory") {
       return json(skillsFactoryPayload);
+    }
+    if (
+      path === "/api/v1/telemetry/snapshot" ||
+      path === "/api/v1/knowledge-vault/status" ||
+      path === "/api/v1/protocols"
+    ) {
+      return json({ items: [], nodes: [] });
     }
     return json({});
   });
@@ -210,6 +290,35 @@ const viewports = [
   { width: 768, height: 900 },
   { width: 390, height: 844 },
 ];
+
+test("dashboard renders host roles, capacity, LAN peers, and node overview", async ({ page }) => {
+  const pageErrors = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await mockApi(page);
+  await page.goto("/?page=dashboard");
+
+  await expect(page.getByRole("heading", { name: "LAN peer links" })).toBeVisible();
+  await expect(page.getByText("2 direct / 0 partial / 0 stale")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Naim nodes" })).toBeVisible();
+
+  const hpcCard = page.locator(".dashboard-hosts-panel .node-card").filter({ hasText: "hpc1" }).first();
+  await expect(hpcCard.locator(".role-badges .tag", { hasText: "worker" })).toBeVisible();
+  await expect(hpcCard.getByText("GPU count")).toBeVisible();
+  await expect(hpcCard.getByText("LAN peers")).toBeVisible();
+  await expect(hpcCard.getByText("1/1 direct")).toBeVisible();
+
+  const storageCard = page.locator(".dashboard-hosts-panel .node-card").filter({ hasText: "storage1" }).first();
+  await expect(storageCard.locator(".role-badges .tag", { hasText: "storage" })).toBeVisible();
+  await expect(storageCard).toContainText(/1[5-7] TB free/);
+
+  await hpcCard.getByRole("button", { name: /open node overview/i }).click();
+  const overviewDialog = page.getByRole("dialog", { name: /node overview hpc1/i });
+  await expect(overviewDialog).toBeVisible();
+  await expect(overviewDialog.getByText("Runtime", { exact: true })).toBeVisible();
+  await expect(overviewDialog.getByText("running", { exact: true })).toBeVisible();
+  expect(pageErrors).toEqual([]);
+});
 
 for (const viewport of viewports) {
   test(`new plane editor remains readable at ${viewport.width}x${viewport.height}`, async ({

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -1926,6 +1926,53 @@ function nodeConnectivityStatus(host) {
   };
 }
 
+function peerLinkState(link) {
+  if (String(link?.state || "").trim()) {
+    return String(link.state).toLowerCase();
+  }
+  if (link?.tcp_reachable === true) {
+    return "direct";
+  }
+  if (link?.seen_udp === true) {
+    return "partial";
+  }
+  return "stale";
+}
+
+function buildPeerLinksFromHostRegistry(hosts) {
+  const items = [];
+  for (const host of Array.isArray(hosts) ? hosts : []) {
+    const observerNodeName = host?.node_name || host?.nodeName || host?.name || "";
+    if (!observerNodeName || !Array.isArray(host?.lan_peers)) {
+      continue;
+    }
+    for (const peer of host.lan_peers) {
+      const state = peerLinkState(peer);
+      items.push({
+        ...peer,
+        observer_node_name: peer?.observer_node_name || observerNodeName,
+        peer_node_name: peer?.peer_node_name || "",
+        same_lan: peer?.same_lan === true || state === "direct",
+        state,
+      });
+    }
+  }
+  const summary = items.reduce(
+    (current, item) => {
+      const state = peerLinkState(item);
+      return {
+        ...current,
+        total: current.total + 1,
+        direct: current.direct + (state === "direct" ? 1 : 0),
+        partial: current.partial + (state === "partial" ? 1 : 0),
+        stale: current.stale + (state === "stale" ? 1 : 0),
+      };
+    },
+    { total: 0, direct: 0, partial: 0, stale: 0 },
+  );
+  return { items, summary };
+}
+
 function App() {
   const initialPlane = new URLSearchParams(window.location.search).get("plane") || "";
   const initialPage = new URLSearchParams(window.location.search).get("page") || "dashboard";
@@ -2079,6 +2126,7 @@ function App() {
   const refreshTimerRef = useRef(null);
   const refreshSequenceRef = useRef(0);
   const liveRefreshSequenceRef = useRef(0);
+  const fullRefreshInFlightRef = useRef(false);
   const selectedPlaneRef = useRef(selectedPlane);
   const eventSourceRef = useRef(null);
   const telemetrySourceRef = useRef(null);
@@ -2483,6 +2531,7 @@ function App() {
   }
 
   async function refreshAll(planeOverride) {
+    fullRefreshInFlightRef.current = true;
     const refreshId = ++refreshSequenceRef.current;
     const requestedPlane = planeOverride ?? selectedPlaneRef.current;
     const shouldCommitFleet = () =>
@@ -2684,6 +2733,9 @@ function App() {
     } finally {
       if (shouldCommitError()) {
         setLoading(false);
+      }
+      if (refreshId === refreshSequenceRef.current) {
+        fullRefreshInFlightRef.current = false;
       }
     }
   }
@@ -3184,6 +3236,10 @@ function App() {
     }
     refreshTimerRef.current = setTimeout(() => {
       refreshTimerRef.current = null;
+      if (fullRefreshInFlightRef.current) {
+        scheduleRefresh(planeName);
+        return;
+      }
       refreshAll(planeName);
     }, REFRESH_DEBOUNCE_MS);
   }
@@ -3714,6 +3770,9 @@ function App() {
     }
     const refreshDelay = selectedPage === "dashboard" ? FLEET_REFRESH_MS : AUTO_REFRESH_MS;
     const timer = setInterval(() => {
+      if (fullRefreshInFlightRef.current) {
+        return;
+      }
       if (selectedPlane && selectedPage === "dashboard") {
         const selectedPlaneDetailLoaded =
           planeDetail?.plane_name === selectedPlane ||
@@ -4141,15 +4200,16 @@ function App() {
         dashboardBrowsingSummary?.reason || "pending"
       }`
     : "disabled";
-  const peerLinkSummary = dashboard?.peer_links?.summary || {
-    total: 0,
-    direct: 0,
-    partial: 0,
-    stale: 0,
-  };
-  const peerLinkItems = Array.isArray(dashboard?.peer_links?.items)
+  const registryPeerLinks = buildPeerLinksFromHostRegistry(hostdHosts);
+  const dashboardPeerLinkItems = Array.isArray(dashboard?.peer_links?.items)
     ? dashboard.peer_links.items
     : [];
+  const peerLinkItems =
+    dashboardPeerLinkItems.length > 0 ? dashboardPeerLinkItems : registryPeerLinks.items;
+  const peerLinkSummary =
+    dashboardPeerLinkItems.length > 0
+      ? dashboard?.peer_links?.summary || registryPeerLinks.summary
+      : registryPeerLinks.summary;
   const chatLanguageOptions = supportedChatLanguageOptions(desiredState, interactionStatus);
   const selectedPlaneApplied =
     Number(planeRecord?.generation || 0) > 0 &&
@@ -5143,6 +5203,12 @@ function App() {
     const gpu = host?.gpu_telemetry?.summary || {};
     const capacity = registry?.capacity_summary || {};
     const connectivity = nodeConnectivityStatus(host);
+    const runtimeStatus = host?.runtime_status || {};
+    const runtimeAvailable = runtimeStatus?.available === true;
+    const runtimePhase =
+      runtimeStatus?.phase ||
+      runtimeStatus?.runtime?.runtime_phase ||
+      (runtimeAvailable ? "ready" : "unavailable");
     const storageSelected = isStorageRoleSelected(host);
     const storageEligible = isStorageRoleEligible(host);
     const lanPeers = Array.isArray(registry?.lan_peers) ? registry.lan_peers : [];

--- a/ui/operator-react/src/planeV2Form.jsx
+++ b/ui/operator-react/src/planeV2Form.jsx
@@ -4302,8 +4302,7 @@ export function PlaneV2FormBuilder({
           {(Array.isArray(form.extraApps) ? form.extraApps : []).map((entry, index) => (
             <div key={`extra-app-${index}`} className="plane-form-section" style={{ marginTop: 12 }}>
               <div
-                className="plane-form-grid"
-                style={{ gridTemplateColumns: "minmax(0,1fr) minmax(0,1fr) auto", alignItems: "end" }}
+                className="plane-form-grid plane-form-grid-extra-app-heading"
               >
                 <label className="field-label">
                   <InfoLabel info={FIELD_INFO.extraAppName}>App name</InfoLabel>

--- a/ui/operator-react/src/styles.css
+++ b/ui/operator-react/src/styles.css
@@ -1095,6 +1095,11 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
 }
 
+.plane-form-grid-extra-app-heading {
+  align-items: end;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+}
+
 .plane-features-grid {
   display: grid;
   gap: 12px;
@@ -1186,6 +1191,7 @@ body {
 @media (max-width: 1080px) {
   .plane-form-grid,
   .plane-form-grid-wide,
+  .plane-form-grid-extra-app-heading,
   .plane-features-grid,
   .skills-factory-selector-layout {
     grid-template-columns: minmax(0, 1fr);
@@ -2559,6 +2565,11 @@ body {
 
   .model-library-picker-head,
   .model-library-picker-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .plane-editor-modal .model-library-picker-head,
+  .plane-editor-modal .model-library-picker-row {
     grid-template-columns: minmax(0, 1fr);
   }
 


### PR DESCRIPTION
## Summary
- prevent overlapping dashboard full-refresh polling from invalidating slow but valid telemetry commits
- render LAN peer links from host registry when dashboard peer data has not committed yet
- fix Naim Nodes overview runtime crash and mobile plane editor grid collapse
- add Playwright coverage for dashboard node roles, capacity, LAN peers, and node overview

## Tests
- npm test
- npx playwright test e2e/plane-editor.spec.js --project=chromium
- npm run build