### PR TITLE
Include ssh-keygen in controller image

### DIFF
--- a/runtime/controller/Dockerfile
+++ b/runtime/controller/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
       bash \
       ca-certificates \
       libssl3t64 \
+      openssh-client \
       tini \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- add openssh-client to the controller runtime image so Secured Connection can compute SSH key fingerprints and verify signed challenges in production

## Testing
- not run locally; Docker image change will be validated by CI