### PR TITLE
Add secured connection plane feature

### DIFF
--- a/common/include/naim/state/auth_repository.h
+++ b/common/include/naim/state/auth_repository.h
@@ -71,12 +71,43 @@ class AuthRepository final {
   bool RevokeAuthSession(const std::string& token, const std::string& revoked_at);
   bool TouchAuthSession(const std::string& token, const std::string& last_used_at);
 
+  void UpsertSecuredConnectionUser(const SecuredConnectionUserRecord& user);
+  std::optional<SecuredConnectionUserRecord> LoadActiveSecuredConnectionUser(
+      const std::string& user_id) const;
+  std::optional<SecuredConnectionUserRecord> LoadActiveSecuredConnectionUserByNameAndFingerprint(
+      const std::string& name,
+      const std::string& fingerprint) const;
+  std::vector<SecuredConnectionUserRecord> LoadSecuredConnectionUsers(
+      const std::optional<std::string>& search,
+      bool include_revoked) const;
+  bool RevokeSecuredConnectionUser(
+      const std::string& user_id,
+      const std::string& revoked_at);
+  void TouchSecuredConnectionUser(
+      const std::string& user_id,
+      const std::string& last_authorized_at);
+  void InsertSecuredConnectionSession(const SecuredConnectionSessionRecord& session);
+  std::optional<SecuredConnectionSessionRecord> LoadActiveSecuredConnectionSession(
+      const std::string& token,
+      const std::string& plane_name) const;
+  bool TouchSecuredConnectionSession(
+      const std::string& token,
+      const std::string& last_used_at);
+  void InsertSecuredConnectionAuthLog(const SecuredConnectionAuthLogRecord& log);
+  std::vector<SecuredConnectionAuthLogRecord> LoadSecuredConnectionAuthLog(
+      const std::optional<std::string>& plane_name,
+      const std::optional<std::string>& user_id,
+      int limit) const;
+
  private:
   static UserRecord ReadUser(sqlite3_stmt* statement);
   static WebAuthnCredentialRecord ReadWebAuthnCredential(sqlite3_stmt* statement);
   static RegistrationInviteRecord ReadRegistrationInvite(sqlite3_stmt* statement);
   static UserSshKeyRecord ReadUserSshKey(sqlite3_stmt* statement);
   static AuthSessionRecord ReadAuthSession(sqlite3_stmt* statement);
+  static SecuredConnectionUserRecord ReadSecuredConnectionUser(sqlite3_stmt* statement);
+  static SecuredConnectionSessionRecord ReadSecuredConnectionSession(sqlite3_stmt* statement);
+  static SecuredConnectionAuthLogRecord ReadSecuredConnectionAuthLog(sqlite3_stmt* statement);
 
   sqlite3* db_;
 };

--- a/common/include/naim/state/models.h
+++ b/common/include/naim/state/models.h
@@ -360,6 +360,11 @@ struct VoiceListenerFeatureSpec {
   std::optional<std::string> image;
 };
 
+struct SecuredConnectionFeatureSpec {
+  bool enabled = false;
+  std::vector<std::string> user_ids;
+};
+
 using WebGatewayPolicySettings = BrowsingPolicySettings;
 using WebGatewaySettings = BrowsingSettings;
 
