### PR TITLE
Fix secured connection conversation owner

### DIFF
--- a/controller/src/interaction/interaction_stream_http_request_preparation_service.cpp
+++ b/controller/src/interaction/interaction_stream_http_request_preparation_service.cpp
@@ -6,6 +6,7 @@
 #include "interaction/interaction_conversation_service.h"
 #include "interaction/interaction_request_contract_support.h"
 #include "interaction/interaction_stream_http_error_response_builder.h"
+#include "naim/security/crypto_utils.h"
 
 namespace naim::controller {
 
@@ -69,10 +70,18 @@ InteractionStreamHttpRequestPreparationService::Prepare(
       };
     }
     if (authenticated.has_value()) {
-      principal.owner_kind = "user";
-      principal.owner_user_id = authenticated->first.id;
       principal.auth_session_kind = authenticated->second.session_kind;
       principal.authenticated = true;
+      if (authenticated->second.session_kind == "secured_ssh" ||
+          authenticated->first.role == "secured_connection") {
+        principal.owner_kind =
+            "secured_connection:" +
+            naim::ComputeSha256Hex(authenticated->second.token).substr(0, 24);
+        principal.owner_user_id = std::nullopt;
+      } else {
+        principal.owner_kind = "user";
+        principal.owner_user_id = authenticated->first.id;
+      }
     }
 
     if (const auto validation_error = InteractionConversationService().PrepareRequest(

--- a/controller/src/interaction/interaction_stream_http_request_preparation_service_tests.cpp
+++ b/controller/src/interaction/interaction_stream_http_request_preparation_service_tests.cpp
@@ -7,6 +7,7 @@
 
 #include "auth/auth_support_service.h"
 #include "interaction/interaction_stream_http_request_preparation_service.h"
+#include "naim/state/sqlite_store.h"
 
 namespace {
 
@@ -121,12 +122,79 @@ void TestPrepareRejectsUnauthorizedProtectedPlane() {
   std::filesystem::remove(db_path);
 }
 
+void TestPrepareUsesExternalOwnerForSecuredConnectionSession() {
+  const std::string db_path =
+      MakeTempDbPath("interaction-stream-http-prepare-secured");
+  naim::ControllerStore store(db_path);
+  store.Initialize();
+  store.UpsertSecuredConnectionUser({
+      "scu-test",
+      "terminal-a",
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestOnly test@example",
+      "SHA256:test",
+      "terminal-a SHA256:test",
+      "",
+      "2026-05-06 00:00:00",
+      "2026-05-06 00:00:00",
+      "",
+  });
+  store.InsertSecuredConnectionSession({
+      "secured-token-test",
+      "scu-test",
+      "protected-plane",
+      "2099-01-01 00:00:00",
+      "2026-05-06 00:00:00",
+      "",
+      "",
+  });
+
+  const naim::controller::InteractionStreamRequestResolver resolver(
+      [](const std::string&, const std::string& plane_name) {
+        return BuildReadyResolution(plane_name, true);
+      },
+      [](const naim::controller::PlaneInteractionResolution&,
+         naim::controller::InteractionRequestContext*) {
+        return std::optional<naim::controller::InteractionValidationError>{};
+      });
+  const naim::controller::InteractionStreamHttpRequestPreparationService service(
+      resolver,
+      [](const naim::controller::PlaneInteractionResolution&,
+         naim::controller::InteractionRequestContext*) {
+        return std::optional<naim::controller::InteractionValidationError>{};
+      });
+  AuthSupportService auth_support;
+  HttpRequest request;
+  request.method = "POST";
+  request.path = "/api/v1/planes/protected-plane/interaction/chat/completions/stream";
+  request.headers["x-naim-session-token"] = "secured-token-test";
+  request.body = R"({"messages":[{"role":"user","content":"hello"}]})";
+
+  const auto result = service.Prepare(db_path, request, "req-3", auth_support);
+  Expect(!result.error_response.has_value(),
+         "secured connection session should authorize protected plane request");
+  Expect(result.setup.has_value(), "secured connection request should return setup");
+  Expect(
+      result.setup->request_context.owner_kind ==
+          "secured_connection:7fff86ef51c3be788e2bafec",
+      "secured connection conversation owner should not use users table ids");
+  Expect(
+      !result.setup->request_context.owner_user_id.has_value(),
+      "secured connection conversation owner_user_id should remain null");
+  Expect(
+      result.setup->request_context.auth_session_kind == "secured_ssh",
+      "secured connection auth session kind should be preserved");
+  std::cout << "ok: interaction-stream-http-prepare-secured-owner" << '\n';
+
+  std::filesystem::remove(db_path);
+}
+
 }  // namespace
 
 int main() {
   try {
     TestPrepareBuildsSetupForReadyUnprotectedPlane();
     TestPrepareRejectsUnauthorizedProtectedPlane();
+    TestPrepareUsesExternalOwnerForSecuredConnectionSession();
     return 0;
   } catch (const std::exception& error) {
     std::cerr << "interaction_stream_http_request_preparation_service_tests failed: "


### PR DESCRIPTION
## Summary
- keep secured-connection protected-plane conversation owners out of users(id) FK paths
- derive a stable non-secret owner kind from the secured session token hash
- add coverage for secured SSH request preparation

## Tests
- cmake --build build/codex-hostd-telemetry --target naim-interaction-stream-http-request-preparation-service-tests naim-auth-http-tests
- ./build/codex-hostd-telemetry/naim-interaction-stream-http-request-preparation-service-tests
- ./build/codex-hostd-telemetry/naim-auth-http-tests