### PR TITLE
Fix telemetry queue budget and protected KV merge

### DIFF
--- a/controller/include/telemetry/telemetry_node_alert_builder.h
+++ b/controller/include/telemetry/telemetry_node_alert_builder.h
@@ -21,6 +21,9 @@ class TelemetryNodeAlertBuilder final {
   std::uint64_t IngestWarningBudgetMs(
       const naim::HostTelemetryFrame& frame,
       const TelemetryAlertThresholds& thresholds) const;
+  std::uint64_t QueueWarningBudgetMs(
+      const naim::HostTelemetryFrame& frame,
+      const TelemetryAlertThresholds& thresholds) const;
   bool HasActivePublishError(const naim::HostTelemetryFrame& frame) const;
 
   TelemetryFrameMatcher matcher_;

--- a/controller/src/knowledge/knowledge_vault_http_service.cpp
+++ b/controller/src/knowledge/knowledge_vault_http_service.cpp
@@ -16,7 +16,10 @@ bool IsPlaneScopedKnowledgeRoute(const std::string& path) {
          suffix == "context" ||
          suffix == "query-route" ||
          suffix == "source-ingest" ||
-         suffix == "graph-neighborhood";
+         suffix == "graph-neighborhood" ||
+         suffix == "overlays" ||
+         suffix == "markdown-import" ||
+         suffix.rfind("replica-merges", 0) == 0;
 }
 
 nlohmann::json SelectedKnowledgeIds(const naim::DesiredState& desired_state) {
@@ -131,6 +134,7 @@ HttpRequest KnowledgeVaultHttpService::BuildPlaneScopedRequest(
   }
 
   body["plane_id"] = plane_name;
+  body["protected_plane"] = desired_state.protected_plane;
   const auto selected_ids = SelectedKnowledgeIds(desired_state);
   if (rewritten.path == "/api/v1/knowledge-vault/context" &&
       !selected_ids.empty() &&

--- a/controller/src/knowledge/knowledge_vault_service_tests.cpp
+++ b/controller/src/knowledge/knowledge_vault_service_tests.cpp
@@ -142,6 +142,12 @@ naim::DesiredState BuildKnowledgePlaneState() {
   return desired_state;
 }
 
+naim::DesiredState BuildProtectedKnowledgePlaneState() {
+  auto desired_state = BuildKnowledgePlaneState();
+  desired_state.protected_plane = true;
+  return desired_state;
+}
+
 void TestPlaneScopedContextRequestAddsPlaneAndSelectedKnowledge() {
   HttpRequest request;
   request.method = "POST";
@@ -218,6 +224,55 @@ void TestPlaneScopedSearchRequestKeepsExplicitBody() {
   Expect(!body.contains("selected_knowledge_ids"), "search should not force selected ids");
 }
 
+void TestPlaneScopedMutationRequestsCarryProtectedPlane() {
+  HttpRequest overlay_request;
+  overlay_request.method = "POST";
+  overlay_request.path = "/api/v1/planes/knowledge-plane/knowledge-vault/overlays";
+  overlay_request.headers["Content-Type"] = "application/json";
+  overlay_request.body = R"({"capsule_id":"cap-test","change_type":"claim_add"})";
+
+  const auto rewritten_overlay =
+      naim::controller::KnowledgeVaultHttpService::BuildPlaneScopedRequest(
+          overlay_request,
+          BuildProtectedKnowledgePlaneState(),
+          "knowledge-plane");
+  const auto overlay_body = nlohmann::json::parse(rewritten_overlay.body);
+
+  Expect(
+      rewritten_overlay.path == "/api/v1/knowledge-vault/overlays",
+      "plane overlay path should rewrite to canonical knowledge route");
+  Expect(
+      overlay_body.value("plane_id", std::string{}) == "knowledge-plane",
+      "plane overlay should include plane id");
+  Expect(
+      overlay_body.value("protected_plane", false),
+      "protected plane overlay should carry protected_plane flag");
+
+  HttpRequest merge_request;
+  merge_request.method = "POST";
+  merge_request.path =
+      "/api/v1/planes/knowledge-plane/knowledge-vault/replica-merges/trigger";
+  merge_request.headers["Content-Type"] = "application/json";
+  merge_request.body = R"({"capsule_id":"cap-test"})";
+
+  const auto rewritten_merge =
+      naim::controller::KnowledgeVaultHttpService::BuildPlaneScopedRequest(
+          merge_request,
+          BuildProtectedKnowledgePlaneState(),
+          "knowledge-plane");
+  const auto merge_body = nlohmann::json::parse(rewritten_merge.body);
+
+  Expect(
+      rewritten_merge.path == "/api/v1/knowledge-vault/replica-merges/trigger",
+      "plane replica-merge path should rewrite to canonical knowledge route");
+  Expect(
+      merge_body.value("plane_id", std::string{}) == "knowledge-plane",
+      "plane replica merge should include plane id");
+  Expect(
+      merge_body.value("protected_plane", false),
+      "protected plane replica merge should carry protected_plane flag");
+}
+
 }  // namespace
 
 int main() {
@@ -227,5 +282,6 @@ int main() {
   TestPlaneScopedContextRequestAddsPlaneAndSelectedKnowledge();
   TestPlaneScopedGraphRequestDefaultsToSelectedKnowledge();
   TestPlaneScopedSearchRequestKeepsExplicitBody();
+  TestPlaneScopedMutationRequestsCarryProtectedPlane();
   return 0;
 }

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -432,6 +432,59 @@ void TestRecoveredTelemetryCountersDoNotDegradeHealth() {
   std::cout << "ok: telemetry-live-store-recovered-counters-health\n";
 }
 
+void TestQueueDelayBudgetTracksAdaptiveCadence() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  store.ResetForTests();
+  naim::controller::TelemetryLiveStore::RetentionConfig retention;
+  naim::controller::TelemetryLiveStore::AlertThresholds thresholds;
+  thresholds.queue_warning_ms = 1000;
+  store.ConfigureOperationalPolicy(retention, thresholds);
+
+  auto stable_frame = MakeFrame("node-queue-budget", "plane-queue-budget", CurrentMillis());
+  stable_frame.ttl_ms = 60000;
+  stable_frame.adaptive_interval_ms = 5000;
+  stable_frame.publisher_queue_delay_ms = 1500;
+  stable_frame.plane_ready_instance_count = stable_frame.plane_instance_count;
+  stable_frame.plane_not_ready_instance_count = 0;
+  stable_frame.plane_runtime_health = "ready";
+  Expect(store.Upsert(stable_frame), "stable queue-delay frame should update");
+  auto health = store.BuildHealth(std::string("plane-queue-budget"));
+  auto has_queue_delay_alert = [](const nlohmann::json& alerts) {
+    for (const auto& alert : alerts) {
+      if (alert.value("code", std::string{}) == "telemetry.publisher.queue_delay") {
+        return true;
+      }
+    }
+    return false;
+  };
+  Expect(
+      !has_queue_delay_alert(health.at("alerts")),
+      "queue delay below adaptive budget should not produce queue alert");
+
+  auto delayed_frame = stable_frame;
+  delayed_frame.sequence += 1;
+  delayed_frame.monotonic_ms += 1;
+  delayed_frame.monotonic_timestamp_ms += 1;
+  delayed_frame.publisher_queue_delay_ms = 3000;
+  Expect(store.Upsert(delayed_frame), "delayed queue frame should update");
+  health = store.BuildHealth(std::string("plane-queue-budget"));
+  Expect(
+      has_queue_delay_alert(health.at("alerts")),
+      "queue delay above adaptive budget should still produce an alert");
+  nlohmann::json queue_alert = nlohmann::json::object();
+  for (const auto& alert : health.at("alerts")) {
+    if (alert.value("code", std::string{}) == "telemetry.publisher.queue_delay") {
+      queue_alert = alert;
+      break;
+    }
+  }
+  Expect(
+      queue_alert.value("warning_budget_ms", 0) == 2500,
+      "queue delay alert should expose adaptive warning budget");
+  store.ResetForTests();
+  std::cout << "ok: telemetry-live-store-queue-delay-adaptive-budget\n";
+}
+
 void TestGpuUnavailableStorageNodeDoesNotDegradeHealth() {
   auto& store = naim::controller::TelemetryLiveStore::Instance();
   store.ResetForTests();
@@ -555,6 +608,7 @@ int main() {
     TestSqlitePersistenceReplayAndHealth();
     TestConfigurableRetentionAndMetrics();
     TestRecoveredTelemetryCountersDoNotDegradeHealth();
+    TestQueueDelayBudgetTracksAdaptiveCadence();
     TestGpuUnavailableStorageNodeDoesNotDegradeHealth();
     TestStreamMetricsAndOpenMetrics();
     return 0;

--- a/controller/src/telemetry/telemetry_node_alert_builder.cpp
+++ b/controller/src/telemetry/telemetry_node_alert_builder.cpp
@@ -16,6 +16,16 @@ std::uint64_t TelemetryNodeAlertBuilder::IngestWarningBudgetMs(
       adaptive_interval_ms * 2 + thresholds.ingest_warning_ms);
 }
 
+std::uint64_t TelemetryNodeAlertBuilder::QueueWarningBudgetMs(
+    const naim::HostTelemetryFrame& frame,
+    const TelemetryAlertThresholds& thresholds) const {
+  const std::uint64_t adaptive_interval_ms =
+      frame.adaptive_interval_ms > 0
+          ? static_cast<std::uint64_t>(frame.adaptive_interval_ms)
+          : static_cast<std::uint64_t>(std::max(0, frame.interval_ms));
+  return std::max(thresholds.queue_warning_ms, adaptive_interval_ms / 2);
+}
+
 bool TelemetryNodeAlertBuilder::HasActivePublishError(
     const naim::HostTelemetryFrame& frame) const {
   return frame.publish_error_count > 0 && !frame.last_publish_error.empty();
@@ -57,13 +67,16 @@ nlohmann::json TelemetryNodeAlertBuilder::Build(
         {"warning_budget_ms", ingest_warning_budget_ms},
     });
   }
-  if (frame.publisher_queue_delay_ms >= thresholds.queue_warning_ms) {
+  const auto queue_warning_budget_ms = QueueWarningBudgetMs(frame, thresholds);
+  if (frame.publisher_queue_delay_ms >= queue_warning_budget_ms) {
     alerts.push_back(nlohmann::json{
         {"code", "telemetry.publisher.queue_delay"},
         {"severity", "warning"},
         {"node_name", frame.node_name},
         {"plane_name", matcher_.PlaneKeyForFrame(frame)},
         {"delay_ms", frame.publisher_queue_delay_ms},
+        {"expected_interval_ms", frame.adaptive_interval_ms},
+        {"warning_budget_ms", queue_warning_budget_ms},
     });
   }
   if (HasActivePublishError(frame)) {

--- a/runtime/knowledge/include/knowledge/knowledge_server.h
+++ b/runtime/knowledge/include/knowledge/knowledge_server.h
@@ -19,6 +19,7 @@ struct KnowledgeRuntimeConfig {
   std::filesystem::path ready_path = "/tmp/naim-ready";
   std::string listen_host = "127.0.0.1";
   int port = 18200;
+  bool protected_plane = false;
 };
 
 class KnowledgeServer final {

--- a/runtime/knowledge/include/knowledge/knowledge_store.h
+++ b/runtime/knowledge/include/knowledge/knowledge_store.h
@@ -15,6 +15,7 @@ class RocksDbJsonRepository;
 class KnowledgeStore final {
  public:
   explicit KnowledgeStore(std::filesystem::path store_path);
+  KnowledgeStore(std::filesystem::path store_path, bool protected_plane);
   ~KnowledgeStore();
 
   KnowledgeStore(const KnowledgeStore&) = delete;
@@ -67,8 +68,13 @@ class KnowledgeStore final {
   static std::string JsonText(const nlohmann::json& value);
   static std::string NormalizeTerm(const std::string& value);
   static std::string MarkdownEscape(const std::string& value);
+  bool ProtectedPlaneRequested(const nlohmann::json& payload) const;
+  nlohmann::json BuildProtectedReplicaMergeSkip(
+      const std::string& plane_id,
+      const std::string& capsule_id);
 
   std::unique_ptr<RocksDbJsonRepository> repository_;
+  bool protected_plane_ = false;
 };
 
 }  // namespace naim::knowledge_runtime

--- a/runtime/knowledge/src/knowledge_runtime_config_loader.cpp
+++ b/runtime/knowledge/src/knowledge_runtime_config_loader.cpp
@@ -15,6 +15,9 @@ KnowledgeRuntimeConfig KnowledgeRuntimeConfigLoader::LoadFromEnvironment() const
   config.ready_path = GetEnvOr("NAIM_READY_FILE", "/tmp/naim-ready");
   config.listen_host = GetEnvOr("NAIM_KNOWLEDGE_LISTEN_HOST", "127.0.0.1");
   config.port = GetEnvIntOr("NAIM_KNOWLEDGE_PORT", 18200);
+  const std::string protected_plane = GetEnvOr("NAIM_PLANE_PROTECTED", "0");
+  config.protected_plane =
+      protected_plane == "1" || protected_plane == "true" || protected_plane == "yes";
   return config;
 }
 

--- a/runtime/knowledge/src/knowledge_server.cpp
+++ b/runtime/knowledge/src/knowledge_server.cpp
@@ -17,7 +17,8 @@ KnowledgeServer::ApiError::ApiError(int status, std::string code, std::string me
     : std::runtime_error(std::move(message)), status_(status), code_(std::move(code)) {}
 
 KnowledgeServer::KnowledgeServer(KnowledgeRuntimeConfig config)
-    : config_(std::move(config)), store_(config_.store_path) {}
+    : config_(std::move(config)),
+      store_(config_.store_path, config_.protected_plane) {}
 
 KnowledgeServer::~KnowledgeServer() {
   RequestStop();

--- a/runtime/knowledge/src/knowledge_store.cpp
+++ b/runtime/knowledge/src/knowledge_store.cpp
@@ -87,7 +87,11 @@ int TokenSearchScore(
 }  // namespace
 
 KnowledgeStore::KnowledgeStore(std::filesystem::path store_path)
-    : repository_(std::make_unique<RocksDbJsonRepository>(std::move(store_path))) {}
+    : KnowledgeStore(std::move(store_path), false) {}
+
+KnowledgeStore::KnowledgeStore(std::filesystem::path store_path, bool protected_plane)
+    : repository_(std::make_unique<RocksDbJsonRepository>(std::move(store_path))),
+      protected_plane_(protected_plane) {}
 
 KnowledgeStore::~KnowledgeStore() = default;
 
@@ -616,6 +620,9 @@ nlohmann::json KnowledgeStore::WriteOverlay(const nlohmann::json& payload) {
       nlohmann::json{{"overlay_change_id", proposal.overlay_change_id}});
   auto proposal_json = naim::knowledge::KnowledgeJsonCodec::ToJson(proposal);
   proposal_json["overlay_event_seq"] = sequence;
+  if (ProtectedPlaneRequested(payload)) {
+    proposal_json["protected_plane"] = true;
+  }
   const std::string sequence_key = KnowledgeStoreKeys::EventKey(sequence).substr(std::string("events:").size());
   rocksdb::WriteBatch batch;
   batch.Put(
@@ -647,6 +654,7 @@ nlohmann::json KnowledgeStore::ScheduleReplicaMerge(const nlohmann::json& payloa
       {"plane_id", plane_id},
       {"capsule_id", capsule_id},
       {"cadence", cadence},
+      {"protected_plane", ProtectedPlaneRequested(payload)},
       {"next_run_at", next_run_at},
       {"last_checkpoint", nlohmann::json::object()},
       {"status", "scheduled"},
@@ -676,6 +684,12 @@ nlohmann::json KnowledgeStore::RunScheduledReplicaMerges(const nlohmann::json& p
     if (!force) {
       // Controller owns wall-clock cadence; the runtime reconciles schedules selected by controller.
     }
+    if (ProtectedPlaneRequested(payload) || schedule.value("protected_plane", false)) {
+      jobs.push_back(BuildProtectedReplicaMergeSkip(
+          plane_id,
+          schedule.value("capsule_id", std::string{})));
+      continue;
+    }
     auto result = TriggerReplicaMerge(nlohmann::json{
         {"plane_id", plane_id},
         {"capsule_id", schedule.value("capsule_id", std::string{})},
@@ -698,6 +712,9 @@ nlohmann::json KnowledgeStore::TriggerReplicaMerge(const nlohmann::json& payload
   checkpoint.capsule_id = payload.value("capsule_id", std::string{});
   if (checkpoint.plane_id.empty() || checkpoint.capsule_id.empty()) {
     throw std::runtime_error("plane_id and capsule_id are required");
+  }
+  if (ProtectedPlaneRequested(payload)) {
+    return BuildProtectedReplicaMergeSkip(checkpoint.plane_id, checkpoint.capsule_id);
   }
   checkpoint.base_event_seq = payload.value("base_event_seq", 0);
   checkpoint.overlay_event_seq_from =
@@ -726,6 +743,10 @@ nlohmann::json KnowledgeStore::TriggerReplicaMerge(const nlohmann::json& payload
         continue;
       }
       max_overlay_seq = std::max(max_overlay_seq, overlay_seq);
+      if (overlay_json.value("protected_plane", false)) {
+        ++rejected;
+        continue;
+      }
       const auto proposal = naim::knowledge::KnowledgeJsonCodec::OverlayFromJson(overlay_json);
       bool conflict = false;
       std::string conflict_knowledge_id;
@@ -838,6 +859,13 @@ nlohmann::json KnowledgeStore::ReconcileDailyReplicaSchedules(const nlohmann::js
     if (!plane_filter.empty() && plane_filter != plane_id) {
       continue;
     }
+    if (ProtectedPlaneRequested(payload) || schedule.value("protected_plane", false)) {
+      skipped.push_back(nlohmann::json{
+          {"plane_id", plane_id},
+          {"capsule_id", schedule.value("capsule_id", std::string{})},
+          {"reason", "protected_plane"}});
+      continue;
+    }
     reconciled.push_back(TriggerReplicaMerge(nlohmann::json{
         {"plane_id", plane_id},
         {"capsule_id", schedule.value("capsule_id", std::string{})},
@@ -865,6 +893,64 @@ nlohmann::json KnowledgeStore::ReplicaMergeStatus(const std::string& plane_id) c
   return nlohmann::json{
       {"last_successful_checkpoint", latest},
       {"status", latest.is_null() ? "skipped" : "completed"},
+  };
+}
+
+bool KnowledgeStore::ProtectedPlaneRequested(const nlohmann::json& payload) const {
+  if (protected_plane_) {
+    return true;
+  }
+  if (!payload.contains("protected_plane")) {
+    return false;
+  }
+  const auto& value = payload.at("protected_plane");
+  if (value.is_boolean()) {
+    return value.get<bool>();
+  }
+  if (value.is_string()) {
+    const std::string text = KnowledgeTextProcessor::Lowercase(value.get<std::string>());
+    return text == "1" || text == "true" || text == "yes";
+  }
+  return false;
+}
+
+nlohmann::json KnowledgeStore::BuildProtectedReplicaMergeSkip(
+    const std::string& plane_id,
+    const std::string& capsule_id) {
+  naim::knowledge::ReplicaMergeCheckpoint checkpoint;
+  checkpoint.replica_merge_id = NewId("rm");
+  checkpoint.plane_id = plane_id;
+  checkpoint.capsule_id = capsule_id;
+  checkpoint.base_event_seq = 0;
+  checkpoint.overlay_event_seq_from = LastCheckpointSequence(plane_id, capsule_id) + 1;
+  checkpoint.overlay_event_seq_to = checkpoint.overlay_event_seq_from - 1;
+  checkpoint.canonical_event_seq_before = LatestEventSequence();
+  checkpoint.started_at = UtcNow();
+  checkpoint.completed_at = checkpoint.started_at;
+  checkpoint.status = "skipped";
+  checkpoint.canonical_event_seq_after = AppendEvent(
+      "replica.merge.skipped",
+      {},
+      {},
+      nlohmann::json{
+          {"replica_merge_id", checkpoint.replica_merge_id},
+          {"plane_id", checkpoint.plane_id},
+          {"capsule_id", checkpoint.capsule_id},
+          {"reason", "protected_plane"},
+      });
+  const auto checkpoint_json = naim::knowledge::KnowledgeJsonCodec::ToJson(checkpoint);
+  repository_->PutJson(
+      "replica_checkpoints:" + checkpoint.plane_id + ":" + checkpoint.capsule_id + ":" +
+          checkpoint.replica_merge_id,
+      checkpoint_json);
+  return nlohmann::json{
+      {"replica_merge_id", checkpoint.replica_merge_id},
+      {"status", "skipped"},
+      {"reason", "protected_plane"},
+      {"accepted", 0},
+      {"review", 0},
+      {"rejected", 0},
+      {"checkpoint", checkpoint_json},
   };
 }
 

--- a/runtime/knowledge/src/knowledge_store_tests.cpp
+++ b/runtime/knowledge/src/knowledge_store_tests.cpp
@@ -156,6 +156,38 @@ int main() {
   Expect(daily.value("status", std::string{}) == "completed", "daily reconcile should complete");
 
   store.WriteOverlay(nlohmann::json{
+      {"plane_id", "protected-plane"},
+      {"capsule_id", "private-cap"},
+      {"protected_plane", true},
+      {"change_type", "claim_add"},
+      {"base_versions", nlohmann::json::object()},
+      {"proposed_blocks",
+       nlohmann::json::array({nlohmann::json{
+           {"knowledge_id", "knowledge.protected-leak-check"},
+           {"title", "Protected Leak Check"},
+           {"body", "Protected plane knowledge must not enter the common vault."},
+           {"scope_ids", nlohmann::json::array({"scope.default"})},
+       }})},
+  });
+  const auto protected_merge = store.TriggerReplicaMerge(nlohmann::json{
+      {"plane_id", "protected-plane"},
+      {"capsule_id", "private-cap"},
+  });
+  Expect(
+      protected_merge.value("accepted", 0) == 0,
+      "protected overlays should not merge into canonical knowledge");
+  Expect(
+      protected_merge.value("rejected", 0) == 1,
+      "protected overlays should be counted as rejected by direct merge trigger");
+  const auto protected_search = store.Search(nlohmann::json{
+      {"query", "Protected Leak Check"},
+      {"scope_id", "scope.default"},
+  });
+  Expect(
+      protected_search.dump().find("knowledge.protected-leak-check") == std::string::npos,
+      "protected overlay content should not be searchable in the common vault");
+
+  store.WriteOverlay(nlohmann::json{
       {"plane_id", "plane-test"},
       {"capsule_id", "cap-test"},
       {"change_type", "claim_add"},
@@ -207,6 +239,30 @@ int main() {
   Expect(
       !import.value("accepted_for_review", nlohmann::json::array()).empty(),
       "markdown import should create proposals");
+
+  const auto protected_store_path = TempStorePath();
+  naim::knowledge_runtime::KnowledgeStore protected_store(protected_store_path, true);
+  protected_store.Open();
+  protected_store.WriteOverlay(nlohmann::json{
+      {"plane_id", "env-protected-plane"},
+      {"capsule_id", "env-private-cap"},
+      {"change_type", "claim_add"},
+      {"base_versions", nlohmann::json::object()},
+      {"proposed_blocks",
+       nlohmann::json::array({nlohmann::json{
+           {"knowledge_id", "knowledge.env-protected"},
+           {"title", "Env Protected Claim"},
+           {"body", "Runtime protected plane data stays isolated."},
+           {"scope_ids", nlohmann::json::array({"scope.default"})},
+       }})},
+  });
+  const auto env_protected_merge = protected_store.TriggerReplicaMerge(nlohmann::json{
+      {"plane_id", "env-protected-plane"},
+      {"capsule_id", "env-private-cap"},
+  });
+  Expect(
+      env_protected_merge.value("status", std::string{}) == "skipped",
+      "protected runtime should skip replica merge into the common vault");
 
   std::cout << "ok: knowledge-store-integration\n";
   return 0;


### PR DESCRIPTION
## Summary
- make publisher queue-delay alerts use an adaptive budget based on host telemetry cadence
- propagate protected-plane context into plane-scoped Knowledge Vault mutation and replica routes
- prevent protected-plane overlays/runtime from merging into the canonical/shared Knowledge Vault

## Tests
- cmake --build build/codex-hostd-telemetry --target naim-telemetry-live-store-tests naim-knowledge-vault-service-tests naim-knowledge-store-tests
- cmake --build build/codex-hostd-telemetry --target naim-knowledged
- ./build/codex-hostd-telemetry/naim-telemetry-live-store-tests
- ./build/codex-hostd-telemetry/naim-knowledge-vault-service-tests
- ./build/codex-hostd-telemetry/naim-knowledge-store-tests