@@ -386,6 +391,7 @@ struct DesiredState {
   std::optional<TurboQuantFeatureSpec> turboquant;
   std::optional<ContextCompressionFeatureSpec> context_compression;
   std::optional<VoiceListenerFeatureSpec> voice_listener;
+  std::optional<SecuredConnectionFeatureSpec> secured_connection;
   std::optional<ExternalAppHostConfig> app_host;
   InferenceRuntimeSettings inference;
   WorkerGroupSpec worker_group;

--- a/common/include/naim/state/sqlite_store.h
+++ b/common/include/naim/state/sqlite_store.h
@@ -294,6 +294,42 @@ struct AuthSessionRecord {
   std::string last_used_at;
 };
 
+struct SecuredConnectionUserRecord {
+  std::string id;
+  std::string name;
+  std::string public_key;
+  std::string fingerprint;
+  std::string search_text;
+  std::string last_authorized_at;
+  std::string created_at;
+  std::string updated_at;
+  std::string revoked_at;
+};
+
+struct SecuredConnectionSessionRecord {
+  std::string token;
+  std::string user_id;
+  std::string plane_name;
+  std::string expires_at;
+  std::string created_at;
+  std::string revoked_at;
+  std::string last_used_at;
+};
+
+struct SecuredConnectionAuthLogRecord {
+  int id = 0;
+  std::string plane_name;
+  std::string user_id;
+  std::string user_name;
+  std::string fingerprint;
+  std::string event_type;
+  std::string outcome;
+  std::string remote_addr;
+  std::string message;
+  std::string created_at;
+  std::string payload_json = "{}";
+};
+
 struct ModelLibraryDownloadJobRecord {
   std::string id;
   std::string job_kind = "download";
@@ -506,6 +542,33 @@ class ControllerStore {
   bool TouchAuthSession(
       const std::string& token,
       const std::string& last_used_at);
+  void UpsertSecuredConnectionUser(const SecuredConnectionUserRecord& user);
+  std::optional<SecuredConnectionUserRecord> LoadActiveSecuredConnectionUser(
+      const std::string& user_id) const;
+  std::optional<SecuredConnectionUserRecord> LoadActiveSecuredConnectionUserByNameAndFingerprint(
+      const std::string& name,
+      const std::string& fingerprint) const;
+  std::vector<SecuredConnectionUserRecord> LoadSecuredConnectionUsers(
+      const std::optional<std::string>& search = std::nullopt,
+      bool include_revoked = false) const;
+  bool RevokeSecuredConnectionUser(
+      const std::string& user_id,
+      const std::string& revoked_at);
+  void TouchSecuredConnectionUser(
+      const std::string& user_id,
+      const std::string& last_authorized_at);
+  void InsertSecuredConnectionSession(const SecuredConnectionSessionRecord& session);
+  std::optional<SecuredConnectionSessionRecord> LoadActiveSecuredConnectionSession(
+      const std::string& token,
+      const std::string& plane_name) const;
+  bool TouchSecuredConnectionSession(
+      const std::string& token,
+      const std::string& last_used_at);
+  void InsertSecuredConnectionAuthLog(const SecuredConnectionAuthLogRecord& log);
+  std::vector<SecuredConnectionAuthLogRecord> LoadSecuredConnectionAuthLog(
+      const std::optional<std::string>& plane_name = std::nullopt,
+      const std::optional<std::string>& user_id = std::nullopt,
+      int limit = 100) const;
   void UpsertModelLibraryDownloadJob(const ModelLibraryDownloadJobRecord& job);
   std::optional<ModelLibraryDownloadJobRecord> LoadModelLibraryDownloadJob(
       const std::string& job_id) const;

--- a/common/src/state/auth_repository.cpp
+++ b/common/src/state/auth_repository.cpp
@@ -447,6 +447,212 @@ bool AuthRepository::TouchAuthSession(
   return sqlite3_changes(db_) > 0;
 }
 
+void AuthRepository::UpsertSecuredConnectionUser(
+    const SecuredConnectionUserRecord& user) {
+  Statement statement(
+      db_,
+      "INSERT INTO secured_connection_users("
+      "id, name, public_key, fingerprint, search_text, last_authorized_at, updated_at, revoked_at"
+      ") VALUES (?1, ?2, ?3, ?4, ?5, ?6, CURRENT_TIMESTAMP, ?7) "
+      "ON CONFLICT(id) DO UPDATE SET "
+      "name = excluded.name, public_key = excluded.public_key, "
+      "fingerprint = excluded.fingerprint, search_text = excluded.search_text, "
+      "updated_at = CURRENT_TIMESTAMP, revoked_at = excluded.revoked_at;");
+  statement.BindText(1, user.id);
+  statement.BindText(2, user.name);
+  statement.BindText(3, user.public_key);
+  statement.BindText(4, user.fingerprint);
+  statement.BindText(5, user.search_text);
+  statement.BindText(6, user.last_authorized_at);
+  statement.BindText(7, user.revoked_at);
+  statement.StepDone();
+}
+
+std::optional<SecuredConnectionUserRecord>
+AuthRepository::LoadActiveSecuredConnectionUser(const std::string& user_id) const {
+  Statement statement(
+      db_,
+      "SELECT id, name, public_key, fingerprint, search_text, last_authorized_at, "
+      "created_at, updated_at, revoked_at "
+      "FROM secured_connection_users WHERE id = ?1 AND revoked_at = '';");
+  statement.BindText(1, user_id);
+  if (!statement.StepRow()) {
+    return std::nullopt;
+  }
+  return ReadSecuredConnectionUser(statement.raw());
+}
+
+std::optional<SecuredConnectionUserRecord>
+AuthRepository::LoadActiveSecuredConnectionUserByNameAndFingerprint(
+    const std::string& name,
+    const std::string& fingerprint) const {
+  Statement statement(
+      db_,
+      "SELECT id, name, public_key, fingerprint, search_text, last_authorized_at, "
+      "created_at, updated_at, revoked_at "
+      "FROM secured_connection_users "
+      "WHERE name = ?1 AND fingerprint = ?2 AND revoked_at = '';");
+  statement.BindText(1, name);
+  statement.BindText(2, fingerprint);
+  if (!statement.StepRow()) {
+    return std::nullopt;
+  }
+  return ReadSecuredConnectionUser(statement.raw());
+}
+
+std::vector<SecuredConnectionUserRecord> AuthRepository::LoadSecuredConnectionUsers(
+    const std::optional<std::string>& search,
+    bool include_revoked) const {
+  std::string sql =
+      "SELECT id, name, public_key, fingerprint, search_text, last_authorized_at, "
+      "created_at, updated_at, revoked_at "
+      "FROM secured_connection_users WHERE 1 = 1";
+  if (!include_revoked) {
+    sql += " AND revoked_at = ''";
+  }
+  if (search.has_value() && !search->empty()) {
+    sql +=
+        " AND lower(id || ' ' || name || ' ' || public_key || ' ' || fingerprint || "
+        "' ' || search_text || ' ' || last_authorized_at || ' ' || created_at || "
+        "' ' || updated_at) LIKE lower(?1)";
+  }
+  sql += " ORDER BY name ASC, created_at ASC, id ASC;";
+  Statement statement(db_, sql);
+  if (search.has_value() && !search->empty()) {
+    statement.BindText(1, "%" + *search + "%");
+  }
+  std::vector<SecuredConnectionUserRecord> users;
+  while (statement.StepRow()) {
+    users.push_back(ReadSecuredConnectionUser(statement.raw()));
+  }
+  return users;
+}
+
+bool AuthRepository::RevokeSecuredConnectionUser(
+    const std::string& user_id,
+    const std::string& revoked_at) {
+  Statement statement(
+      db_,
+      "UPDATE secured_connection_users "
+      "SET revoked_at = ?2, updated_at = CURRENT_TIMESTAMP "
+      "WHERE id = ?1 AND revoked_at = '';");
+  statement.BindText(1, user_id);
+  statement.BindText(2, revoked_at);
+  statement.StepDone();
+  return sqlite3_changes(db_) > 0;
+}
+
+void AuthRepository::TouchSecuredConnectionUser(
+    const std::string& user_id,
+    const std::string& last_authorized_at) {
+  Statement statement(
+      db_,
+      "UPDATE secured_connection_users "
+      "SET last_authorized_at = ?2, updated_at = CURRENT_TIMESTAMP "
+      "WHERE id = ?1;");
+  statement.BindText(1, user_id);
+  statement.BindText(2, last_authorized_at);
+  statement.StepDone();
+}
+
+void AuthRepository::InsertSecuredConnectionSession(
+    const SecuredConnectionSessionRecord& session) {
+  Statement statement(
+      db_,
+      "INSERT INTO secured_connection_sessions("
+      "token, user_id, plane_name, expires_at, last_used_at"
+      ") VALUES (?1, ?2, ?3, ?4, ?5);");
+  statement.BindText(1, session.token);
+  statement.BindText(2, session.user_id);
+  statement.BindText(3, session.plane_name);
+  statement.BindText(4, session.expires_at);
+  statement.BindText(5, session.last_used_at);
+  statement.StepDone();
+}
+
+std::optional<SecuredConnectionSessionRecord>
+AuthRepository::LoadActiveSecuredConnectionSession(
+    const std::string& token,
+    const std::string& plane_name) const {
+  Statement statement(
+      db_,
+      "SELECT token, user_id, plane_name, expires_at, created_at, revoked_at, last_used_at "
+      "FROM secured_connection_sessions "
+      "WHERE token = ?1 AND plane_name = ?2 AND revoked_at = '' "
+      "AND expires_at >= CURRENT_TIMESTAMP;");
+  statement.BindText(1, token);
+  statement.BindText(2, plane_name);
+  if (!statement.StepRow()) {
+    return std::nullopt;
+  }
+  return ReadSecuredConnectionSession(statement.raw());
+}
+
+bool AuthRepository::TouchSecuredConnectionSession(
+    const std::string& token,
+    const std::string& last_used_at) {
+  Statement statement(
+      db_,
+      "UPDATE secured_connection_sessions SET last_used_at = ?2 WHERE token = ?1;");
+  statement.BindText(1, token);
+  statement.BindText(2, last_used_at);
+  statement.StepDone();
+  return sqlite3_changes(db_) > 0;
+}
+
+void AuthRepository::InsertSecuredConnectionAuthLog(
+    const SecuredConnectionAuthLogRecord& log) {
+  Statement statement(
+      db_,
+      "INSERT INTO secured_connection_auth_log("
+      "plane_name, user_id, user_name, fingerprint, event_type, outcome, "
+      "remote_addr, message, payload_json"
+      ") VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9);");
+  statement.BindText(1, log.plane_name);
+  statement.BindText(2, log.user_id);
+  statement.BindText(3, log.user_name);
+  statement.BindText(4, log.fingerprint);
+  statement.BindText(5, log.event_type);
+  statement.BindText(6, log.outcome);
+  statement.BindText(7, log.remote_addr);
+  statement.BindText(8, log.message);
+  statement.BindText(9, log.payload_json.empty() ? std::string("{}") : log.payload_json);
+  statement.StepDone();
+}
+
+std::vector<SecuredConnectionAuthLogRecord>
+AuthRepository::LoadSecuredConnectionAuthLog(
+    const std::optional<std::string>& plane_name,
+    const std::optional<std::string>& user_id,
+    int limit) const {
+  std::string sql =
+      "SELECT id, plane_name, user_id, user_name, fingerprint, event_type, outcome, "
+      "remote_addr, message, created_at, payload_json "
+      "FROM secured_connection_auth_log WHERE 1 = 1";
+  int next_index = 1;
+  if (plane_name.has_value() && !plane_name->empty()) {
+    sql += " AND plane_name = ?" + std::to_string(next_index++);
+  }
+  if (user_id.has_value() && !user_id->empty()) {
+    sql += " AND user_id = ?" + std::to_string(next_index++);
+  }
+  sql += " ORDER BY created_at DESC, id DESC LIMIT ?" + std::to_string(next_index) + ";";
+  Statement statement(db_, sql);
+  next_index = 1;
+  if (plane_name.has_value() && !plane_name->empty()) {
+    statement.BindText(next_index++, *plane_name);
+  }
+  if (user_id.has_value() && !user_id->empty()) {
+    statement.BindText(next_index++, *user_id);
+  }
+  statement.BindInt(next_index, limit <= 0 ? 100 : limit);
+  std::vector<SecuredConnectionAuthLogRecord> logs;
+  while (statement.StepRow()) {
+    logs.push_back(ReadSecuredConnectionAuthLog(statement.raw()));
+  }
+  return logs;
+}
+
 UserRecord AuthRepository::ReadUser(sqlite3_stmt* statement) {
   return UserRecord{
       sqlite3_column_int(statement, 0),
@@ -511,6 +717,51 @@ AuthSessionRecord AuthRepository::ReadAuthSession(sqlite3_stmt* statement) {
       ToColumnText(statement, 5),
       ToColumnText(statement, 6),
       ToColumnText(statement, 7),
+  };
+}
+
+SecuredConnectionUserRecord AuthRepository::ReadSecuredConnectionUser(
+    sqlite3_stmt* statement) {
+  return SecuredConnectionUserRecord{
+      ToColumnText(statement, 0),
+      ToColumnText(statement, 1),
+      ToColumnText(statement, 2),
+      ToColumnText(statement, 3),
+      ToColumnText(statement, 4),
+      ToColumnText(statement, 5),
+      ToColumnText(statement, 6),
+      ToColumnText(statement, 7),
+      ToColumnText(statement, 8),
+  };
+}
+
+SecuredConnectionSessionRecord AuthRepository::ReadSecuredConnectionSession(
+    sqlite3_stmt* statement) {
+  return SecuredConnectionSessionRecord{
+      ToColumnText(statement, 0),
+      ToColumnText(statement, 1),
+      ToColumnText(statement, 2),
+      ToColumnText(statement, 3),
+      ToColumnText(statement, 4),
+      ToColumnText(statement, 5),
+      ToColumnText(statement, 6),
+  };
+}
+
+SecuredConnectionAuthLogRecord AuthRepository::ReadSecuredConnectionAuthLog(
+    sqlite3_stmt* statement) {
+  return SecuredConnectionAuthLogRecord{
+      sqlite3_column_int(statement, 0),
+      ToColumnText(statement, 1),
+      ToColumnText(statement, 2),
+      ToColumnText(statement, 3),
+      ToColumnText(statement, 4),
+      ToColumnText(statement, 5),
+      ToColumnText(statement, 6),
+      ToColumnText(statement, 7),
+      ToColumnText(statement, 8),
+      ToColumnText(statement, 9),
+      ToColumnText(statement, 10),
   };
 }
 

--- a/common/src/state/desired_state_v2_projector.cpp
+++ b/common/src/state/desired_state_v2_projector.cpp
@@ -76,7 +76,8 @@ void DesiredStateV2Projector::CollectInstancesAndDisks() {
 void DesiredStateV2Projector::ProjectIdentity() {
   value_["plane_name"] = state_.plane_name;
   value_["plane_mode"] = ToString(state_.plane_mode);
-  if (state_.protected_plane) {
+  if (state_.protected_plane ||
+      (state_.secured_connection.has_value() && state_.secured_connection->enabled)) {
     value_["protected"] = true;
   }
 }
@@ -113,7 +114,7 @@ void DesiredStateV2Projector::ProjectPlacement() {
 
 void DesiredStateV2Projector::ProjectFeatures() {
   if (!state_.turboquant.has_value() && !state_.context_compression.has_value() &&
-      !state_.voice_listener.has_value()) {
+      !state_.voice_listener.has_value() && !state_.secured_connection.has_value()) {
     return;
   }
   nlohmann::json features = nlohmann::json::object();
@@ -172,6 +173,12 @@ void DesiredStateV2Projector::ProjectFeatures() {
       voice_json["image"] = voice_module_instance_->image;
     }
     features["voice_listener"] = std::move(voice_json);
+  }
+  if (state_.secured_connection.has_value()) {
+    features["secured_connection"] = {
+        {"enabled", state_.secured_connection->enabled},
+        {"user_ids", state_.secured_connection->user_ids},
+    };
   }
   value_["features"] = std::move(features);
 }

--- a/common/src/state/desired_state_v2_projector_tests.cpp
+++ b/common/src/state/desired_state_v2_projector_tests.cpp
@@ -151,6 +151,15 @@ void ExpectRoundTrip(const json& source, const std::string& name) {
             rendered.context_compression->memory_priority,
         name + ": context_compression.memory_priority mismatch");
   }
+  if (rendered.secured_connection.has_value()) {
+    Expect(rerendered.secured_connection.has_value(),
+           name + ": secured_connection missing after rerender");
+    Expect(rerendered.secured_connection->enabled == rendered.secured_connection->enabled,
+           name + ": secured_connection.enabled mismatch");
+    Expect(rerendered.secured_connection->user_ids == rendered.secured_connection->user_ids,
+           name + ": secured_connection.user_ids mismatch");
+    Expect(rerendered.protected_plane, name + ": secured_connection should imply protected");
+  }
   if (source.contains("features") && source.at("features").contains("turboquant")) {
     Expect(projected.contains("features"), name + ": features block missing after projection");
     Expect(projected.at("features").contains("turboquant"),
@@ -176,6 +185,15 @@ void ExpectRoundTrip(const json& source, const std::string& name) {
     Expect(projected.at("features").at("context_compression") ==
                source.at("features").at("context_compression"),
            name + ": context_compression projection mismatch");
+  }
+  if (source.contains("features") && source.at("features").contains("secured_connection")) {
+    Expect(projected.contains("features"), name + ": features block missing after projection");
+    Expect(projected.at("features").contains("secured_connection"),
+           name + ": secured_connection block missing after projection");
+    Expect(projected.at("features").at("secured_connection") ==
+               source.at("features").at("secured_connection"),
+           name + ": secured_connection projection mismatch");
+    Expect(projected.value("protected", false), name + ": secured_connection must project protected=true");
   }
   if (source.contains("skills")) {
     Expect(projected.contains("skills"), name + ": skills block missing after projection");
@@ -375,7 +393,9 @@ int main() {
                 {"target", "dialog_and_knowledge"},
                 {"memory_priority", "balanced"}}},
               {"turboquant",
-               {{"enabled", true}, {"cache_type_k", "turbo4"}, {"cache_type_v", "turbo4"}}}}},
+               {{"enabled", true}, {"cache_type_k", "turbo4"}, {"cache_type_v", "turbo4"}}},
+              {"secured_connection",
+               {{"enabled", true}, {"user_ids", json::array({"scu-alpha", "scu-beta"})}}}}},
             {"runtime",
              {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
             {"infer", {{"replicas", 1}}},

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -389,6 +389,20 @@ void DesiredStateV2Renderer::RenderFeatures() {
       state_.voice_listener = std::move(voice_listener);
     }
   }
+  if (features_json_.contains("secured_connection") &&
+      features_json_.at("secured_connection").is_object()) {
+    const auto& secured_json = features_json_.at("secured_connection");
+    if (secured_json.value("enabled", false)) {
+      SecuredConnectionFeatureSpec secured_connection;
+      secured_connection.enabled = true;
+      if (secured_json.contains("user_ids") && secured_json.at("user_ids").is_array()) {
+        secured_connection.user_ids =
+            secured_json.at("user_ids").get<std::vector<std::string>>();
+      }
+      state_.secured_connection = std::move(secured_connection);
+      state_.protected_plane = true;
+    }
+  }
 }
 
 void DesiredStateV2Renderer::RenderHooks() {

--- a/common/src/state/desired_state_v2_validator.cpp
+++ b/common/src/state/desired_state_v2_validator.cpp
@@ -479,6 +479,40 @@ void DesiredStateV2Validator::ValidateFeatures() const {
           "desired-state v2 features.context_compression.memory_priority supports balanced only");
     }
   }
+  if (features.contains("secured_connection")) {
+    if (!features.at("secured_connection").is_object()) {
+      throw std::runtime_error(
+          "desired-state v2 features.secured_connection must be an object");
+    }
+    const auto& secured_connection = features.at("secured_connection");
+    if (secured_connection.contains("enabled") &&
+        !secured_connection.at("enabled").is_boolean()) {
+      throw std::runtime_error(
+          "desired-state v2 features.secured_connection.enabled must be a boolean");
+    }
+    if (secured_connection.contains("user_ids") &&
+        !secured_connection.at("user_ids").is_array()) {
+      throw std::runtime_error(
+          "desired-state v2 features.secured_connection.user_ids must be an array");
+    }
+    std::set<std::string> user_ids;
+    if (secured_connection.contains("user_ids")) {
+      for (const auto& item : secured_connection.at("user_ids")) {
+        if (!item.is_string() || item.get<std::string>().empty()) {
+          throw std::runtime_error(
+              "desired-state v2 features.secured_connection.user_ids entries must be non-empty strings");
+        }
+        if (!user_ids.insert(item.get<std::string>()).second) {
+          throw std::runtime_error(
+              "desired-state v2 features.secured_connection.user_ids entries must be unique");
+        }
+      }
+    }
+    if (secured_connection.value("enabled", false) && user_ids.empty()) {
+      throw std::runtime_error(
+          "desired-state v2 features.secured_connection requires at least one user_id when enabled");
+    }
+  }
 }
 
 void DesiredStateV2Validator::ValidateRuntime() const {

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -137,6 +137,58 @@ int main() {
     }
 
     {
+      const json secured_connection_enabled{
+          {"version", 2},
+          {"plane_name", "secured-connection-enabled"},
+          {"plane_mode", "llm"},
+          {"model",
+           {
+               {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+               {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+               {"served_model_name", "qwen-secured"},
+           }},
+          {"features",
+           {{"secured_connection",
+             {{"enabled", true}, {"user_ids", json::array({"scu-alpha"})}}}}},
+          {"runtime",
+           {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+          {"infer", {{"replicas", 1}}},
+          {"app", {{"enabled", false}}},
+      };
+      const auto state = RenderValid(secured_connection_enabled, "secured-connection-enabled");
+      Expect(state.protected_plane, "secured-connection-enabled: should imply protected plane");
+      Expect(
+          state.secured_connection.has_value() &&
+              state.secured_connection->user_ids == std::vector<std::string>{"scu-alpha"},
+          "secured-connection-enabled: user ids mismatch");
+      std::cout << "ok: secured-connection-enabled" << '\n';
+    }
+
+    {
+      json invalid_secured_connection{
+          {"version", 2},
+          {"plane_name", "secured-connection-empty"},
+          {"plane_mode", "llm"},
+          {"model",
+           {
+               {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+               {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+               {"served_model_name", "qwen-secured"},
+           }},
+          {"features",
+           {{"secured_connection", {{"enabled", true}, {"user_ids", json::array()}}}}},
+          {"runtime",
+           {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+          {"infer", {{"replicas", 1}}},
+          {"app", {{"enabled", false}}},
+      };
+      ExpectInvalid(invalid_secured_connection, "secured-connection-empty");
+      invalid_secured_connection["features"]["secured_connection"]["user_ids"] =
+          json::array({"scu-alpha", "scu-alpha"});
+      ExpectInvalid(invalid_secured_connection, "secured-connection-duplicate-user");
+    }
+
+    {
       ExpectInvalid(
           json{
               {"version", 2},

--- a/common/src/state/sqlite_store.cpp
+++ b/common/src/state/sqlite_store.cpp
@@ -205,6 +205,49 @@ CREATE TABLE IF NOT EXISTS auth_sessions (
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS secured_connection_users (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    public_key TEXT NOT NULL,
+    fingerprint TEXT NOT NULL UNIQUE,
+    search_text TEXT NOT NULL DEFAULT '',
+    last_authorized_at TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_at TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS secured_connection_sessions (
+    token TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    plane_name TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_at TEXT NOT NULL DEFAULT '',
+    last_used_at TEXT NOT NULL DEFAULT '',
+    FOREIGN KEY (user_id) REFERENCES secured_connection_users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_secured_connection_sessions_plane
+    ON secured_connection_sessions(plane_name, user_id);
+
+CREATE TABLE IF NOT EXISTS secured_connection_auth_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    plane_name TEXT NOT NULL DEFAULT '',
+    user_id TEXT NOT NULL DEFAULT '',
+    user_name TEXT NOT NULL DEFAULT '',
+    fingerprint TEXT NOT NULL DEFAULT '',
+    event_type TEXT NOT NULL,
+    outcome TEXT NOT NULL,
+    remote_addr TEXT NOT NULL DEFAULT '',
+    message TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    payload_json TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_secured_connection_auth_log_plane_created
+    ON secured_connection_auth_log(plane_name, created_at DESC);
+
 CREATE TABLE IF NOT EXISTS model_library_download_jobs (
     id TEXT PRIMARY KEY,
     job_kind TEXT NOT NULL DEFAULT 'download',
@@ -1041,6 +1084,77 @@ bool ControllerStore::TouchAuthSession(
     const std::string& token,
     const std::string& last_used_at) {
   return AuthRepository(AsSqlite(db_)).TouchAuthSession(token, last_used_at);
+}
+
+void ControllerStore::UpsertSecuredConnectionUser(
+    const SecuredConnectionUserRecord& user) {
+  AuthRepository(AsSqlite(db_)).UpsertSecuredConnectionUser(user);
+}
+
+std::optional<SecuredConnectionUserRecord>
+ControllerStore::LoadActiveSecuredConnectionUser(const std::string& user_id) const {
+  return AuthRepository(AsSqlite(db_)).LoadActiveSecuredConnectionUser(user_id);
+}
+
+std::optional<SecuredConnectionUserRecord>
+ControllerStore::LoadActiveSecuredConnectionUserByNameAndFingerprint(
+    const std::string& name,
+    const std::string& fingerprint) const {
+  return AuthRepository(AsSqlite(db_))
+      .LoadActiveSecuredConnectionUserByNameAndFingerprint(name, fingerprint);
+}
+
+std::vector<SecuredConnectionUserRecord> ControllerStore::LoadSecuredConnectionUsers(
+    const std::optional<std::string>& search,
+    bool include_revoked) const {
+  return AuthRepository(AsSqlite(db_))
+      .LoadSecuredConnectionUsers(search, include_revoked);
+}
+
+bool ControllerStore::RevokeSecuredConnectionUser(
+    const std::string& user_id,
+    const std::string& revoked_at) {
+  return AuthRepository(AsSqlite(db_)).RevokeSecuredConnectionUser(user_id, revoked_at);
+}
+
+void ControllerStore::TouchSecuredConnectionUser(
+    const std::string& user_id,
+    const std::string& last_authorized_at) {
+  AuthRepository(AsSqlite(db_)).TouchSecuredConnectionUser(user_id, last_authorized_at);
+}
+
+void ControllerStore::InsertSecuredConnectionSession(
+    const SecuredConnectionSessionRecord& session) {
+  AuthRepository(AsSqlite(db_)).InsertSecuredConnectionSession(session);
+}
+
+std::optional<SecuredConnectionSessionRecord>
+ControllerStore::LoadActiveSecuredConnectionSession(
+    const std::string& token,
+    const std::string& plane_name) const {
+  return AuthRepository(AsSqlite(db_))
+      .LoadActiveSecuredConnectionSession(token, plane_name);
+}
+
+bool ControllerStore::TouchSecuredConnectionSession(
+    const std::string& token,
+    const std::string& last_used_at) {
+  return AuthRepository(AsSqlite(db_))
+      .TouchSecuredConnectionSession(token, last_used_at);
+}
+
+void ControllerStore::InsertSecuredConnectionAuthLog(
+    const SecuredConnectionAuthLogRecord& log) {
+  AuthRepository(AsSqlite(db_)).InsertSecuredConnectionAuthLog(log);
+}
+
+std::vector<SecuredConnectionAuthLogRecord>
+ControllerStore::LoadSecuredConnectionAuthLog(
+    const std::optional<std::string>& plane_name,
+    const std::optional<std::string>& user_id,
+    int limit) const {
+  return AuthRepository(AsSqlite(db_))
+      .LoadSecuredConnectionAuthLog(plane_name, user_id, limit);
 }
 
 void ControllerStore::UpsertModelLibraryDownloadJob(

--- a/common/src/state/sqlite_store_schema.cpp
+++ b/common/src/state/sqlite_store_schema.cpp
@@ -158,6 +158,54 @@ void InitializeSchema(
       "created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,"
       "updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP"
       ");");
+  Exec(
+      db,
+      "CREATE TABLE IF NOT EXISTS secured_connection_users("
+      "id TEXT PRIMARY KEY,"
+      "name TEXT NOT NULL UNIQUE,"
+      "public_key TEXT NOT NULL,"
+      "fingerprint TEXT NOT NULL UNIQUE,"
+      "search_text TEXT NOT NULL DEFAULT '',"
+      "last_authorized_at TEXT NOT NULL DEFAULT '',"
+      "created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+      "updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+      "revoked_at TEXT NOT NULL DEFAULT ''"
+      ");");
+  Exec(
+      db,
+      "CREATE TABLE IF NOT EXISTS secured_connection_sessions("
+      "token TEXT PRIMARY KEY,"
+      "user_id TEXT NOT NULL,"
+      "plane_name TEXT NOT NULL,"
+      "expires_at TEXT NOT NULL,"
+      "created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+      "revoked_at TEXT NOT NULL DEFAULT '',"
+      "last_used_at TEXT NOT NULL DEFAULT '',"
+      "FOREIGN KEY (user_id) REFERENCES secured_connection_users(id) ON DELETE CASCADE"
+      ");");
+  Exec(
+      db,
+      "CREATE INDEX IF NOT EXISTS idx_secured_connection_sessions_plane "
+      "ON secured_connection_sessions(plane_name, user_id);");
+  Exec(
+      db,
+      "CREATE TABLE IF NOT EXISTS secured_connection_auth_log("
+      "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+      "plane_name TEXT NOT NULL DEFAULT '',"
+      "user_id TEXT NOT NULL DEFAULT '',"
+      "user_name TEXT NOT NULL DEFAULT '',"
+      "fingerprint TEXT NOT NULL DEFAULT '',"
+      "event_type TEXT NOT NULL,"
+      "outcome TEXT NOT NULL,"
+      "remote_addr TEXT NOT NULL DEFAULT '',"
+      "message TEXT NOT NULL DEFAULT '',"
+      "created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+      "payload_json TEXT NOT NULL DEFAULT '{}'"
+      ");");
+  Exec(
+      db,
+      "CREATE INDEX IF NOT EXISTS idx_secured_connection_auth_log_plane_created "
+      "ON secured_connection_auth_log(plane_name, created_at DESC);");
   EnsureColumn(
       db,
       "planes",

--- a/common/src/state/state_json.cpp
+++ b/common/src/state/state_json.cpp
@@ -184,13 +184,22 @@ json ToJson(const VoiceListenerFeatureSpec& voice_listener) {
   return result;
 }
 
+json ToJson(const SecuredConnectionFeatureSpec& secured_connection) {
+  return json{
+      {"enabled", secured_connection.enabled},
+      {"user_ids", secured_connection.user_ids},
+  };
+}
+
 json DesiredStateToJson(const DesiredState& state) {
   json result = {
       {"plane_name", state.plane_name},
       {"plane_shared_disk_name", state.plane_shared_disk_name},
       {"control_root", state.control_root},
       {"plane_mode", ToString(state.plane_mode)},
-      {"protected", state.protected_plane},
+      {"protected",
+       state.protected_plane ||
+           (state.secured_connection.has_value() && state.secured_connection->enabled)},
       {"inference",
        {
            {"primary_infer_node", state.inference.primary_infer_node},
@@ -257,7 +266,7 @@ json DesiredStateToJson(const DesiredState& state) {
     result["knowledge"] = SettingsCodecs::ToJson(*state.knowledge);
   }
   if (state.turboquant.has_value() || state.context_compression.has_value() ||
-      state.voice_listener.has_value()) {
+      state.voice_listener.has_value() || state.secured_connection.has_value()) {
     json features = json::object();
     if (state.turboquant.has_value()) {
       features["turboquant"] = ToJson(*state.turboquant);
@@ -267,6 +276,9 @@ json DesiredStateToJson(const DesiredState& state) {
     }
     if (state.voice_listener.has_value()) {
       features["voice_listener"] = ToJson(*state.voice_listener);
+    }
+    if (state.secured_connection.has_value()) {
+      features["secured_connection"] = ToJson(*state.secured_connection);
     }
     result["features"] = std::move(features);
   }
@@ -402,6 +414,22 @@ DesiredState DesiredStateFromJson(const json& value) {
         voice_listener.model.required = model_json.value("required", true);
       }
       state.voice_listener = std::move(voice_listener);
+    }
+    if (features.contains("secured_connection") &&
+        features.at("secured_connection").is_object()) {
+      SecuredConnectionFeatureSpec secured_connection;
+      const auto& secured_connection_json = features.at("secured_connection");
+      secured_connection.enabled =
+          secured_connection_json.value("enabled", secured_connection.enabled);
+      if (secured_connection_json.contains("user_ids") &&
+          secured_connection_json.at("user_ids").is_array()) {
+        secured_connection.user_ids =
+            secured_connection_json.at("user_ids").get<std::vector<std::string>>();
+      }
+      state.secured_connection = std::move(secured_connection);
+      if (state.secured_connection->enabled) {
+        state.protected_plane = true;
+      }
     }
   }
   if (value.contains("app_host") && value.at("app_host").is_object()) {
@@ -617,6 +645,7 @@ DesiredState SliceDesiredStateForNode(
   result.browsing = state.browsing;
   result.turboquant = state.turboquant;
   result.context_compression = state.context_compression;
+  result.secured_connection = state.secured_connection;
   result.app_host = state.app_host;
   result.inference = state.inference;
   result.worker_group = state.worker_group;

--- a/controller/include/auth/auth_http_service.h
+++ b/controller/include/auth/auth_http_service.h
@@ -64,6 +64,16 @@ class AuthHttpService {
   HttpResponse HandleSshKeyDelete(
       const std::string& db_path,
       const HttpRequest& request) const;
+  HttpResponse HandleUserStorage(
+      const std::string& db_path,
+      const HttpRequest& request) const;
+  HttpResponse HandleUserStorageItem(
+      const std::string& db_path,
+      const HttpRequest& request,
+      const std::string& user_id) const;
+  HttpResponse HandleUserStorageAuthLog(
+      const std::string& db_path,
+      const HttpRequest& request) const;
   HttpResponse HandleSshChallenge(
       const std::string& db_path,
       const HttpRequest& request) const;

--- a/controller/include/auth/auth_pending_flows.h
+++ b/controller/include/auth/auth_pending_flows.h
@@ -19,6 +19,8 @@ struct PendingSshChallenge {
   std::string challenge_id;
   int user_id = 0;
   int ssh_key_id = 0;
+  std::string secured_user_id;
+  bool secured_connection = false;
   std::string username;
   std::string plane_name;
   std::string fingerprint;

--- a/controller/src/auth/auth_http_service.cpp
+++ b/controller/src/auth/auth_http_service.cpp
@@ -1,5 +1,7 @@
 #include "auth/auth_http_service.h"
 
+#include <algorithm>
+#include <cctype>
 #include <stdexcept>
 #include <utility>
 
@@ -33,6 +35,154 @@ bool StartsWithPathPrefix(const std::string& path, const std::string& prefix) {
   return path.rfind(prefix, 0) == 0;
 }
 
+std::optional<std::string> FindHeaderString(
+    const HttpRequest& request,
+    const std::string& key) {
+  std::string lowered;
+  lowered.reserve(key.size());
+  for (unsigned char ch : key) {
+    lowered.push_back(static_cast<char>(std::tolower(ch)));
+  }
+  const auto it = request.headers.find(lowered);
+  if (it == request.headers.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+std::string LowercaseCopy(const std::string& value) {
+  std::string lowered;
+  lowered.reserve(value.size());
+  for (unsigned char ch : value) {
+    lowered.push_back(static_cast<char>(std::tolower(ch)));
+  }
+  return lowered;
+}
+
+std::string TrimCopy(const std::string& value) {
+  const auto begin = std::find_if_not(
+      value.begin(),
+      value.end(),
+      [](unsigned char ch) { return std::isspace(ch) != 0; });
+  const auto end = std::find_if_not(
+                       value.rbegin(),
+                       value.rend(),
+                       [](unsigned char ch) { return std::isspace(ch) != 0; })
+                       .base();
+  if (begin >= end) {
+    return "";
+  }
+  return std::string(begin, end);
+}
+
+std::string FirstForwardedValue(const std::string& value) {
+  const auto comma = value.find(',');
+  return comma == std::string::npos ? value : value.substr(0, comma);
+}
+
+std::string RequestScheme(const HttpRequest& request) {
+  if (const auto forwarded = FindHeaderString(request, "x-forwarded-proto");
+      forwarded.has_value()) {
+    return LowercaseCopy(TrimCopy(FirstForwardedValue(*forwarded)));
+  }
+  if (const auto forwarded = FindHeaderString(request, "x-forwarded-ssl");
+      forwarded.has_value() && LowercaseCopy(*forwarded) == "on") {
+    return "https";
+  }
+  if (const auto forwarded = FindHeaderString(request, "x-forwarded-port");
+      forwarded.has_value() && *forwarded == "443") {
+    return "https";
+  }
+  return "http";
+}
+
+std::string HostWithoutPort(const std::string& host) {
+  if (host.empty()) {
+    return host;
+  }
+  if (host.front() == '[') {
+    const auto close = host.find(']');
+    return close == std::string::npos ? host : host.substr(1, close - 1);
+  }
+  const auto colon = host.find(':');
+  return colon == std::string::npos ? host : host.substr(0, colon);
+}
+
+bool IsLocalHostName(const std::string& host) {
+  const std::string lowered = LowercaseCopy(HostWithoutPort(host));
+  return lowered.empty() || lowered == "localhost" || lowered == "127.0.0.1" ||
+         lowered == "::1";
+}
+
+bool IsSecuredRequestTransportAllowed(const HttpRequest& request) {
+  if (RequestScheme(request) == "https") {
+    return true;
+  }
+  auto host = FindHeaderString(request, "x-forwarded-host");
+  if (!host.has_value()) {
+    host = FindHeaderString(request, "host");
+  }
+  return IsLocalHostName(host.value_or(""));
+}
+
+std::string RequestRemoteAddress(const HttpRequest& request) {
+  if (const auto forwarded = FindHeaderString(request, "x-forwarded-for");
+      forwarded.has_value()) {
+    return FirstForwardedValue(*forwarded);
+  }
+  if (const auto real_ip = FindHeaderString(request, "x-real-ip"); real_ip.has_value()) {
+    return *real_ip;
+  }
+  return "";
+}
+
+std::string BuildSecuredUserSearchText(
+    const naim::SecuredConnectionUserRecord& user) {
+  return user.id + " " + user.name + " " + user.public_key + " " +
+         user.fingerprint + " " + user.last_authorized_at + " " +
+         user.created_at + " " + user.updated_at;
+}
+
+json BuildSecuredConnectionUserPayload(
+    const naim::SecuredConnectionUserRecord& user) {
+  return json{
+      {"id", user.id},
+      {"name", user.name},
+      {"public_key", user.public_key},
+      {"fingerprint", user.fingerprint},
+      {"last_authorized_at",
+       user.last_authorized_at.empty() ? json(nullptr) : json(user.last_authorized_at)},
+      {"created_at", user.created_at},
+      {"updated_at", user.updated_at},
+      {"revoked_at", user.revoked_at.empty() ? json(nullptr) : json(user.revoked_at)},
+  };
+}
+
+json BuildSecuredConnectionAuthLogPayload(
+    const naim::SecuredConnectionAuthLogRecord& log) {
+  json payload = json::parse(log.payload_json.empty() ? "{}" : log.payload_json, nullptr, false);
+  if (payload.is_discarded()) {
+    payload = json::object();
+  }
+  return json{
+      {"id", log.id},
+      {"plane_name", log.plane_name},
+      {"user_id", log.user_id},
+      {"user_name", log.user_name},
+      {"fingerprint", log.fingerprint},
+      {"event_type", log.event_type},
+      {"outcome", log.outcome},
+      {"remote_addr", log.remote_addr},
+      {"message", log.message},
+      {"created_at", log.created_at},
+      {"payload", std::move(payload)},
+  };
+}
+
+bool ContainsString(const std::vector<std::string>& items, const std::string& value) {
+  return std::find(items.begin(), items.end(), value) != items.end();
+}
+
 constexpr int InviteLifetimeSeconds() {
   return 60 * 60;
 }
@@ -52,6 +202,18 @@ AuthHttpService::AuthHttpService(AuthHttpSupport support) : support_(std::move(s
 std::optional<HttpResponse> AuthHttpService::HandleRequest(
     const std::string& db_path,
     const HttpRequest& request) const {
+  if (request.path == "/api/v1/user-storage") {
+    return HandleUserStorage(db_path, request);
+  }
+  if (request.path == "/api/v1/user-storage/auth-log") {
+    return HandleUserStorageAuthLog(db_path, request);
+  }
+  if (StartsWithPathPrefix(request.path, "/api/v1/user-storage/")) {
+    return HandleUserStorageItem(
+        db_path,
+        request,
+        request.path.substr(std::string("/api/v1/user-storage/").size()));
+  }
   if (!StartsWithPathPrefix(request.path, "/api/v1/auth/")) {
     return std::nullopt;
   }
@@ -827,6 +989,173 @@ HttpResponse AuthHttpService::HandleSshKeyDelete(
   }
 }
 
+HttpResponse AuthHttpService::HandleUserStorage(
+    const std::string& db_path,
+    const HttpRequest& request) const {
+  try {
+    naim::ControllerStore store(db_path);
+    store.Initialize();
+    if (!support_.require_controller_admin_user(store, request).has_value()) {
+      return support_.build_json_response(
+          401,
+          json{{"status", "unauthorized"}, {"message", "admin authentication required"}},
+          {});
+    }
+    if (request.method == "GET") {
+      std::optional<std::string> search;
+      if (const auto it = request.query_params.find("search");
+          it != request.query_params.end() && !it->second.empty()) {
+        search = it->second;
+      }
+      const bool include_revoked =
+          request.query_params.find("include_revoked") != request.query_params.end() &&
+          request.query_params.at("include_revoked") == "true";
+      json items = json::array();
+      for (const auto& user : store.LoadSecuredConnectionUsers(search, include_revoked)) {
+        items.push_back(BuildSecuredConnectionUserPayload(user));
+      }
+      return support_.build_json_response(200, json{{"items", std::move(items)}}, {});
+    }
+    if (request.method != "POST") {
+      return support_.build_json_response(405, json{{"status", "method_not_allowed"}}, {});
+    }
+    const json body = ParseJsonBody(request);
+    naim::SecuredConnectionUserRecord user;
+    user.id = "scu_" + support_.sanitize_token_for_path(naim::RandomTokenBase64(18));
+    user.name = support_.trim(body.value("name", std::string{}));
+    user.public_key = support_.trim(body.value("public_key", std::string{}));
+    if (user.name.empty() || user.public_key.empty()) {
+      return support_.build_json_response(
+          400,
+          json{{"status", "bad_request"},
+               {"message", "name and public_key are required"}},
+          {});
+    }
+    user.fingerprint = support_.compute_ssh_public_key_fingerprint(user.public_key);
+    user.search_text = BuildSecuredUserSearchText(user);
+    store.UpsertSecuredConnectionUser(user);
+    const auto saved = store.LoadActiveSecuredConnectionUser(user.id);
+    return support_.build_json_response(
+        201,
+        json{{"item", BuildSecuredConnectionUserPayload(saved.value_or(user))}},
+        {});
+  } catch (const std::invalid_argument& error) {
+    return support_.build_json_response(
+        400,
+        json{{"status", "bad_request"}, {"message", error.what()}, {"path", request.path}},
+        {});
+  } catch (const std::exception& error) {
+    return support_.build_json_response(
+        500,
+        json{{"status", "internal_error"}, {"message", error.what()}, {"path", request.path}},
+        {});
+  }
+}
+
+HttpResponse AuthHttpService::HandleUserStorageItem(
+    const std::string& db_path,
+    const HttpRequest& request,
+    const std::string& user_id) const {
+  try {
+    naim::ControllerStore store(db_path);
+    store.Initialize();
+    if (!support_.require_controller_admin_user(store, request).has_value()) {
+      return support_.build_json_response(
+          401,
+          json{{"status", "unauthorized"}, {"message", "admin authentication required"}},
+          {});
+    }
+    const auto current = store.LoadActiveSecuredConnectionUser(user_id);
+    if (!current.has_value()) {
+      return support_.build_json_response(
+          404, json{{"status", "not_found"}, {"message", "user not found"}}, {});
+    }
+    if (request.method == "DELETE") {
+      store.RevokeSecuredConnectionUser(user_id, support_.utc_now_sql_timestamp());
+      return support_.build_json_response(200, json{{"status", "revoked"}}, {});
+    }
+    if (request.method != "PATCH") {
+      return support_.build_json_response(405, json{{"status", "method_not_allowed"}}, {});
+    }
+    const json body = ParseJsonBody(request);
+    naim::SecuredConnectionUserRecord next = *current;
+    if (body.contains("name")) {
+      next.name = support_.trim(body.value("name", std::string{}));
+    }
+    if (body.contains("public_key")) {
+      next.public_key = support_.trim(body.value("public_key", std::string{}));
+      next.fingerprint = support_.compute_ssh_public_key_fingerprint(next.public_key);
+    }
+    if (next.name.empty() || next.public_key.empty()) {
+      return support_.build_json_response(
+          400,
+          json{{"status", "bad_request"},
+               {"message", "name and public_key are required"}},
+          {});
+    }
+    next.search_text = BuildSecuredUserSearchText(next);
+    store.UpsertSecuredConnectionUser(next);
+    const auto saved = store.LoadActiveSecuredConnectionUser(user_id);
+    return support_.build_json_response(
+        200,
+        json{{"item", BuildSecuredConnectionUserPayload(saved.value_or(next))}},
+        {});
+  } catch (const std::invalid_argument& error) {
+    return support_.build_json_response(
+        400,
+        json{{"status", "bad_request"}, {"message", error.what()}, {"path", request.path}},
+        {});
+  } catch (const std::exception& error) {
+    return support_.build_json_response(
+        500,
+        json{{"status", "internal_error"}, {"message", error.what()}, {"path", request.path}},
+        {});
+  }
+}
+
+HttpResponse AuthHttpService::HandleUserStorageAuthLog(
+    const std::string& db_path,
+    const HttpRequest& request) const {
+  if (request.method != "GET") {
+    return support_.build_json_response(405, json{{"status", "method_not_allowed"}}, {});
+  }
+  try {
+    naim::ControllerStore store(db_path);
+    store.Initialize();
+    if (!support_.require_controller_admin_user(store, request).has_value()) {
+      return support_.build_json_response(
+          401,
+          json{{"status", "unauthorized"}, {"message", "admin authentication required"}},
+          {});
+    }
+    std::optional<std::string> plane_name;
+    if (const auto it = request.query_params.find("plane_name");
+        it != request.query_params.end() && !it->second.empty()) {
+      plane_name = it->second;
+    }
+    std::optional<std::string> user_id;
+    if (const auto it = request.query_params.find("user_id");
+        it != request.query_params.end() && !it->second.empty()) {
+      user_id = it->second;
+    }
+    int limit = 100;
+    if (const auto it = request.query_params.find("limit");
+        it != request.query_params.end() && !it->second.empty()) {
+      limit = std::stoi(it->second);
+    }
+    json items = json::array();
+    for (const auto& log : store.LoadSecuredConnectionAuthLog(plane_name, user_id, limit)) {
+      items.push_back(BuildSecuredConnectionAuthLogPayload(log));
+    }
+    return support_.build_json_response(200, json{{"items", std::move(items)}}, {});
+  } catch (const std::exception& error) {
+    return support_.build_json_response(
+        500,
+        json{{"status", "internal_error"}, {"message", error.what()}, {"path", request.path}},
+        {});
+  }
+}
+
 HttpResponse AuthHttpService::HandleSshChallenge(
     const std::string& db_path,
     const HttpRequest& request) const {
@@ -835,7 +1164,8 @@ HttpResponse AuthHttpService::HandleSshChallenge(
   }
   try {
     const json body = ParseJsonBody(request);
-    const std::string username = support_.trim(body.value("username", std::string{}));
+    const std::string username = support_.trim(
+        body.value("username", body.value("name", std::string{})));
     const std::string plane_name = support_.trim(body.value("plane_name", std::string{}));
     const std::string fingerprint = support_.trim(body.value("fingerprint", std::string{}));
     if (username.empty() || plane_name.empty() || fingerprint.empty()) {
@@ -854,6 +1184,109 @@ HttpResponse AuthHttpService::HandleSshChallenge(
           404,
           json{{"status", "not_found"},
                {"message", "protected plane not found"}},
+          {});
+    }
+    const bool secured_enabled =
+        desired_state->secured_connection.has_value() &&
+        desired_state->secured_connection->enabled;
+    if (secured_enabled) {
+      if (!IsSecuredRequestTransportAllowed(request)) {
+        store.InsertSecuredConnectionAuthLog({
+            0,
+            plane_name,
+            "",
+            username,
+            fingerprint,
+            "challenge",
+            "rejected",
+            RequestRemoteAddress(request),
+            "HTTPS/TLS is required for secured connection authentication",
+            "",
+            "{}",
+        });
+        return support_.build_json_response(
+            403,
+            json{{"status", "forbidden"},
+                 {"message", "secured connection authentication requires HTTPS/TLS"}},
+            {});
+      }
+      const auto secured_user =
+          store.LoadActiveSecuredConnectionUserByNameAndFingerprint(username, fingerprint);
+      if (!secured_user.has_value()) {
+        store.InsertSecuredConnectionAuthLog({
+            0,
+            plane_name,
+            "",
+            username,
+            fingerprint,
+            "challenge",
+            "rejected",
+            RequestRemoteAddress(request),
+            "secured connection user or fingerprint not found",
+            "",
+            "{}",
+        });
+        return support_.build_json_response(
+            404,
+            json{{"status", "not_found"},
+                 {"message", "secured connection user or fingerprint not found"}},
+            {});
+      }
+      if (!ContainsString(desired_state->secured_connection->user_ids, secured_user->id)) {
+        store.InsertSecuredConnectionAuthLog({
+            0,
+            plane_name,
+            secured_user->id,
+            secured_user->name,
+            fingerprint,
+            "challenge",
+            "rejected",
+            RequestRemoteAddress(request),
+            "user is not allowed for secured plane",
+            "",
+            "{}",
+        });
+        return support_.build_json_response(
+            403,
+            json{{"status", "forbidden"},
+                 {"message", "user is not allowed for secured plane"}},
+            {});
+      }
+      PendingSshChallenge challenge;
+      challenge.challenge_id = naim::RandomTokenBase64(24);
+      challenge.secured_connection = true;
+      challenge.secured_user_id = secured_user->id;
+      challenge.username = secured_user->name;
+      challenge.plane_name = plane_name;
+      challenge.fingerprint = fingerprint;
+      challenge.challenge_token = naim::RandomTokenBase64(24);
+      challenge.expires_at =
+          support_.sql_timestamp_after_seconds(SshChallengeLifetimeSeconds());
+      challenge.message = support_.build_ssh_challenge_message(
+          challenge.username,
+          challenge.plane_name,
+          challenge.challenge_token,
+          challenge.expires_at);
+      support_.save_pending_ssh_challenge(challenge);
+      store.InsertSecuredConnectionAuthLog({
+          0,
+          plane_name,
+          secured_user->id,
+          secured_user->name,
+          fingerprint,
+          "challenge",
+          "accepted",
+          RequestRemoteAddress(request),
+          "",
+          "",
+          "{}",
+      });
+      return support_.build_json_response(
+          200,
+          json{{"challenge_id", challenge.challenge_id},
+               {"challenge_token", challenge.challenge_token},
+               {"expires_at", challenge.expires_at},
+               {"message", challenge.message}},
           {});
     }
     const auto user = store.LoadUserByUsername(username);
@@ -935,6 +1368,118 @@ HttpResponse AuthHttpService::HandleSshVerify(
     }
     naim::ControllerStore store(db_path);
     store.Initialize();
+    if (challenge->secured_connection) {
+      if (!IsSecuredRequestTransportAllowed(request)) {
+        store.InsertSecuredConnectionAuthLog({
+            0,
+            challenge->plane_name,
+            challenge->secured_user_id,
+            challenge->username,
+            challenge->fingerprint,
+            "verify",
+            "rejected",
+            RequestRemoteAddress(request),
+            "HTTPS/TLS is required for secured connection authentication",
+            "",
+            "{}",
+        });
+        return support_.build_json_response(
+            403,
+            json{{"status", "forbidden"},
+                 {"message", "secured connection authentication requires HTTPS/TLS"}},
+            {});
+      }
+      const auto secured_user =
+          store.LoadActiveSecuredConnectionUser(challenge->secured_user_id);
+      if (!secured_user.has_value()) {
+        store.InsertSecuredConnectionAuthLog({
+            0,
+            challenge->plane_name,
+            challenge->secured_user_id,
+            challenge->username,
+            challenge->fingerprint,
+            "verify",
+            "rejected",
+            RequestRemoteAddress(request),
+            "secured connection user not found",
+            "",
+            "{}",
+        });
+        return support_.build_json_response(
+            404,
+            json{{"status", "not_found"},
+                 {"message", "secured connection user not found"}},
+            {});
+      }
+      if (!support_.verify_ssh_detached_signature(
+              challenge->username,
+              secured_user->public_key,
+              challenge->message,
+              signature)) {
+        store.InsertSecuredConnectionAuthLog({
+            0,
+            challenge->plane_name,
+            secured_user->id,
+            secured_user->name,
+            challenge->fingerprint,
+            "verify",
+            "rejected",
+            RequestRemoteAddress(request),
+            "SSH signature verification failed",
+            "",
+            "{}",
+        });
+        return support_.build_json_response(
+            403,
+            json{{"status", "forbidden"},
+                 {"message", "SSH signature verification failed"}},
+            {});
+      }
+      const std::string now = support_.utc_now_sql_timestamp();
+      store.TouchSecuredConnectionUser(secured_user->id, now);
+      const std::string session_token = naim::RandomTokenBase64(32);
+      store.InsertSecuredConnectionSession({
+          session_token,
+          secured_user->id,
+          challenge->plane_name,
+          support_.sql_timestamp_after_seconds(SshSessionLifetimeSeconds()),
+          "",
+          "",
+          now,
+      });
+      store.InsertSecuredConnectionAuthLog({
+          0,
+          challenge->plane_name,
+          secured_user->id,
+          secured_user->name,
+          challenge->fingerprint,
+          "verify",
+          "accepted",
+          RequestRemoteAddress(request),
+          "",
+          "",
+          "{}",
+      });
+      support_.erase_pending_ssh_challenge(challenge_id);
+      json payload{
+          {"plane_name", challenge->plane_name},
+          {"expires_at",
+           support_.sql_timestamp_after_seconds(SshSessionLifetimeSeconds())},
+          {"session_kind", "secured_ssh"},
+      };
+      if (issue_cookie) {
+        payload["issued_cookie"] = true;
+      }
+      if (include_token) {
+        payload["token"] = session_token;
+      }
+      std::map<std::string, std::string> headers;
+      if (issue_cookie) {
+        headers["Set-Cookie"] =
+            support_.session_cookie_header(session_token, request);
+      }
+      return support_.build_json_response(200, payload, headers);
+    }
     const auto ssh_key = store.LoadActiveUserSshKeyById(challenge->ssh_key_id);
     if (!ssh_key.has_value()) {
       return support_.build_json_response(

--- a/controller/src/auth/auth_http_service_tests.cpp
+++ b/controller/src/auth/auth_http_service_tests.cpp
@@ -108,6 +108,31 @@ naim::DesiredState BuildProtectedDesiredState(const std::string& plane_name) {
   return naim::DesiredStateV2Renderer::Render(value);
 }
 
+naim::DesiredState BuildSecuredDesiredState(
+    const std::string& plane_name,
+    const std::string& secured_user_id) {
+  json value{
+      {"version", 2},
+      {"plane_name", plane_name},
+      {"plane_mode", "llm"},
+      {"model",
+       {
+           {"source", {{"type", "local"}, {"path", "/models/demo"}}},
+           {"materialization", {{"mode", "reference"}, {"local_path", "/models/demo"}}},
+           {"served_model_name", plane_name + "-model"},
+       }},
+      {"features",
+       {{"secured_connection",
+         {{"enabled", true}, {"user_ids", json::array({secured_user_id})}}}}},
+      {"runtime",
+       {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+      {"infer", {{"replicas", 1}}},
+      {"app", {{"enabled", false}}},
+  };
+  naim::DesiredStateV2Validator::ValidateOrThrow(value);
+  return naim::DesiredStateV2Renderer::Render(value);
+}
+
 std::string ExtractCookieToken(const std::string& set_cookie) {
   const auto prefix = std::string("naim.sid=");
   Expect(set_cookie.rfind(prefix, 0) == 0, "Set-Cookie must start with naim.sid=");
@@ -222,11 +247,107 @@ void TestSshVerifyCanIssueCookieOnlySession() {
   std::cout << "ok: ssh-verify-cookie-only-session" << '\n';
 }
 
+void TestUserStorageAdminApiAndSecuredChallengeGuards() {
+  auto temp = MakeTempDir("naim-user-storage-tests");
+  const auto db_path = temp.path / "controller.sqlite";
+
+  naim::ControllerStore store(db_path.string());
+  store.Initialize();
+  const auto admin =
+      store.CreateBootstrapAdmin("admin", naim::HashPassword("secret"));
+
+  const auto key_path = temp.path / "secured_ed25519";
+  RunShellOrThrow(
+      "ssh-keygen -q -t ed25519 -N '' -f '" + key_path.string() + "' >/dev/null 2>/dev/null",
+      "failed to generate secured ssh test key");
+  const auto public_key = ReadFile(key_path.string() + ".pub");
+
+  AuthSupportService auth_support;
+  AuthHttpSupport http_support(auth_support);
+  AuthHttpService service(std::move(http_support));
+  const std::string admin_token =
+      auth_support.CreateControllerSession(store, admin.id, "web");
+
+  HttpRequest create_request;
+  create_request.method = "POST";
+  create_request.path = "/api/v1/user-storage";
+  create_request.headers["x-naim-session-token"] = admin_token;
+  create_request.body = json{
+      {"name", "terminal-a"},
+      {"public_key", public_key},
+  }.dump();
+
+  const auto create_response =
+      service.HandleRequest(db_path.string(), create_request);
+  Expect(create_response.has_value(), "user-storage create route should respond");
+  Expect(create_response->status_code == 201, "user-storage create should succeed");
+  const auto created_user =
+      json::parse(create_response->body).at("item");
+  const std::string secured_user_id = created_user.at("id").get<std::string>();
+  const std::string fingerprint = created_user.at("fingerprint").get<std::string>();
+  Expect(!secured_user_id.empty(), "user-storage create should return id");
+  Expect(!fingerprint.empty(), "user-storage create should return fingerprint");
+
+  HttpRequest list_request;
+  list_request.method = "GET";
+  list_request.path = "/api/v1/user-storage";
+  list_request.headers["x-naim-session-token"] = admin_token;
+  list_request.query_params["search"] = "terminal-a";
+  const auto list_response = service.HandleRequest(db_path.string(), list_request);
+  Expect(list_response.has_value(), "user-storage list route should respond");
+  Expect(list_response->status_code == 200, "user-storage list should succeed");
+  Expect(
+      json::parse(list_response->body).at("items").size() == 1,
+      "user-storage search should match created user");
+
+  store.ReplaceDesiredState(BuildSecuredDesiredState("secured-plane", secured_user_id), 1);
+
+  HttpRequest insecure_challenge;
+  insecure_challenge.method = "POST";
+  insecure_challenge.path = "/api/v1/auth/ssh/challenge";
+  insecure_challenge.headers["host"] = "public.example";
+  insecure_challenge.body = json{
+      {"name", "terminal-a"},
+      {"plane_name", "secured-plane"},
+      {"fingerprint", fingerprint},
+  }.dump();
+  const auto insecure_response =
+      service.HandleRequest(db_path.string(), insecure_challenge);
+  Expect(insecure_response.has_value(), "secured challenge route should respond");
+  Expect(
+      insecure_response->status_code == 403,
+      "secured challenge should reject non-local HTTP transport");
+
+  store.ReplaceDesiredState(BuildSecuredDesiredState("secured-plane", "other-user"), 2);
+  HttpRequest forbidden_challenge = insecure_challenge;
+  forbidden_challenge.headers["x-forwarded-proto"] = "https";
+  const auto forbidden_response =
+      service.HandleRequest(db_path.string(), forbidden_challenge);
+  Expect(forbidden_response.has_value(), "secured allowlist route should respond");
+  Expect(
+      forbidden_response->status_code == 403,
+      "secured challenge should reject users missing from plane allowlist");
+
+  store.ReplaceDesiredState(BuildSecuredDesiredState("secured-plane", secured_user_id), 3);
+  const auto accepted_response =
+      service.HandleRequest(db_path.string(), forbidden_challenge);
+  Expect(accepted_response.has_value(), "secured accepted route should respond");
+  Expect(
+      accepted_response->status_code == 200,
+      "secured challenge should accept HTTPS and selected User Storage user");
+  Expect(
+      store.LoadSecuredConnectionAuthLog("secured-plane", secured_user_id, 10).size() >= 2,
+      "secured challenge attempts should be audit logged");
+
+  std::cout << "ok: user-storage-secured-challenge-guards" << '\n';
+}
+
 }  // namespace
 
 int main() {
   try {
     TestSshVerifyCanIssueCookieOnlySession();
+    TestUserStorageAdminApiAndSecuredChallengeGuards();
     std::cout << "auth_http_service_tests passed" << '\n';
     return 0;
   } catch (const std::exception& error) {

--- a/controller/src/auth/auth_support_service.cpp
+++ b/controller/src/auth/auth_support_service.cpp
@@ -496,7 +496,33 @@ AuthSupportService::AuthenticateProtectedPlaneRequest(
   const auto ssh_session =
       store.LoadActiveAuthSession(*token, std::optional<std::string>("ssh"), plane_name);
   if (!ssh_session.has_value()) {
-    return std::nullopt;
+    const auto secured_session =
+        store.LoadActiveSecuredConnectionSession(*token, plane_name);
+    if (!secured_session.has_value()) {
+      return std::nullopt;
+    }
+    const auto secured_user =
+        store.LoadActiveSecuredConnectionUser(secured_session->user_id);
+    if (!secured_user.has_value()) {
+      return std::nullopt;
+    }
+    store.TouchSecuredConnectionSession(
+        secured_session->token,
+        UtcNowSqlTimestamp());
+    naim::UserRecord user;
+    user.id = 0;
+    user.username = secured_user->name;
+    user.role = "secured_connection";
+    naim::AuthSessionRecord session;
+    session.token = secured_session->token;
+    session.user_id = 0;
+    session.session_kind = "secured_ssh";
+    session.plane_name = secured_session->plane_name;
+    session.expires_at = secured_session->expires_at;
+    session.created_at = secured_session->created_at;
+    session.revoked_at = secured_session->revoked_at;
+    session.last_used_at = secured_session->last_used_at;
+    return std::make_pair(user, session);
   }
   const auto user = store.LoadUserById(ssh_session->user_id);
   if (!user.has_value()) {

--- a/ui/operator-react/src/App.jsx
+++ b/ui/operator-react/src/App.jsx
@@ -168,6 +168,10 @@ function skillsFactoryPath(suffix = "") {
   return suffix ? `/api/v1/skills-factory/${suffix}` : "/api/v1/skills-factory";
 }
 
+function userStoragePath(suffix = "") {
+  return suffix ? `/api/v1/user-storage/${suffix}` : "/api/v1/user-storage";
+}
+
 function protocolsPath(suffix = "") {
   return suffix ? `/api/v1/protocols/${suffix}` : "/api/v1/protocols";
 }
@@ -1209,6 +1213,7 @@ export function PlaneEditorDialog({
   peerLinks,
   skillsFactoryItems,
   skillsFactoryGroups = [],
+  userStorageItems = [],
   onResetLtCypherDeployment,
 }) {
   if (!dialog.open) {
@@ -1295,6 +1300,7 @@ export function PlaneEditorDialog({
               peerLinks={peerLinks || null}
               skillsFactoryItems={skillsFactoryItems || []}
               skillsFactoryGroups={skillsFactoryGroups || []}
+              userStorageItems={userStorageItems || []}
               showValidation={showValidation}
               onResetLtCypherDeployment={onResetLtCypherDeployment}
             />
@@ -2077,10 +2083,15 @@ function App() {
   });
   const [adminInvites, setAdminInvites] = useState([]);
   const [sshKeys, setSshKeys] = useState([]);
+  const [userStorage, setUserStorage] = useState({ items: [], authLog: [], search: "" });
   const [accessBusy, setAccessBusy] = useState("");
   const [accessError, setAccessError] = useState("");
   const [sshKeyForm, setSshKeyForm] = useState({
     label: "",
+    publicKey: "",
+  });
+  const [userStorageForm, setUserStorageForm] = useState({
+    name: "",
     publicKey: "",
   });
   const [planeDetail, setPlaneDetail] = useState(null);
@@ -2253,6 +2264,7 @@ function App() {
     setModelsTab("library");
     setSkillsFactory({
       items: [],
+      groups: [],
       busy: false,
       error: "",
       mode: "create",
@@ -2262,6 +2274,7 @@ function App() {
       selectedGroupPath: "",
       expandedGroupPaths: [""],
     });
+    setUserStorage({ items: [], authLog: [], search: "" });
     setChatMessages([]);
     setChatError("");
     setApiHealthy(false);
@@ -2332,6 +2345,19 @@ function App() {
       ]);
       setSshKeys(Array.isArray(sshKeysPayload.items) ? sshKeysPayload.items : []);
       setAdminInvites(Array.isArray(invitesPayload.items) ? invitesPayload.items : []);
+      if (authState.user?.role === "admin") {
+        const [userStoragePayload, userStorageLogPayload] = await Promise.all([
+          fetchJson(userStoragePath()),
+          fetchJson(userStoragePath("auth-log?limit=25")),
+        ]);
+        setUserStorage((current) => ({
+          ...current,
+          items: Array.isArray(userStoragePayload.items) ? userStoragePayload.items : [],
+          authLog: Array.isArray(userStorageLogPayload.items) ? userStorageLogPayload.items : [],
+        }));
+      } else {
+        setUserStorage((current) => ({ ...current, items: [], authLog: [] }));
+      }
       setAccessError("");
     } catch (error) {
       if (error?.status === 401) {
@@ -3050,6 +3076,50 @@ function App() {
     setAccessBusy(`delete-ssh-key:${keyId}`);
     try {
       await fetchJson(`/api/v1/auth/ssh-keys/${keyId}`, { method: "DELETE" });
+      await refreshAccessData();
+    } catch (error) {
+      if (error?.status === 401) {
+        handleUnauthorized();
+        return;
+      }
+      setAccessError(error.message || String(error));
+    } finally {
+      setAccessBusy("");
+    }
+  }
+
+  async function handleAddUserStorageUser(event) {
+    event.preventDefault();
+    setAccessBusy("create-user-storage-user");
+    setAccessError("");
+    try {
+      await fetchJson(userStoragePath(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: userStorageForm.name.trim(),
+          public_key: userStorageForm.publicKey.trim(),
+        }),
+      });
+      setUserStorageForm({ name: "", publicKey: "" });
+      await refreshAccessData();
+    } catch (error) {
+      if (error?.status === 401) {
+        handleUnauthorized();
+        return;
+      }
+      setAccessError(error.message || String(error));
+    } finally {
+      setAccessBusy("");
+    }
+  }
+
+  async function handleDeleteUserStorageUser(userId) {
+    setAccessBusy(`delete-user-storage-user:${userId}`);
+    try {
+      await fetchJson(userStoragePath(userId), { method: "DELETE" });
       await refreshAccessData();
     } catch (error) {
       if (error?.status === 401) {
@@ -7701,6 +7771,25 @@ function App() {
   }
 
   function renderAccessPage() {
+    const userStorageNeedle = String(userStorage.search || "").trim().toLowerCase();
+    const filteredUserStorageItems = (Array.isArray(userStorage.items) ? userStorage.items : [])
+      .filter((item) => {
+        if (!userStorageNeedle) {
+          return true;
+        }
+        return [
+          item?.id,
+          item?.name,
+          item?.public_key,
+          item?.fingerprint,
+          item?.last_authorized_at,
+          item?.created_at,
+          item?.updated_at,
+        ]
+          .map((value) => String(value || "").toLowerCase())
+          .join(" ")
+          .includes(userStorageNeedle);
+      });
     return (
       <section className="panel page-panel">
         <div className="panel-header">
@@ -7793,6 +7882,104 @@ function App() {
                     </article>
                   ))
                 )}
+              </div>
+            </section>
+          ) : null}
+
+          {authState.user?.role === "admin" ? (
+            <section className="subpanel">
+              <div className="subpanel-header">
+                <h3>User Storage</h3>
+                <span className="subpanel-meta">SSH identities allowed by Secured Connection</span>
+              </div>
+              <form className="list-card access-form-card" onSubmit={handleAddUserStorageUser}>
+                <label className="field-label" htmlFor="user-storage-name">Name</label>
+                <input
+                  id="user-storage-name"
+                  className="text-input"
+                  type="text"
+                  value={userStorageForm.name}
+                  onChange={(event) =>
+                    setUserStorageForm((current) => ({ ...current, name: event.target.value }))
+                  }
+                  placeholder="trading-terminal"
+                />
+                <label className="field-label" htmlFor="user-storage-public">Public key</label>
+                <textarea
+                  id="user-storage-public"
+                  className="editor-textarea"
+                  value={userStorageForm.publicKey}
+                  onChange={(event) =>
+                    setUserStorageForm((current) => ({ ...current, publicKey: event.target.value }))
+                  }
+                  placeholder="ssh-ed25519 AAAA..."
+                />
+                <div className="toolbar">
+                  <button
+                    className="ghost-button"
+                    type="submit"
+                    disabled={
+                      accessBusy !== "" ||
+                      !userStorageForm.name.trim() ||
+                      !userStorageForm.publicKey.trim()
+                    }
+                  >
+                    Add user
+                  </button>
+                </div>
+              </form>
+              <label className="field-label">
+                <span className="field-label-title">Filter users</span>
+                <input
+                  className="text-input"
+                  value={userStorage.search}
+                  onChange={(event) =>
+                    setUserStorage((current) => ({ ...current, search: event.target.value }))
+                  }
+                  placeholder="Search name, key, fingerprint, or last auth"
+                />
+              </label>
+              <div className="list-column">
+                {filteredUserStorageItems.length === 0 ? (
+                  <EmptyState title="No User Storage users" detail="Add a public SSH key to allow selection in Secured Connection." />
+                ) : (
+                  filteredUserStorageItems.map((item) => (
+                    <article className="list-card" key={item.id}>
+                      <div className="card-row">
+                        <strong>{item.name || "User Storage user"}</strong>
+                        <span className="tag">{item.fingerprint}</span>
+                      </div>
+                      <div className="list-detail">
+                        <div>{item.public_key}</div>
+                        <div>last auth {formatTimestamp(item.last_authorized_at)}</div>
+                      </div>
+                      <div className="toolbar">
+                        <button
+                          className="ghost-button compact-button danger-button"
+                          type="button"
+                          disabled={accessBusy !== ""}
+                          onClick={() => handleDeleteUserStorageUser(item.id)}
+                        >
+                          Revoke
+                        </button>
+                      </div>
+                    </article>
+                  ))
+                )}
+              </div>
+              <div className="list-column">
+                {(Array.isArray(userStorage.authLog) ? userStorage.authLog : []).slice(0, 5).map((entry) => (
+                  <article className="list-card" key={entry.id}>
+                    <div className="card-row">
+                      <strong>{entry.event_type} / {entry.outcome}</strong>
+                      <span className="tag">{entry.plane_name || "no-plane"}</span>
+                    </div>
+                    <div className="list-detail">
+                      <div>{entry.user_name || entry.user_id || "unknown-user"}</div>
+                      <div>{formatTimestamp(entry.created_at)} {entry.message ? `- ${entry.message}` : ""}</div>
+                    </div>
+                  </article>
+                ))}
               </div>
             </section>
           ) : null}
@@ -8582,6 +8769,7 @@ function App() {
         peerLinks={dashboard?.peer_links || null}
         skillsFactoryItems={skillsFactory.items || []}
         skillsFactoryGroups={skillsFactory.groups || []}
+        userStorageItems={userStorage.items || []}
         onResetLtCypherDeployment={resetLtCypherDeployment}
       />
       <SkillsDialog

--- a/ui/operator-react/src/planeV2Form.jsx
+++ b/ui/operator-react/src/planeV2Form.jsx
@@ -92,6 +92,8 @@ const FIELD_INFO = {
   voiceListenerModel: "Whisper model artifact used by the Voice Listener. Only whisper.cpp models are selectable here.",
   voiceListenerWakePhrase: "Phrase that activates the listener before a transcript is submitted to chat.",
   voiceListenerLanguage: "Language hint for whisper.cpp. Use auto unless a plane must listen in one fixed language.",
+  securedConnectionEnabled: "Require HTTPS/TLS plus SSH key authentication for users explicitly selected from User Storage.",
+  securedConnectionUserIds: "Select User Storage identities that are allowed to authenticate to this plane.",
   browserSessionEnabled: "Allow approval-gated browser session APIs for this plane. Search and sanitized fetch stay enabled when Isolated Browsing is on.",
   renderedBrowserEnabled: "Allow the plane WebGateway to use rendered browser sessions when a request explicitly needs them.",
   browsingLoginEnabled: "Allow login-capable browser sessions for this plane WebGateway. Keep disabled unless the plane needs authenticated browsing.",
@@ -497,6 +499,29 @@ function NodeNameDatalist({ id, hostdHosts }) {
   );
 }
 
+function buildUserStorageSearchHaystack(user) {
+  return [
+    user?.id,
+    user?.name,
+    user?.public_key,
+    user?.fingerprint,
+    user?.last_authorized_at,
+    user?.created_at,
+    user?.updated_at,
+  ]
+    .map((item) => String(item || "").toLowerCase())
+    .join(" ");
+}
+
+function filterUserStorageItems(items, filter) {
+  const needle = String(filter || "").trim().toLowerCase();
+  const users = Array.isArray(items) ? items : [];
+  if (!needle) {
+    return users;
+  }
+  return users.filter((item) => buildUserStorageSearchHaystack(item).includes(needle));
+}
+
 function applyLtCypherPresetToForm(form, modelLibraryItems, hostdHosts = []) {
   const modelItem = findLtCypherModelItem(modelLibraryItems);
   const sourcePaths = modelLibraryPaths(modelItem);
@@ -768,6 +793,8 @@ export function buildNewPlaneFormState() {
     voiceListenerModelPaths: [],
     voiceListenerModelMountPath: VOICE_LISTENER_DEFAULT_MOUNT_PATH,
     voiceListenerImage: "",
+    securedConnectionEnabled: false,
+    securedConnectionUserIds: [],
     planeMode: "llm",
     protectedPlane: false,
     factorySkillIds: [],
@@ -905,6 +932,7 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
   const turboquant = value?.features?.turboquant || {};
   const contextCompression = value?.features?.context_compression || {};
   const voiceListener = value?.features?.voice_listener || {};
+  const securedConnection = value?.features?.secured_connection || {};
   const voiceListenerModel = voiceListener?.model || {};
   const voiceListenerModelSource = voiceListenerModel?.source || {};
   const browsing = value?.webgateway && typeof value.webgateway === "object"
@@ -969,6 +997,10 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
     voiceListenerModelMountPath:
       voiceListenerModel?.mount_path || VOICE_LISTENER_DEFAULT_MOUNT_PATH,
     voiceListenerImage: voiceListener?.image || defaults.voiceListenerImage,
+    securedConnectionEnabled: Boolean(securedConnection?.enabled),
+    securedConnectionUserIds: Array.isArray(securedConnection?.user_ids)
+      ? securedConnection.user_ids.filter((item) => typeof item === "string" && item)
+      : [],
     planeMode: value?.plane_mode || defaults.planeMode,
     protectedPlane: Boolean(value?.protected),
     factorySkillIds: Array.isArray(value?.skills?.factory_skill_ids)
@@ -1129,7 +1161,7 @@ export function buildDesiredStateV2FromForm(form) {
     version: 2,
     plane_name: planeName,
     plane_mode: form.planeMode,
-    protected: Boolean(form.protectedPlane),
+    protected: Boolean(form.protectedPlane || form.securedConnectionEnabled),
     runtime: {
       engine: form.planeMode === "compute" ? "custom" : "llama.cpp",
       workers: parseNumber(form.workers, 1),
@@ -1384,6 +1416,20 @@ export function buildDesiredStateV2FromForm(form) {
         size_gb: 1,
       };
     }
+    if (form.securedConnectionEnabled) {
+      features.secured_connection = {
+        enabled: true,
+        user_ids: [
+          ...new Set(
+            (Array.isArray(form.securedConnectionUserIds)
+              ? form.securedConnectionUserIds
+              : [])
+              .map((item) => String(item || "").trim())
+              .filter(Boolean),
+          ),
+        ],
+      };
+    }
     if (Object.keys(features).length > 0) {
       desiredState.features = features;
     }
@@ -1395,6 +1441,22 @@ export function buildDesiredStateV2FromForm(form) {
         share_mode: "shared",
       };
     }
+  }
+
+  if (form.securedConnectionEnabled) {
+    desiredState.features = desiredState.features || {};
+    desiredState.features.secured_connection = {
+      enabled: true,
+      user_ids: [
+        ...new Set(
+          (Array.isArray(form.securedConnectionUserIds)
+            ? form.securedConnectionUserIds
+            : [])
+            .map((item) => String(item || "").trim())
+            .filter(Boolean),
+        ),
+      ],
+    };
   }
 
   if (
@@ -1723,6 +1785,10 @@ export function validatePlaneV2Form(form) {
   }
   if (!form?.skillsEnabled && Array.isArray(form?.factorySkillIds) && form.factorySkillIds.length > 0) {
     warnings.push("Selected Skills Factory records are ignored until Skills is enabled.");
+  }
+  if (form?.securedConnectionEnabled &&
+      (!Array.isArray(form?.securedConnectionUserIds) || form.securedConnectionUserIds.length === 0)) {
+    errors.push("Secured Connection requires at least one selected User Storage user.");
   }
   if (!form?.browsingEnabled && form?.browserSessionEnabled) {
     warnings.push("Browser sessions are ignored until Isolated Browsing is enabled.");
@@ -2168,6 +2234,7 @@ export function PlaneV2FormBuilder({
   modelLibraryItems = [],
   skillsFactoryItems = [],
   skillsFactoryGroups = [],
+  userStorageItems = [],
   hostdHosts = [],
   peerLinks = null,
   showValidation = false,
@@ -2178,6 +2245,7 @@ export function PlaneV2FormBuilder({
   const validation = showValidation ? rawValidation : { errors: [], warnings: [] };
   const [ltCypherPreflight, setLtCypherPreflight] = useState(null);
   const [factorySkillFilter, setFactorySkillFilter] = useState("");
+  const [securedUserFilter, setSecuredUserFilter] = useState("");
   const [knowledgeSelectorOpen, setKnowledgeSelectorOpen] = useState(false);
   const [selectedFactoryGroupPath, setSelectedFactoryGroupPath] = useState("");
   const [expandedFactoryGroupPaths, setExpandedFactoryGroupPaths] = useState([""]);
@@ -2549,6 +2617,20 @@ export function PlaneV2FormBuilder({
     });
   }
 
+  function toggleSecuredConnectionUser(userId) {
+    updatePlaneDialogForm(setDialog, (current) => {
+      const currentIds = Array.isArray(current.securedConnectionUserIds)
+        ? current.securedConnectionUserIds
+        : [];
+      return {
+        ...current,
+        securedConnectionUserIds: currentIds.includes(userId)
+          ? currentIds.filter((item) => item !== userId)
+          : [...currentIds, userId],
+      };
+    });
+  }
+
   function applyLtCypherPreset() {
     updatePlaneDialogForm(setDialog, (current) =>
       applyLtCypherPresetToForm(current, modelLibraryItems, hostdHosts),
@@ -2589,6 +2671,7 @@ export function PlaneV2FormBuilder({
     factorySkillFilter,
     selectedFactoryGroupPath,
   );
+  const filteredSecuredUsers = filterUserStorageItems(userStorageItems, securedUserFilter);
   const factoryGroupTree = buildSkillsFactoryGroupTree(skillsFactoryItems, skillsFactoryGroups);
   const factoryTreePaths = collectSkillsFactoryTreePaths(factoryGroupTree);
   const whisperModelLibraryItems = (Array.isArray(modelLibraryItems) ? modelLibraryItems : [])
@@ -2822,9 +2905,17 @@ export function PlaneV2FormBuilder({
           onToggle={toggleFeature("appEnabled")}
         />
         <FeatureToggle
+          title="Secured Connection"
+          info={FIELD_INFO.securedConnectionEnabled}
+          active={form.securedConnectionEnabled}
+          onToggle={toggleFeature("securedConnectionEnabled")}
+        />
+        <FeatureToggle
           title="Protected Plane"
           info={FIELD_INFO.protectedPlane}
-          active={form.protectedPlane}
+          active={form.protectedPlane || form.securedConnectionEnabled}
+          disabled={form.securedConnectionEnabled}
+          disabledLabel="Secured"
           onToggle={toggleFeature("protectedPlane")}
         />
       </div>
@@ -2836,6 +2927,70 @@ export function PlaneV2FormBuilder({
         onSelectAll={selectKnowledgeIds}
         onUnselectAll={unselectKnowledgeIds}
       />
+
+      {form.securedConnectionEnabled ? (
+        <div className="plane-form-toggle">
+          <div className="plane-form-section-header">
+            <InfoLabel info={FIELD_INFO.securedConnectionEnabled}>Secured Connection</InfoLabel>
+            <p className="plane-form-section-copy">
+              HTTPS/TLS is required and only selected User Storage identities can obtain SSH API sessions.
+            </p>
+          </div>
+          <label className="field-label">
+            <InfoLabel info={FIELD_INFO.securedConnectionUserIds}>Filter users</InfoLabel>
+            <input
+              className="text-input"
+              value={securedUserFilter}
+              onChange={(event) => setSecuredUserFilter(event.target.value)}
+              placeholder="Search by name, key, fingerprint, or authorization date"
+            />
+          </label>
+          <div className="factory-skill-table-shell">
+            <table className="factory-skill-table">
+              <thead>
+                <tr>
+                  <th>Select</th>
+                  <th>Name</th>
+                  <th>Fingerprint</th>
+                  <th>Last auth</th>
+                  <th>Id</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredSecuredUsers.length === 0 ? (
+                  <tr>
+                    <td colSpan="5" className="factory-skill-table-empty">
+                      No User Storage records match the current filter.
+                    </td>
+                  </tr>
+                ) : (
+                  filteredSecuredUsers.map((item) => {
+                    const selected = Array.isArray(form.securedConnectionUserIds)
+                      ? form.securedConnectionUserIds.includes(item.id)
+                      : false;
+                    return (
+                      <tr key={item.id}>
+                        <td>
+                          <input
+                            type="checkbox"
+                            checked={selected}
+                            onChange={() => toggleSecuredConnectionUser(item.id)}
+                          />
+                        </td>
+                        <td>{item.name || "unnamed-user"}</td>
+                        <td className="factory-skill-table-id">{item.fingerprint || "none"}</td>
+                        <td>{item.last_authorized_at || "never"}</td>
+                        <td className="factory-skill-table-id">{item.id}</td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+          <FieldHint message={fieldError("Secured Connection requires at least one selected User Storage user.")} />
+        </div>
+      ) : null}
 
       {form.planeMode === "llm" && form.knowledgeEnabled ? (
         <div className="plane-form-toggle">

--- a/ui/operator-react/src/skillsFactory.test.js
+++ b/ui/operator-react/src/skillsFactory.test.js
@@ -153,6 +153,25 @@ describe("planeV2Form SkillsFactory mapping", () => {
     expect(reparsed.factorySkillIds).toEqual(["skill-alpha", "skill-beta"]);
   });
 
+  it("round-trips secured connection user ids through desired state v2", () => {
+    const form = buildNewPlaneFormState();
+    form.planeName = "secured-plane";
+    form.modelPath = "/models/qwen";
+    form.securedConnectionEnabled = true;
+    form.securedConnectionUserIds = ["scu-alpha", "scu-beta"];
+
+    const desiredState = buildDesiredStateV2FromForm(form);
+    expect(desiredState.protected).toBe(true);
+    expect(desiredState.features.secured_connection).toEqual({
+      enabled: true,
+      user_ids: ["scu-alpha", "scu-beta"],
+    });
+
+    const reparsed = buildPlaneFormStateFromDesiredStateV2(desiredState);
+    expect(reparsed.securedConnectionEnabled).toBe(true);
+    expect(reparsed.securedConnectionUserIds).toEqual(["scu-alpha", "scu-beta"]);
+  });
+
   it("clears stale plane dialog errors when the form changes", () => {
     let dialog = {
       form: buildNewPlaneFormState(),


### PR DESCRIPTION
## Summary
- add Secured Connection desired-state feature with protected-plane compatibility
- add separate User Storage, secured SSH sessions, and auth audit log
- add Operator UI controls for User Storage and plane-level secured user selection

## Tests
- cmake --build build/secured-connection --target naim-auth-http-tests naim-state-v2-projector-tests naim-state-v2-tests -j 4
- ./build/secured-connection/naim-auth-http-tests
- ./build/secured-connection/naim-state-v2-projector-tests
- ./build/secured-connection/naim-state-v2-tests
- npm test -- --run
- npm run build