### PR TITLE
Fix plane editor scaling and runtime telemetry

### DIFF
--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -1212,6 +1212,7 @@ void DesiredStateV2Renderer::RenderVoiceModuleInstance() {
       {"NAIM_NODE_NAME", voice.node_name},
       {"NAIM_PRIVATE_DISK_PATH", "/naim/private"},
       {"NAIM_VOICE_MODULE_PORT", std::to_string(kVoiceModuleContainerPort)},
+      {"NAIM_VOICE_MODULE_RUNTIME_STATUS_PATH", "/naim/private/voice-module-runtime-status.json"},
       {"NAIM_VOICE_LISTENER_WAKE_PHRASE", config.wake_phrase},
       {"VOICE_LISTENER_WAKE_PHRASE", config.wake_phrase},
       {"VOICE_ASR_LANGUAGE", config.language},

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -2041,6 +2041,9 @@ int main() {
              "voice-listener-plane: voice module should mount plane shared disk");
       Expect(voice.environment.at("NAIM_VOICE_LISTENER_WAKE_PHRASE") == "Hey Jex",
              "voice-listener-plane: wake phrase env mismatch");
+      Expect(voice.environment.at("NAIM_VOICE_MODULE_RUNTIME_STATUS_PATH") ==
+                 "/naim/private/voice-module-runtime-status.json",
+             "voice-listener-plane: voice module runtime status path mismatch");
       Expect(voice.app_model_mounts.size() == 1,
              "voice-listener-plane: voice module should mount whisper model");
       const auto app = FindInstance(state, "app-voice-listener-plane");

--- a/hostd/include/app/hostd_runtime_telemetry_support.h
+++ b/hostd/include/app/hostd_runtime_telemetry_support.h
@@ -42,6 +42,8 @@ class HostdRuntimeTelemetrySupport final {
   naim::RuntimeProcessStatus ToProcessStatus(
       naim::RuntimeStatus status,
       const naim::InstanceSpec& instance) const;
+  std::optional<naim::RuntimeProcessStatus> BuildContainerRuntimeStatusForInstance(
+      const naim::InstanceSpec& instance) const;
   std::optional<std::string> ParseTaggedValue(
       const std::string& text,
       const std::string& key) const;

--- a/hostd/src/app/hostd_local_state_support_tests.cpp
+++ b/hostd/src/app/hostd_local_state_support_tests.cpp
@@ -13,6 +13,7 @@
 #include "app/hostd_local_state_path_support.h"
 #include "app/hostd_local_state_repository.h"
 #include "app/hostd_runtime_telemetry_support.h"
+#include "naim/runtime/runtime_status.h"
 #include "naim/state/desired_state_v2_renderer.h"
 
 namespace {
@@ -153,10 +154,12 @@ int main() {
             .has_value(),
         "plane-b state should remain present");
 
-    const auto aggregate_state = local_state_repository.LoadLocalAppliedState(state_root, node_name);
+    const auto aggregate_state =
+        local_state_repository.LoadLocalAppliedState(state_root, node_name);
     Expect(aggregate_state.has_value(), "aggregate state should still exist");
-    Expect(aggregate_state->instances.size() == 4,
-           "aggregate should only contain plane-b infer aggregator, infer leaf, worker, and skills instances");
+    Expect(
+        aggregate_state->instances.size() == 5,
+        "aggregate should only contain plane-b runtime instances");
     Expect(
         std::all_of(
             aggregate_state->instances.begin(),
@@ -166,8 +169,60 @@ int main() {
     Expect(
         local_runtime_state_support.ExpectedRuntimeStatusCountForNode(
             *aggregate_state,
-            node_name) == 4,
-        "infer aggregator, infer leaf, worker, and skills instances should all contribute runtime statuses");
+            node_name) == 5,
+        "plane-b runtime instances should all contribute runtime statuses");
+
+    const std::string telemetry_plane = "plane-telemetry";
+    naim::DesiredState telemetry_state = BuildState(telemetry_plane, node_name);
+    naim::InstanceSpec webgateway;
+    webgateway.name = "webgateway-" + telemetry_plane;
+    webgateway.role = naim::InstanceRole::Browsing;
+    webgateway.plane_name = telemetry_plane;
+    webgateway.node_name = node_name;
+    webgateway.private_disk_name = webgateway.name + "-private";
+    telemetry_state.instances.push_back(webgateway);
+    naim::DiskSpec webgateway_disk;
+    webgateway_disk.name = webgateway.private_disk_name;
+    webgateway_disk.kind = naim::DiskKind::BrowsingPrivate;
+    webgateway_disk.plane_name = telemetry_plane;
+    webgateway_disk.owner_name = webgateway.name;
+    webgateway_disk.node_name = node_name;
+    webgateway_disk.host_path = (temp_root / "webgateway-private").string();
+    webgateway_disk.container_path = "/naim/private";
+    telemetry_state.disks.push_back(webgateway_disk);
+    local_state_repository.SaveLocalAppliedState(
+        state_root,
+        node_name,
+        telemetry_state,
+        telemetry_plane);
+    fs::create_directories(webgateway_disk.host_path);
+    naim::RuntimeStatus webgateway_status;
+    webgateway_status.instance_name = webgateway.name;
+    webgateway_status.instance_role = "webgateway";
+    webgateway_status.node_name = node_name;
+    webgateway_status.plane_name = telemetry_plane;
+    webgateway_status.runtime_phase = "running";
+    webgateway_status.ready = true;
+    webgateway_status.launch_ready = true;
+    webgateway_status.inference_ready = true;
+    naim::SaveRuntimeStatusJson(
+        webgateway_status,
+        (fs::path(webgateway_disk.host_path) / "webgateway-runtime-status.json").string());
+    const auto telemetry_statuses =
+        runtime_telemetry_support.LoadLocalInstanceRuntimeStatuses(
+            state_root,
+            node_name,
+            telemetry_plane);
+    Expect(
+        std::any_of(
+            telemetry_statuses.begin(),
+            telemetry_statuses.end(),
+            [&](const naim::RuntimeProcessStatus& status) {
+              return status.instance_name == webgateway.name &&
+                     status.instance_role == "webgateway" &&
+                     status.ready;
+            }),
+        "webgateway runtime status should be collected from its private disk");
 
     const std::string partial_plane = "plane-partial";
     const naim::DesiredState partial_state =
@@ -213,6 +268,7 @@ int main() {
     std::cout << "ok: recursive-plane-state-removal\n";
     std::cout << "ok: partial-llm-state-roundtrip\n";
     std::cout << "ok: require-single-node-sliced-state\n";
+    std::cout << "ok: webgateway-runtime-telemetry\n";
     return 0;
   } catch (const std::exception& ex) {
     std::cerr << ex.what() << '\n';

--- a/hostd/src/app/hostd_runtime_telemetry_support.cpp
+++ b/hostd/src/app/hostd_runtime_telemetry_support.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "app/hostd_local_state_path_support.h"
@@ -66,6 +67,10 @@ std::vector<naim::RuntimeProcessStatus> HostdRuntimeTelemetrySupport::LoadLocalI
       const auto selected_path =
           infer_status_path.has_value() ? infer_status_path : status_path;
       if (!selected_path.has_value() || !fs::exists(*selected_path)) {
+        if (const auto container_status = BuildContainerRuntimeStatusForInstance(instance);
+            container_status.has_value()) {
+          result.push_back(*container_status);
+        }
         continue;
       }
       const auto status = naim::LoadRuntimeStatusJson(*selected_path);
@@ -194,6 +199,8 @@ std::optional<std::string> HostdRuntimeTelemetrySupport::WorkerRuntimeStatusPath
     const naim::InstanceSpec& instance) const {
   if (instance.role != naim::InstanceRole::Worker &&
       instance.role != naim::InstanceRole::Skills &&
+      instance.role != naim::InstanceRole::Browsing &&
+      instance.role != naim::InstanceRole::VoiceModule &&
       instance.role != naim::InstanceRole::Interaction) {
     return std::nullopt;
   }
@@ -203,6 +210,10 @@ std::optional<std::string> HostdRuntimeTelemetrySupport::WorkerRuntimeStatusPath
          disk.kind == naim::DiskKind::WorkerPrivate) ||
         (instance.role == naim::InstanceRole::Skills &&
          disk.kind == naim::DiskKind::SkillsPrivate) ||
+        (instance.role == naim::InstanceRole::Browsing &&
+         disk.kind == naim::DiskKind::BrowsingPrivate) ||
+        (instance.role == naim::InstanceRole::VoiceModule &&
+         disk.kind == naim::DiskKind::VoiceModulePrivate) ||
         (instance.role == naim::InstanceRole::Interaction &&
          disk.kind == naim::DiskKind::InteractionPrivate);
     if (matching_disk_kind && disk.owner_name == instance.name &&
@@ -210,6 +221,10 @@ std::optional<std::string> HostdRuntimeTelemetrySupport::WorkerRuntimeStatusPath
       return (fs::path(disk.host_path) /
               (instance.role == naim::InstanceRole::Skills
                    ? "skills-runtime-status.json"
+                   : instance.role == naim::InstanceRole::Browsing
+                         ? "webgateway-runtime-status.json"
+                   : instance.role == naim::InstanceRole::VoiceModule
+                         ? "voice-module-runtime-status.json"
                    : instance.role == naim::InstanceRole::Interaction
                          ? "interaction-runtime-status.json"
                    : "worker-runtime-status.json"))
@@ -251,6 +266,32 @@ naim::RuntimeProcessStatus HostdRuntimeTelemetrySupport::ToProcessStatus(
   process.ready = status.ready || status.launch_ready || status.inference_ready;
   process.plane_name = status.plane_name;
   return process;
+}
+
+std::optional<naim::RuntimeProcessStatus>
+HostdRuntimeTelemetrySupport::BuildContainerRuntimeStatusForInstance(
+    const naim::InstanceSpec& instance) const {
+  if (instance.role != naim::InstanceRole::VoiceModule) {
+    return std::nullopt;
+  }
+  const auto host_pid = ResolveServiceHostPid(instance.name);
+  if (!host_pid.has_value()) {
+    return std::nullopt;
+  }
+  naim::RuntimeStatus status;
+  status.instance_name = instance.name;
+  status.instance_role = naim::ToString(instance.role);
+  status.node_name = instance.node_name;
+  status.plane_name = instance.plane_name;
+  status.runtime_phase = "running";
+  status.runtime_backend = "container";
+  status.ready = true;
+  status.launch_ready = true;
+  status.inference_ready = true;
+  status.active_model_ready = true;
+  status.runtime_pid = *host_pid;
+  status.engine_pid = *host_pid;
+  return ToProcessStatus(std::move(status), instance);
 }
 
 std::optional<std::string> HostdRuntimeTelemetrySupport::ParseTaggedValue(

--- a/runtime/voice/src/main.cpp
+++ b/runtime/voice/src/main.cpp
@@ -22,6 +22,8 @@
 #include <thread>
 #include <vector>
 
+#include <unistd.h>
+
 namespace {
 
 struct Config {
@@ -32,6 +34,10 @@ struct Config {
   std::string wake_phrase = "Hey Jex";
   std::string ffmpeg_bin = "ffmpeg";
   std::string language = "auto";
+  std::string plane_name;
+  std::string instance_name;
+  std::string node_name;
+  std::string runtime_status_path;
   int threads = std::max(1u, std::thread::hardware_concurrency());
   int max_body_bytes = 16 * 1024 * 1024;
   bool translate = false;
@@ -88,6 +94,10 @@ Config load_config() {
   config.wake_phrase = getenv_string("VOICE_LISTENER_WAKE_PHRASE", getenv_string("NAIM_VOICE_LISTENER_WAKE_PHRASE", config.wake_phrase));
   config.ffmpeg_bin = getenv_string("VOICE_ASR_FFMPEG_BIN", config.ffmpeg_bin);
   config.language = getenv_string("VOICE_ASR_LANGUAGE", config.language);
+  config.plane_name = getenv_string("NAIM_PLANE_NAME");
+  config.instance_name = getenv_string("NAIM_INSTANCE_NAME");
+  config.node_name = getenv_string("NAIM_NODE_NAME");
+  config.runtime_status_path = getenv_string("NAIM_VOICE_MODULE_RUNTIME_STATUS_PATH");
   config.threads = getenv_int("VOICE_ASR_THREADS", config.threads);
   config.max_body_bytes = getenv_int("VOICE_BODY_LIMIT_BYTES", config.max_body_bytes);
   config.translate = getenv_bool("VOICE_ASR_TRANSLATE", config.translate);
@@ -118,6 +128,38 @@ std::string json_escape(const std::string &input) {
 
 std::string make_json_error(const std::string &message) {
   return "{\"error\":\"" + json_escape(message) + "\"}";
+}
+
+void write_runtime_status(const Config &config, const std::string &phase, bool ready) {
+  if (config.runtime_status_path.empty()) {
+    return;
+  }
+  const std::filesystem::path status_path(config.runtime_status_path);
+  if (status_path.has_parent_path()) {
+    std::filesystem::create_directories(status_path.parent_path());
+  }
+  std::ofstream out(status_path, std::ios::binary | std::ios::trunc);
+  if (!out) {
+    std::cerr << "failed to write voice-module runtime status: "
+              << status_path.string() << "\n";
+    return;
+  }
+  const int pid = static_cast<int>(getpid());
+  out << "{\n"
+      << "  \"plane_name\": \"" << json_escape(config.plane_name) << "\",\n"
+      << "  \"instance_name\": \"" << json_escape(config.instance_name) << "\",\n"
+      << "  \"instance_role\": \"voice-module\",\n"
+      << "  \"node_name\": \"" << json_escape(config.node_name) << "\",\n"
+      << "  \"runtime_backend\": \"whisper.cpp\",\n"
+      << "  \"runtime_phase\": \"" << json_escape(phase) << "\",\n"
+      << "  \"model_path\": \"" << json_escape(config.model_path) << "\",\n"
+      << "  \"runtime_pid\": " << pid << ",\n"
+      << "  \"engine_pid\": " << pid << ",\n"
+      << "  \"ready\": " << (ready ? "true" : "false") << ",\n"
+      << "  \"launch_ready\": " << (ready ? "true" : "false") << ",\n"
+      << "  \"inference_ready\": " << (ready ? "true" : "false") << ",\n"
+      << "  \"active_model_ready\": " << (ready ? "true" : "false") << "\n"
+      << "}\n";
 }
 
 std::string request_id() {
@@ -437,6 +479,7 @@ int main() {
   const Config config = load_config();
   if (config.model_path.empty()) {
     std::cerr << "WHISPER_MODEL_PATH is required\n";
+    write_runtime_status(config, "failed", false);
     return 2;
   }
 
@@ -444,8 +487,10 @@ int main() {
   whisper_context *ctx = whisper_init_from_file_with_params(config.model_path.c_str(), cparams);
   if (!ctx) {
     std::cerr << "failed to load whisper model: " << config.model_path << "\n";
+    write_runtime_status(config, "failed", false);
     return 2;
   }
+  write_runtime_status(config, "running", true);
 
   httplib::Server server;
   server.set_payload_max_length(static_cast<size_t>(config.max_body_bytes));

--- a/ui/operator-react/src/styles.css
+++ b/ui/operator-react/src/styles.css
@@ -2332,6 +2332,8 @@ body {
 
 .plane-editor-modal {
   width: min(1480px, calc(100vw - 48px));
+  height: min(920px, calc(100vh - 48px));
+  max-height: calc(100vh - 48px);
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -2341,12 +2343,14 @@ body {
 
 .plane-editor-scroll {
   display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   align-items: stretch;
   gap: 14px;
   min-height: 0;
   max-width: 100%;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 0 4px 4px 0;
 }
 
@@ -2591,6 +2595,11 @@ body {
     width: calc(100vw - 28px);
     max-height: calc(100vh - 28px);
     padding: 16px;
+  }
+
+  .plane-editor-modal {
+    height: calc(100vh - 28px);
+    max-height: calc(100vh - 28px);
   }
 
   .plane-editor-modal > .toolbar:last-child {


### PR DESCRIPTION
## Summary
- make Edit Plane modal use a single internal scroll area
- collect webgateway runtime status from its private disk
- add voice-module runtime status path and status file emission, with hostd fallback for existing containers

## Validation
- npm run build (ui/operator-react)
- cmake --build build/codex-hostd-telemetry --target naim-hostd-local-state-tests naim-state-v2-tests
- ./build/codex-hostd-telemetry/naim-hostd-local-state-tests
- ./build/codex-hostd-telemetry/naim-state-v2-tests
- cmake -S runtime/voice -B build/codex-voice-telemetry -G Ninja -DCMAKE_BUILD_TYPE=Debug -DNAIM_ENABLE_CUDA=OFF
- cmake --build build/codex-voice-telemetry --target naim-voice-moduled