### PR TITLE
Allow secured auth by SSH fingerprint

### DIFF
--- a/common/include/naim/state/auth_repository.h
+++ b/common/include/naim/state/auth_repository.h
@@ -77,6 +77,8 @@ class AuthRepository final {
   std::optional<SecuredConnectionUserRecord> LoadActiveSecuredConnectionUserByNameAndFingerprint(
       const std::string& name,
       const std::string& fingerprint) const;
+  std::optional<SecuredConnectionUserRecord> LoadActiveSecuredConnectionUserByFingerprint(
+      const std::string& fingerprint) const;
   std::vector<SecuredConnectionUserRecord> LoadSecuredConnectionUsers(
       const std::optional<std::string>& search,
       bool include_revoked) const;

--- a/common/include/naim/state/sqlite_store.h
+++ b/common/include/naim/state/sqlite_store.h
@@ -548,6 +548,8 @@ class ControllerStore {
   std::optional<SecuredConnectionUserRecord> LoadActiveSecuredConnectionUserByNameAndFingerprint(
       const std::string& name,
       const std::string& fingerprint) const;
+  std::optional<SecuredConnectionUserRecord> LoadActiveSecuredConnectionUserByFingerprint(
+      const std::string& fingerprint) const;
   std::vector<SecuredConnectionUserRecord> LoadSecuredConnectionUsers(
       const std::optional<std::string>& search = std::nullopt,
       bool include_revoked = false) const;

--- a/common/src/state/auth_repository.cpp
+++ b/common/src/state/auth_repository.cpp
@@ -500,6 +500,22 @@ AuthRepository::LoadActiveSecuredConnectionUserByNameAndFingerprint(
   return ReadSecuredConnectionUser(statement.raw());
 }
 
+std::optional<SecuredConnectionUserRecord>
+AuthRepository::LoadActiveSecuredConnectionUserByFingerprint(
+    const std::string& fingerprint) const {
+  Statement statement(
+      db_,
+      "SELECT id, name, public_key, fingerprint, search_text, last_authorized_at, "
+      "created_at, updated_at, revoked_at "
+      "FROM secured_connection_users "
+      "WHERE fingerprint = ?1 AND revoked_at = '';");
+  statement.BindText(1, fingerprint);
+  if (!statement.StepRow()) {
+    return std::nullopt;
+  }
+  return ReadSecuredConnectionUser(statement.raw());
+}
+
 std::vector<SecuredConnectionUserRecord> AuthRepository::LoadSecuredConnectionUsers(
     const std::optional<std::string>& search,
     bool include_revoked) const {

--- a/common/src/state/sqlite_store.cpp
+++ b/common/src/state/sqlite_store.cpp
@@ -1104,6 +1104,13 @@ ControllerStore::LoadActiveSecuredConnectionUserByNameAndFingerprint(
       .LoadActiveSecuredConnectionUserByNameAndFingerprint(name, fingerprint);
 }
 
+std::optional<SecuredConnectionUserRecord>
+ControllerStore::LoadActiveSecuredConnectionUserByFingerprint(
+    const std::string& fingerprint) const {
+  return AuthRepository(AsSqlite(db_))
+      .LoadActiveSecuredConnectionUserByFingerprint(fingerprint);
+}
+
 std::vector<SecuredConnectionUserRecord> ControllerStore::LoadSecuredConnectionUsers(
     const std::optional<std::string>& search,
     bool include_revoked) const {

--- a/controller/src/auth/auth_http_service.cpp
+++ b/controller/src/auth/auth_http_service.cpp
@@ -1168,12 +1168,12 @@ HttpResponse AuthHttpService::HandleSshChallenge(
         body.value("username", body.value("name", std::string{})));
     const std::string plane_name = support_.trim(body.value("plane_name", std::string{}));
     const std::string fingerprint = support_.trim(body.value("fingerprint", std::string{}));
-    if (username.empty() || plane_name.empty() || fingerprint.empty()) {
+    if (plane_name.empty() || fingerprint.empty()) {
       return support_.build_json_response(
           400,
           json{{"status", "bad_request"},
                {"message",
-                "username, plane_name, and fingerprint are required"}},
+                "plane_name and fingerprint are required"}},
           {});
     }
     naim::ControllerStore store(db_path);
@@ -1211,7 +1211,7 @@ HttpResponse AuthHttpService::HandleSshChallenge(
             {});
       }
       const auto secured_user =
-          store.LoadActiveSecuredConnectionUserByNameAndFingerprint(username, fingerprint);
+          store.LoadActiveSecuredConnectionUserByFingerprint(fingerprint);
       if (!secured_user.has_value()) {
         store.InsertSecuredConnectionAuthLog({
             0,

--- a/controller/src/auth/auth_http_service_tests.cpp
+++ b/controller/src/auth/auth_http_service_tests.cpp
@@ -335,6 +335,18 @@ void TestUserStorageAdminApiAndSecuredChallengeGuards() {
   Expect(
       accepted_response->status_code == 200,
       "secured challenge should accept HTTPS and selected User Storage user");
+
+  HttpRequest fingerprint_only_challenge = forbidden_challenge;
+  fingerprint_only_challenge.body = json{
+      {"plane_name", "secured-plane"},
+      {"fingerprint", fingerprint},
+  }.dump();
+  const auto fingerprint_only_response =
+      service.HandleRequest(db_path.string(), fingerprint_only_challenge);
+  Expect(fingerprint_only_response.has_value(), "fingerprint-only challenge should respond");
+  Expect(
+      fingerprint_only_response->status_code == 200,
+      "secured challenge should accept fingerprint without username");
   Expect(
       store.LoadSecuredConnectionAuthLog("secured-plane", secured_user_id, 10).size() >= 2,
       "secured challenge attempts should be audit logged");


### PR DESCRIPTION
## Summary
- make secured-connection SSH challenge accept fingerprint without requiring username
- look up active User Storage records by unique SSH fingerprint
- keep existing username/name requests compatible

## Tests
- cmake --build build/codex-hostd-telemetry --target naim-auth-http-tests
- ./build/codex-hostd-telemetry/naim-auth-http-tests