### PR TITLE
Make peer discovery controller-aware

### DIFF
--- a/common/include/naim/runtime/runtime_status.h
+++ b/common/include/naim/runtime/runtime_status.h
@@ -98,6 +98,9 @@ struct NetworkInterfaceTelemetry {
 struct PeerDiscoveryTelemetry {
   std::string peer_node_name;
   std::string peer_endpoint;
+  std::string cluster_id;
+  std::string controller_url;
+  std::string controller_fingerprint;
   std::string local_interface;
   std::string remote_address;
   bool seen_udp = false;

--- a/common/src/runtime/runtime_status.cpp
+++ b/common/src/runtime/runtime_status.cpp
@@ -258,6 +258,9 @@ json ToJson(const PeerDiscoveryTelemetry& peer) {
   return json{
       {"peer_node_name", peer.peer_node_name},
       {"peer_endpoint", peer.peer_endpoint},
+      {"cluster_id", peer.cluster_id},
+      {"controller_url", peer.controller_url},
+      {"controller_fingerprint", peer.controller_fingerprint},
       {"local_interface", peer.local_interface},
       {"remote_address", peer.remote_address},
       {"seen_udp", peer.seen_udp},
@@ -272,6 +275,9 @@ PeerDiscoveryTelemetry PeerDiscoveryTelemetryFromJson(const json& value) {
   PeerDiscoveryTelemetry peer;
   peer.peer_node_name = value.value("peer_node_name", std::string{});
   peer.peer_endpoint = value.value("peer_endpoint", std::string{});
+  peer.cluster_id = value.value("cluster_id", std::string{});
+  peer.controller_url = value.value("controller_url", std::string{});
+  peer.controller_fingerprint = value.value("controller_fingerprint", std::string{});
   peer.local_interface = value.value("local_interface", std::string{});
   peer.remote_address = value.value("remote_address", std::string{});
   peer.seen_udp = value.value("seen_udp", false);

--- a/controller/src/host/host_registry_service.cpp
+++ b/controller/src/host/host_registry_service.cpp
@@ -197,6 +197,11 @@ json HostRegistryService::BuildPayload(
   store.DeleteStaleHostPeerLinks(
       ControllerTimeSupport::SqlTimestampAfterSeconds(-kPeerLinkFreshSeconds));
   const auto all_peer_links = store.LoadHostPeerLinks();
+  const auto all_registered_hosts = store.LoadRegisteredHosts(std::nullopt);
+  std::set<std::string> registered_node_names;
+  for (const auto& registered_host : all_registered_hosts) {
+    registered_node_names.insert(registered_host.node_name);
+  }
   std::map<std::string, std::vector<naim::HostPeerLinkRecord>> peer_links_by_node;
   for (const auto& link : all_peer_links) {
     peer_links_by_node[link.observer_node_name].push_back(link);
@@ -229,10 +234,11 @@ json HostRegistryService::BuildPayload(
       planes.push_back(plane_name_value);
     }
     json lan_peers = json::array();
+    json unregistered_lan_peers = json::array();
     if (const auto peer_it = peer_links_by_node.find(host.node_name);
         peer_it != peer_links_by_node.end()) {
       for (const auto& link : peer_it->second) {
-        lan_peers.push_back(json{
+        json peer_payload{
             {"peer_node_name", link.peer_node_name},
             {"peer_endpoint", link.peer_endpoint.empty() ? json(nullptr) : json(link.peer_endpoint)},
             {"local_interface",
@@ -244,7 +250,14 @@ json HostRegistryService::BuildPayload(
             {"rtt_ms", link.rtt_ms > 0 ? json(link.rtt_ms) : json(nullptr)},
             {"last_seen_at", link.last_seen_at.empty() ? json(nullptr) : json(link.last_seen_at)},
             {"last_probe_at", link.last_probe_at.empty() ? json(nullptr) : json(link.last_probe_at)},
-        });
+        };
+        if (registered_node_names.empty() ||
+            registered_node_names.count(link.peer_node_name) > 0) {
+          lan_peers.push_back(std::move(peer_payload));
+        } else {
+          peer_payload["diagnostic_reason"] = "unregistered_node";
+          unregistered_lan_peers.push_back(std::move(peer_payload));
+        }
       }
     }
     items.push_back(json{
@@ -297,9 +310,10 @@ json HostRegistryService::BuildPayload(
              {"total_memory_bytes", inventory.total_memory_bytes > 0
                                         ? json(inventory.total_memory_bytes)
                                         : json(nullptr)},
-         }},
+        }},
         {"plane_participation", planes},
         {"lan_peers", std::move(lan_peers)},
+        {"unregistered_lan_peers", std::move(unregistered_lan_peers)},
         {"updated_at", host.updated_at},
     });
   }

--- a/controller/src/host/host_registry_service_tests.cpp
+++ b/controller/src/host/host_registry_service_tests.cpp
@@ -226,6 +226,16 @@ void TestHostRegistryPrunesExpiredLanPeers() {
   active_link.last_probe_at = now;
   store.UpsertHostPeerLink(active_link);
 
+  naim::HostPeerLinkRecord unregistered_link;
+  unregistered_link.observer_node_name = "hpc1";
+  unregistered_link.peer_node_name = "local-hostd";
+  unregistered_link.peer_endpoint = "http://192.168.88.13:29999";
+  unregistered_link.seen_udp = true;
+  unregistered_link.tcp_reachable = true;
+  unregistered_link.last_seen_at = now;
+  unregistered_link.last_probe_at = now;
+  store.UpsertHostPeerLink(unregistered_link);
+
   naim::HostPeerLinkRecord expired_link;
   expired_link.observer_node_name = "hpc1";
   expired_link.peer_node_name = "sandbox-old";
@@ -243,6 +253,15 @@ void TestHostRegistryPrunesExpiredLanPeers() {
   Expect(
       lan_peers.at(0).at("peer_node_name").get<std::string>() == "storage1",
       "host registry should keep the fresh storage peer");
+  const auto& unregistered_lan_peers =
+      payload.at("items").at(0).at("unregistered_lan_peers");
+  Expect(
+      unregistered_lan_peers.size() == 1,
+      "host registry should move unregistered LAN peers to diagnostics");
+  Expect(
+      unregistered_lan_peers.at(0).at("peer_node_name").get<std::string>() ==
+          "local-hostd",
+      "host registry should keep local-hostd out of the registered LAN peer graph");
   Expect(
       store.LoadHostPeerLinks(
                std::optional<std::string>("hpc1"),

--- a/controller/src/plane/dashboard_service.cpp
+++ b/controller/src/plane/dashboard_service.cpp
@@ -43,22 +43,64 @@ struct NodeDemandSummary {
 
 constexpr int kPeerLinkFreshSeconds = 120;
 
-json BuildPeerLinksPayload(const std::vector<naim::HostPeerLinkRecord>& links) {
+bool IsRegisteredPeerLink(
+    const naim::HostPeerLinkRecord& link,
+    const std::set<std::string>& registered_node_names) {
+  if (registered_node_names.empty()) {
+    return true;
+  }
+  return registered_node_names.count(link.observer_node_name) > 0 &&
+         registered_node_names.count(link.peer_node_name) > 0;
+}
+
+json BuildPeerLinkItem(
+    const naim::HostPeerLinkRecord& link,
+    const std::map<std::pair<std::string, std::string>, naim::HostPeerLinkRecord>&
+        by_direction) {
+  const auto reverse_it =
+      by_direction.find({link.peer_node_name, link.observer_node_name});
+  const bool direct = reverse_it != by_direction.end() &&
+                      link.tcp_reachable &&
+                      reverse_it->second.tcp_reachable;
+  const std::string state = direct ? "direct" : (link.seen_udp ? "partial" : "stale");
+  return json{
+      {"observer_node_name", link.observer_node_name},
+      {"peer_node_name", link.peer_node_name},
+      {"peer_endpoint", link.peer_endpoint.empty() ? json(nullptr) : json(link.peer_endpoint)},
+      {"local_interface",
+       link.local_interface.empty() ? json(nullptr) : json(link.local_interface)},
+      {"remote_address",
+       link.remote_address.empty() ? json(nullptr) : json(link.remote_address)},
+      {"seen_udp", link.seen_udp},
+      {"tcp_reachable", link.tcp_reachable},
+      {"same_lan", direct},
+      {"state", state},
+      {"rtt_ms", link.rtt_ms > 0 ? json(link.rtt_ms) : json(nullptr)},
+      {"last_seen_at", link.last_seen_at.empty() ? json(nullptr) : json(link.last_seen_at)},
+      {"last_probe_at", link.last_probe_at.empty() ? json(nullptr) : json(link.last_probe_at)},
+  };
+}
+
+json BuildPeerLinksPayload(
+    const std::vector<naim::HostPeerLinkRecord>& links,
+    const std::set<std::string>& registered_node_names) {
   std::map<std::pair<std::string, std::string>, naim::HostPeerLinkRecord> by_direction;
   for (const auto& link : links) {
     by_direction[{link.observer_node_name, link.peer_node_name}] = link;
   }
   json items = json::array();
+  json unregistered_items = json::array();
   int direct_count = 0;
   int partial_count = 0;
   int stale_count = 0;
   for (const auto& link : links) {
-    const auto reverse_it =
-        by_direction.find({link.peer_node_name, link.observer_node_name});
-    const bool direct = reverse_it != by_direction.end() &&
-                        link.tcp_reachable &&
-                        reverse_it->second.tcp_reachable;
-    const std::string state = direct ? "direct" : (link.seen_udp ? "partial" : "stale");
+    json item = BuildPeerLinkItem(link, by_direction);
+    const std::string state = item.value("state", std::string{});
+    if (!IsRegisteredPeerLink(link, registered_node_names)) {
+      item["diagnostic_reason"] = "unregistered_node";
+      unregistered_items.push_back(std::move(item));
+      continue;
+    }
     if (state == "direct") {
       ++direct_count;
     } else if (state == "partial") {
@@ -66,30 +108,18 @@ json BuildPeerLinksPayload(const std::vector<naim::HostPeerLinkRecord>& links) {
     } else {
       ++stale_count;
     }
-    items.push_back(json{
-        {"observer_node_name", link.observer_node_name},
-        {"peer_node_name", link.peer_node_name},
-        {"peer_endpoint", link.peer_endpoint.empty() ? json(nullptr) : json(link.peer_endpoint)},
-        {"local_interface",
-         link.local_interface.empty() ? json(nullptr) : json(link.local_interface)},
-        {"remote_address",
-         link.remote_address.empty() ? json(nullptr) : json(link.remote_address)},
-        {"seen_udp", link.seen_udp},
-        {"tcp_reachable", link.tcp_reachable},
-        {"same_lan", direct},
-        {"state", state},
-        {"rtt_ms", link.rtt_ms > 0 ? json(link.rtt_ms) : json(nullptr)},
-        {"last_seen_at", link.last_seen_at.empty() ? json(nullptr) : json(link.last_seen_at)},
-        {"last_probe_at", link.last_probe_at.empty() ? json(nullptr) : json(link.last_probe_at)},
-    });
+    items.push_back(std::move(item));
   }
+  const auto unregistered_count = unregistered_items.size();
   return json{
       {"items", std::move(items)},
+      {"unregistered_items", std::move(unregistered_items)},
       {"summary",
-       json{{"total", links.size()},
+       json{{"total", direct_count + partial_count + stale_count},
             {"direct", direct_count},
             {"partial", partial_count},
-            {"stale", stale_count}}},
+            {"stale", stale_count},
+            {"unregistered", unregistered_count}}},
   };
 }
 
@@ -715,7 +745,13 @@ nlohmann::json DashboardService::BuildPayload(
   payload["self_services"] = BuildSelfServicesPayload(store, stale_after_seconds);
   store.DeleteStaleHostPeerLinks(
       ControllerTimeSupport::SqlTimestampAfterSeconds(-kPeerLinkFreshSeconds));
-  payload["peer_links"] = BuildPeerLinksPayload(store.LoadHostPeerLinks());
+  std::set<std::string> registered_node_names;
+  for (const auto& host : store.LoadRegisteredHosts(std::nullopt)) {
+    registered_node_names.insert(host.node_name);
+  }
+  payload["peer_links"] = BuildPeerLinksPayload(
+      store.LoadHostPeerLinks(),
+      registered_node_names);
   if (!view.desired_state.has_value()) {
     payload["plane"] = nullptr;
     payload["planes"] = json::array();

--- a/controller/src/plane/dashboard_service_tests.cpp
+++ b/controller/src/plane/dashboard_service_tests.cpp
@@ -567,6 +567,62 @@ void TestPeerLinksIncludedWithoutDesiredPlane() {
   std::cout << "ok: peer-links-included-without-desired-plane" << '\n';
 }
 
+void TestDashboardMovesUnregisteredPeerLinksToDiagnostics() {
+  const auto db_path = MakeTempDbPath("peer-links-unregistered-diagnostics");
+  naim::ControllerStore store(db_path);
+  store.Initialize();
+  const naim::controller::ControllerRuntimeSupportService runtime_support_service;
+  const std::string now = runtime_support_service.UtcNowSqlTimestamp();
+  SeedHostRecord(store, "hpc1", "registered", "connected", now, now);
+  SeedHostRecord(store, "storage1", "registered", "connected", now, now);
+
+  naim::HostPeerLinkRecord hpc_to_storage;
+  hpc_to_storage.observer_node_name = "hpc1";
+  hpc_to_storage.peer_node_name = "storage1";
+  hpc_to_storage.peer_endpoint = "http://192.168.88.252:29999";
+  hpc_to_storage.seen_udp = true;
+  hpc_to_storage.tcp_reachable = true;
+  hpc_to_storage.last_seen_at = now;
+  hpc_to_storage.last_probe_at = now;
+  store.UpsertHostPeerLink(hpc_to_storage);
+
+  naim::HostPeerLinkRecord storage_to_hpc = hpc_to_storage;
+  storage_to_hpc.observer_node_name = "storage1";
+  storage_to_hpc.peer_node_name = "hpc1";
+  storage_to_hpc.peer_endpoint = "http://192.168.88.13:29999";
+  store.UpsertHostPeerLink(storage_to_hpc);
+
+  naim::HostPeerLinkRecord hpc_to_local;
+  hpc_to_local.observer_node_name = "hpc1";
+  hpc_to_local.peer_node_name = "local-hostd";
+  hpc_to_local.peer_endpoint = "http://192.168.88.13:29999";
+  hpc_to_local.seen_udp = true;
+  hpc_to_local.tcp_reachable = true;
+  hpc_to_local.last_seen_at = now;
+  hpc_to_local.last_probe_at = now;
+  store.UpsertHostPeerLink(hpc_to_local);
+
+  ScopedEnvVar admin_upstream("NAIM_CONTROLLER_ADMIN_UPSTREAM", std::nullopt);
+  ScopedEnvVar internal_upstream("NAIM_CONTROLLER_INTERNAL_UPSTREAM", std::nullopt);
+  ScopedEnvVar skills_factory_upstream("NAIM_SKILLS_FACTORY_UPSTREAM", std::nullopt);
+  ScopedEnvVar web_ui_root_env("NAIM_WEB_UI_ROOT", std::nullopt);
+  ScopedEnvVar hostd_node("NAIM_HOSTD_NODE_NAME", std::string("local-hostd"));
+
+  const auto payload = MakeDashboardService().BuildPayload(db_path, 300, std::nullopt);
+  const auto peer_links = payload.at("peer_links");
+  Expect(
+      peer_links.at("summary").at("total").get<int>() == 2,
+      "registered peer graph should include only registered hosts");
+  Expect(
+      peer_links.at("summary").at("unregistered").get<int>() == 1,
+      "unregistered peer link should be counted as diagnostics");
+  Expect(
+      peer_links.at("unregistered_items").at(0).at("peer_node_name").get<std::string>() ==
+          "local-hostd",
+      "local-hostd should be moved to diagnostics when it is not registered");
+  std::cout << "ok: peer-links-unregistered-diagnostics" << '\n';
+}
+
 void TestDashboardPrunesExpiredPeerLinks() {
   const auto db_path = MakeTempDbPath("dashboard-prunes-expired-peer-links");
   naim::ControllerStore store(db_path);
@@ -939,6 +995,7 @@ int main() {
     TestWebUiMissingStateCritical();
     TestSkillsFactoryProbeFailureDoesNotBreakPayload();
     TestPeerLinksIncludedWithoutDesiredPlane();
+    TestDashboardMovesUnregisteredPeerLinksToDiagnostics();
     TestDashboardPrunesExpiredPeerLinks();
     TestRuntimePayloadIncludesKvCacheBytes();
     TestPlaneScopedNodesIgnoreForeignRuntimeStatus();

--- a/controller/src/plane/plane_placement_payload_builder.cpp
+++ b/controller/src/plane/plane_placement_payload_builder.cpp
@@ -71,7 +71,9 @@ nlohmann::json PlanePlacementPayloadBuilder::Build() const {
                                        ? instance->name
                                        : app_name_it->second;
       const auto primary_it = instance->environment.find("NAIM_APP_PRIMARY");
-      const bool primary = primary_it != instance->environment.end() && primary_it->second == "true";
+      const bool primary =
+          (app_instances.size() == 1 && primary_it == instance->environment.end()) ||
+          (primary_it != instance->environment.end() && primary_it->second == "true");
       service_targets.push_back(nlohmann::json{
           {"service", primary ? nlohmann::json("app")
                               : nlohmann::json("app:" + app_name)},

--- a/launcher/include/run/hostd_peer_service.h
+++ b/launcher/include/run/hostd_peer_service.h
@@ -10,6 +10,8 @@
 #include <thread>
 #include <vector>
 
+#include <nlohmann/json_fwd.hpp>
+
 #include "config/launcher_options.h"
 
 namespace naim::hostd {
@@ -34,6 +36,9 @@ class HostdPeerService final {
   struct PeerRecord {
     std::string peer_node_name;
     std::string peer_endpoint;
+    std::string cluster_id;
+    std::string controller_url;
+    std::string controller_fingerprint;
     std::string local_interface;
     std::string remote_address;
     bool seen_udp = false;
@@ -61,6 +66,8 @@ class HostdPeerService final {
   void WritePeerState();
   bool ProbePeerHealth(const std::string& endpoint, int* rtt_ms) const;
   std::string BuildBeaconPayload() const;
+  std::string PeerClusterId() const;
+  bool BeaconMatchesCluster(const nlohmann::json& payload) const;
   std::string BuildAdvertisedEndpoint() const;
   std::string BestLanAddress() const;
   std::vector<std::pair<std::string, std::string>> LocalInterfaceAddresses() const;

--- a/launcher/src/run/hostd_peer_service.cpp
+++ b/launcher/src/run/hostd_peer_service.cpp
@@ -61,6 +61,27 @@ std::string EnvString(const char* name, const std::string& fallback) {
   return raw == nullptr || *raw == '\0' ? fallback : std::string(raw);
 }
 
+std::string TrimCopy(std::string value) {
+  const auto first = std::find_if_not(value.begin(), value.end(), [](unsigned char ch) {
+    return std::isspace(ch) != 0;
+  });
+  const auto last = std::find_if_not(value.rbegin(), value.rend(), [](unsigned char ch) {
+    return std::isspace(ch) != 0;
+  }).base();
+  if (first >= last) {
+    return {};
+  }
+  return std::string(first, last);
+}
+
+std::string NormalizeControllerUrl(std::string value) {
+  value = TrimCopy(std::move(value));
+  while (value.size() > 1 && value.back() == '/') {
+    value.pop_back();
+  }
+  return value;
+}
+
 bool IsPrivateIpv4(const std::string& address) {
   std::istringstream input(address);
   std::string octet_text;
@@ -359,13 +380,59 @@ std::string HostdPeerService::BuildAdvertisedEndpoint() const {
   return "http://" + BestLanAddress() + ":" + std::to_string(peer_port_);
 }
 
+std::string HostdPeerService::PeerClusterId() const {
+  const std::string fingerprint = TrimCopy(options_.controller_fingerprint);
+  if (!fingerprint.empty()) {
+    return "fingerprint:" + fingerprint;
+  }
+  const std::string controller_url = NormalizeControllerUrl(options_.controller_url);
+  if (!controller_url.empty()) {
+    return "controller:" + controller_url;
+  }
+  return {};
+}
+
 std::string HostdPeerService::BuildBeaconPayload() const {
-  return json{
+  json payload{
       {"service", "naim-peer-v1"},
       {"node_name", options_.node_name},
       {"peer_endpoint", BuildAdvertisedEndpoint()},
       {"sent_at", CurrentTimestamp()},
-  }.dump();
+  };
+  const std::string cluster_id = PeerClusterId();
+  if (!cluster_id.empty()) {
+    payload["cluster_id"] = cluster_id;
+  }
+  const std::string controller_url = NormalizeControllerUrl(options_.controller_url);
+  if (!controller_url.empty()) {
+    payload["controller_url"] = controller_url;
+  }
+  const std::string controller_fingerprint = TrimCopy(options_.controller_fingerprint);
+  if (!controller_fingerprint.empty()) {
+    payload["controller_fingerprint"] = controller_fingerprint;
+  }
+  return payload.dump();
+}
+
+bool HostdPeerService::BeaconMatchesCluster(const json& payload) const {
+  const std::string local_cluster_id = PeerClusterId();
+  if (local_cluster_id.empty()) {
+    return true;
+  }
+  const std::string remote_cluster_id = payload.value("cluster_id", std::string{});
+  if (!remote_cluster_id.empty()) {
+    return remote_cluster_id == local_cluster_id;
+  }
+  const std::string local_fingerprint = TrimCopy(options_.controller_fingerprint);
+  if (!local_fingerprint.empty()) {
+    return payload.value("controller_fingerprint", std::string{}) == local_fingerprint;
+  }
+  const std::string local_controller_url = NormalizeControllerUrl(options_.controller_url);
+  if (!local_controller_url.empty()) {
+    return NormalizeControllerUrl(payload.value("controller_url", std::string{})) ==
+           local_controller_url;
+  }
+  return true;
 }
 
 void HostdPeerService::BeaconLoop() {
@@ -444,11 +511,17 @@ void HostdPeerService::ListenLoop() {
     if (peer_node_name.empty() || peer_node_name == options_.node_name) {
       continue;
     }
+    if (!BeaconMatchesCluster(parsed)) {
+      continue;
+    }
     char remote_text[INET_ADDRSTRLEN] = {};
     inet_ntop(AF_INET, &remote.sin_addr, remote_text, sizeof(remote_text));
     PeerRecord peer;
     peer.peer_node_name = peer_node_name;
     peer.peer_endpoint = parsed.value("peer_endpoint", std::string{});
+    peer.cluster_id = parsed.value("cluster_id", std::string{});
+    peer.controller_url = parsed.value("controller_url", std::string{});
+    peer.controller_fingerprint = parsed.value("controller_fingerprint", std::string{});
     peer.remote_address = remote_text;
     peer.local_interface = LocalInterfaceAddresses().empty()
                                 ? std::string{}
@@ -527,6 +600,9 @@ void HostdPeerService::WritePeerState() {
     peers.push_back(json{
         {"peer_node_name", peer.peer_node_name},
         {"peer_endpoint", peer.peer_endpoint},
+        {"cluster_id", peer.cluster_id},
+        {"controller_url", peer.controller_url},
+        {"controller_fingerprint", peer.controller_fingerprint},
         {"local_interface", peer.local_interface},
         {"remote_address", peer.remote_address},
         {"seen_udp", peer.seen_udp},

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -1950,10 +1950,86 @@ function peerLinkState(link) {
   return "stale";
 }
 
+function hostRegistryNodeName(host) {
+  return String(host?.node_name || host?.nodeName || host?.name || "").trim();
+}
+
+function registeredHostNodeNames(hosts) {
+  return new Set(
+    (Array.isArray(hosts) ? hosts : [])
+      .map((host) => hostRegistryNodeName(host))
+      .filter(Boolean),
+  );
+}
+
+function summarizePeerLinks(items) {
+  return (Array.isArray(items) ? items : []).reduce(
+    (current, item) => {
+      const state = peerLinkState(item);
+      return {
+        ...current,
+        total: current.total + 1,
+        direct: current.direct + (state === "direct" ? 1 : 0),
+        partial: current.partial + (state === "partial" ? 1 : 0),
+        stale: current.stale + (state === "stale" ? 1 : 0),
+      };
+    },
+    { total: 0, direct: 0, partial: 0, stale: 0 },
+  );
+}
+
+function splitPeerLinksByRegisteredHosts(items, hosts) {
+  const registeredNames = registeredHostNodeNames(hosts);
+  if (registeredNames.size === 0) {
+    return {
+      registered: Array.isArray(items) ? items : [],
+      unregistered: [],
+    };
+  }
+  return (Array.isArray(items) ? items : []).reduce(
+    (current, item) => {
+      const observerNodeName = String(item?.observer_node_name || "").trim();
+      const peerNodeName = String(item?.peer_node_name || "").trim();
+      const registered =
+        registeredNames.has(observerNodeName) && registeredNames.has(peerNodeName);
+      current[registered ? "registered" : "unregistered"].push(item);
+      return current;
+    },
+    { registered: [], unregistered: [] },
+  );
+}
+
+function registeredLanPeers(registry, hosts) {
+  const peers = Array.isArray(registry?.lan_peers) ? registry.lan_peers : [];
+  const registeredNames = registeredHostNodeNames(hosts);
+  if (registeredNames.size === 0) {
+    return peers;
+  }
+  return peers.filter((peer) => registeredNames.has(String(peer?.peer_node_name || "").trim()));
+}
+
+function uniquePeerLinks(items) {
+  const seen = new Set();
+  const result = [];
+  for (const item of Array.isArray(items) ? items : []) {
+    const key = [
+      item?.observer_node_name || "",
+      item?.peer_node_name || "",
+      item?.peer_endpoint || "",
+    ].join("\u0000");
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(item);
+  }
+  return result;
+}
+
 function buildPeerLinksFromHostRegistry(hosts) {
   const items = [];
   for (const host of Array.isArray(hosts) ? hosts : []) {
-    const observerNodeName = host?.node_name || host?.nodeName || host?.name || "";
+    const observerNodeName = hostRegistryNodeName(host);
     if (!observerNodeName || !Array.isArray(host?.lan_peers)) {
       continue;
     }
@@ -1968,19 +2044,7 @@ function buildPeerLinksFromHostRegistry(hosts) {
       });
     }
   }
-  const summary = items.reduce(
-    (current, item) => {
-      const state = peerLinkState(item);
-      return {
-        ...current,
-        total: current.total + 1,
-        direct: current.direct + (state === "direct" ? 1 : 0),
-        partial: current.partial + (state === "partial" ? 1 : 0),
-        stale: current.stale + (state === "stale" ? 1 : 0),
-      };
-    },
-    { total: 0, direct: 0, partial: 0, stale: 0 },
-  );
+  const summary = summarizePeerLinks(items);
   return { items, summary };
 }
 
@@ -4215,12 +4279,32 @@ function App() {
   const dashboardPeerLinkItems = Array.isArray(dashboard?.peer_links?.items)
     ? dashboard.peer_links.items
     : [];
-  const peerLinkItems =
+  const dashboardPeerLinkDiagnostics = Array.isArray(dashboard?.peer_links?.unregistered_items)
+    ? dashboard.peer_links.unregistered_items
+    : [];
+  const rawPeerLinkItems =
     dashboardPeerLinkItems.length > 0 ? dashboardPeerLinkItems : registryPeerLinks.items;
-  const peerLinkSummary =
-    dashboardPeerLinkItems.length > 0
-      ? dashboard?.peer_links?.summary || registryPeerLinks.summary
-      : registryPeerLinks.summary;
+  const splitPeerLinkItems = splitPeerLinksByRegisteredHosts(rawPeerLinkItems, hostdHosts);
+  const peerLinkItems = splitPeerLinkItems.registered;
+  const registryPeerDiagnostics = (Array.isArray(hostdHosts) ? hostdHosts : []).flatMap((host) =>
+    (Array.isArray(host?.unregistered_lan_peers) ? host.unregistered_lan_peers : []).map((peer) => ({
+      ...peer,
+      observer_node_name: peer?.observer_node_name || hostRegistryNodeName(host),
+      peer_node_name: peer?.peer_node_name || "",
+      state: peerLinkState(peer),
+    })),
+  );
+  const peerLinkDiagnostics = uniquePeerLinks([
+    ...dashboardPeerLinkDiagnostics,
+    ...splitPeerLinkItems.unregistered,
+    ...registryPeerDiagnostics,
+  ]);
+  const peerLinkSummary = summarizePeerLinks(peerLinkItems);
+  const peerLinkDiagnosticsSummary = {
+    ...summarizePeerLinks(peerLinkDiagnostics),
+    unregistered:
+      Number(dashboard?.peer_links?.summary?.unregistered || 0) || peerLinkDiagnostics.length,
+  };
   const chatLanguageOptions = supportedChatLanguageOptions(desiredState, interactionStatus);
   const selectedPlaneApplied =
     Number(planeRecord?.generation || 0) > 0 &&
@@ -5169,7 +5253,7 @@ function App() {
           const usedMemoryBytes = Number(cpu.used_memory_bytes || 0);
           const totalMemoryBytes = Number(cpu.total_memory_bytes || storageCapacity.total_memory_bytes || 0);
           const gpuDeviceCount = Number(gpu.device_count || storageCapacity.gpu_count || 0);
-          const lanPeers = Array.isArray(registry?.lan_peers) ? registry.lan_peers : [];
+          const lanPeers = registeredLanPeers(registry, hostdHosts);
           const directLanPeers = lanPeers.filter((peer) => peer?.tcp_reachable === true);
           const storageTotalBytes = Number(storageCapacity.storage_total_bytes || 0);
           const storageFreeBytes = Number(storageCapacity.storage_free_bytes || 0);
@@ -5222,7 +5306,10 @@ function App() {
       (runtimeAvailable ? "ready" : "unavailable");
     const storageSelected = isStorageRoleSelected(host);
     const storageEligible = isStorageRoleEligible(host);
-    const lanPeers = Array.isArray(registry?.lan_peers) ? registry.lan_peers : [];
+    const lanPeers = registeredLanPeers(registry, hostdHosts);
+    const unregisteredLanPeers = Array.isArray(registry?.unregistered_lan_peers)
+      ? registry.unregistered_lan_peers
+      : [];
     const gpuDeviceCount = Number(gpu.device_count || capacity.gpu_count || 0);
     const totalMemoryBytes = Number(cpu.total_memory_bytes || capacity.total_memory_bytes || 0);
     const usedMemoryBytes = Number(cpu.used_memory_bytes || 0);
@@ -5332,6 +5419,25 @@ function App() {
               <div className="metric-grid">
                 {lanPeers.map((peer) => (
                   <div className="metric-row" key={`${host?.node_name}:${peer?.peer_node_name}`}>
+                    <span>{peer?.peer_node_name || "peer"}</span>
+                    <strong>
+                      {peer?.tcp_reachable ? "direct" : peer?.seen_udp ? "partial" : "stale"}
+                      {peer?.peer_endpoint ? ` / ${peer.peer_endpoint}` : ""}
+                    </strong>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ) : null}
+          {unregisteredLanPeers.length > 0 ? (
+            <section className="subpanel">
+              <div className="subpanel-header">
+                <h3>LAN diagnostics</h3>
+                <span className="subpanel-meta">{`${unregisteredLanPeers.length} unregistered`}</span>
+              </div>
+              <div className="metric-grid">
+                {unregisteredLanPeers.map((peer) => (
+                  <div className="metric-row" key={`${host?.node_name}:diagnostic:${peer?.peer_node_name}`}>
                     <span>{peer?.peer_node_name || "peer"}</span>
                     <strong>
                       {peer?.tcp_reachable ? "direct" : peer?.seen_udp ? "partial" : "stale"}
@@ -8364,6 +8470,39 @@ function App() {
                   </div>
                 )}
               </section>
+
+              {peerLinkDiagnostics.length > 0 ? (
+                <section className="subpanel dashboard-services-panel">
+                  <div className="subpanel-header">
+                    <h3>LAN diagnostics</h3>
+                    <span className="subpanel-meta">
+                      {`${peerLinkDiagnosticsSummary.unregistered || 0} unregistered`}
+                    </span>
+                  </div>
+                  <div className="plane-list">
+                    {peerLinkDiagnostics.slice(0, 8).map((link) => (
+                      <article
+                        className="node-card"
+                        key={`diagnostic:${link?.observer_node_name}:${link?.peer_node_name}`}
+                      >
+                        <div className="card-row">
+                          <strong>{link?.observer_node_name || "node"} to {link?.peer_node_name || "peer"}</strong>
+                          <div className="pill is-warning">
+                            {statusDot("is-warning")}
+                            <span>{link?.diagnostic_reason || "unregistered"}</span>
+                          </div>
+                        </div>
+                        <div className="metric-grid">
+                          <div className="metric-row"><span>Endpoint</span><strong>{link?.peer_endpoint || "n/a"}</strong></div>
+                          <div className="metric-row"><span>Remote</span><strong>{link?.remote_address || "n/a"}</strong></div>
+                          <div className="metric-row"><span>Interface</span><strong>{link?.local_interface || "n/a"}</strong></div>
+                          <div className="metric-row"><span>State</span><strong>{link?.state || peerLinkState(link)}</strong></div>
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
 
               <section className="subpanel dashboard-hosts-panel">
                 <div className="subpanel-header">


### PR DESCRIPTION
## Summary
- add controller/cluster identity to hostd LAN peer beacons and ignore beacons from other controllers
- keep production LAN peer graph limited to registered hosts and show unregistered peers as diagnostics
- preserve local-hostd single-machine behavior and treat single app instances as primary placement targets

## Tests
- cmake --build build/macos/arm64 --target naim-dashboard-service-tests naim-host-registry-tests naim-node -j 8
- ./build/macos/arm64/naim-dashboard-service-tests
- ./build/macos/arm64/naim-host-registry-tests
- npm test
- npm run build