### PR TITLE
Fix single-node storage telemetry plumbing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1087,6 +1087,17 @@ target_link_libraries(naim-hostd-local-state-tests PRIVATE naim-common)
 naim_enable_strict_warnings(naim-hostd-local-state-tests)
 
 add_executable(
+  naim-generated-config-loader-tests
+  launcher/src/config/generated_config_loader.cpp
+  launcher/src/config/install_layout.cpp
+  launcher/src/config/generated_config_loader_tests.cpp
+)
+target_include_directories(
+  naim-generated-config-loader-tests PRIVATE common/include launcher/include)
+target_link_libraries(naim-generated-config-loader-tests PRIVATE naim-common)
+naim_enable_strict_warnings(naim-generated-config-loader-tests)
+
+add_executable(
   naim-hostd-command-support-tests
   hostd/src/app/hostd_command_support.cpp
   hostd/src/app/hostd_command_support_tests.cpp

--- a/controller/src/telemetry/telemetry_frame_ring_buffer.cpp
+++ b/controller/src/telemetry/telemetry_frame_ring_buffer.cpp
@@ -27,6 +27,9 @@ bool TelemetryFrameRingBuffer::Upsert(
     buffer.history.push_back(std::move(frame));
     nodes.push_back(std::move(buffer));
   } else {
+    if (frame.disk.items.empty() && !it->latest.disk.items.empty()) {
+      frame.disk = it->latest.disk;
+    }
     it->latest = frame;
     it->history.push_back(std::move(frame));
   }

--- a/controller/src/telemetry/telemetry_live_store_tests.cpp
+++ b/controller/src/telemetry/telemetry_live_store_tests.cpp
@@ -346,6 +346,66 @@ void TestSqlitePersistenceReplayAndHealth() {
   std::cout << "ok: telemetry-live-store-sqlite-persistence-health\n";
 }
 
+void TestFastFramePreservesSlowDiskTelemetry() {
+  auto& store = naim::controller::TelemetryLiveStore::Instance();
+  store.ResetForTests();
+  const auto now = CurrentMillis();
+  auto slow = MakeFrame("node-disk-sticky", "plane-disk-sticky", now);
+  slow.ttl_ms = 60000;
+  slow.lane = "full";
+  slow.disk.source = "hostd";
+  slow.disk.collected_at = slow.collected_at;
+  slow.disk.items.push_back(naim::DiskTelemetryRecord{
+      "storage-root",
+      "",
+      "node-disk-sticky",
+      "/srv/naim-storage",
+      "",
+      "",
+      "present",
+      "ok",
+      "",
+      200,
+      80,
+      120,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      false,
+      false,
+      false,
+      false,
+      {},
+  });
+  Expect(store.Upsert(slow), "slow disk frame should update");
+
+  auto fast = MakeFrame("node-disk-sticky", "plane-disk-sticky", now + 1);
+  fast.ttl_ms = 60000;
+  fast.lane = "fast";
+  fast.disk.items.clear();
+  Expect(store.Upsert(fast), "fast frame should update");
+
+  const auto snapshot = store.BuildSnapshot(std::string("plane-disk-sticky"), 0);
+  const auto disk_items = snapshot.at("nodes").at(0).at("disk").at("items");
+  Expect(disk_items.size() == 1, "fast frame should preserve latest slow disk item");
+  Expect(
+      disk_items.at(0).at("disk_name").get<std::string>() == "storage-root",
+      "preserved disk item should remain storage-root");
+  Expect(
+      disk_items.at(0).at("total_bytes").get<std::uint64_t>() == 200,
+      "preserved disk item should keep capacity");
+
+  store.ResetForTests();
+  std::cout << "ok: telemetry-live-store-fast-frame-preserves-disk\n";
+}
+
 void TestConfigurableRetentionAndMetrics() {
   auto& store = naim::controller::TelemetryLiveStore::Instance();
   store.ResetForTests();
@@ -606,6 +666,7 @@ int main() {
     TestPlaneAggregatesAndDownsampling();
     TestMultiPlaneNodeTelemetryIsPlaneScoped();
     TestSqlitePersistenceReplayAndHealth();
+    TestFastFramePreservesSlowDiskTelemetry();
     TestConfigurableRetentionAndMetrics();
     TestRecoveredTelemetryCountersDoNotDegradeHealth();
     TestQueueDelayBudgetTracksAdaptiveCadence();

--- a/hostd/include/cli/hostd_command_line.h
+++ b/hostd/include/cli/hostd_command_line.h
@@ -23,6 +23,7 @@ class HostdCommandLine {
   std::optional<std::string> db() const;
   std::optional<std::string> controller() const;
   std::optional<std::string> artifacts_root() const;
+  std::optional<std::string> storage_root() const;
   std::optional<std::string> runtime_root() const;
   std::optional<std::string> compose_mode_raw() const;
   std::optional<std::string> state_root() const;

--- a/hostd/src/app/hostd_reporting_support_tests.cpp
+++ b/hostd/src/app/hostd_reporting_support_tests.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <filesystem>
 #include <iostream>
 #include <stdexcept>
@@ -7,6 +8,7 @@
 #include <nlohmann/json.hpp>
 
 #include "app/hostd_reporting_support.h"
+#include "naim/runtime/runtime_status.h"
 
 namespace {
 
@@ -228,6 +230,28 @@ int main() {
       Expect(
           !observation.disk_telemetry_json.empty(),
           "observation should include disk telemetry payload");
+      const auto disk_snapshot =
+          naim::DeserializeDiskTelemetryJson(observation.disk_telemetry_json);
+      const auto storage_it = std::find_if(
+          disk_snapshot.items.begin(),
+          disk_snapshot.items.end(),
+          [](const naim::DiskTelemetryRecord& record) {
+            return record.disk_name == "storage-root";
+          });
+      Expect(
+          storage_it != disk_snapshot.items.end(),
+          "observation should include storage-root telemetry");
+      Expect(
+          storage_it->mount_point == temp_root.string(),
+          "storage-root telemetry should use configured storage root");
+      Expect(
+          storage_it->total_bytes > 0,
+          "storage-root telemetry should collect capacity for an existing non-mountpoint path");
+      const auto cpu_snapshot =
+          naim::DeserializeCpuTelemetryJson(observation.cpu_telemetry_json);
+      Expect(
+          cpu_snapshot.total_memory_bytes > 0,
+          "observation should include total memory bytes");
 
       fs::remove_all(temp_root, cleanup_error);
     }

--- a/hostd/src/cli/hostd_cli_request_resolution_support.cpp
+++ b/hostd/src/cli/hostd_cli_request_resolution_support.cpp
@@ -18,7 +18,7 @@ HostdCliCommonRequest HostdCliRequestResolutionSupport::ResolveCommonRequest(
   HostdCliCommonRequest request;
   const auto state_request = ResolveNodeStateRequest(command_line, node_name);
   request.node_name = state_request.node_name;
-  request.storage_root = node_config.storage_root;
+  request.storage_root = command_line.storage_root().value_or(node_config.storage_root);
   request.runtime_root = command_line.runtime_root();
   request.state_root = state_request.state_root;
   return request;

--- a/hostd/src/cli/hostd_cli_request_resolution_support_tests.cpp
+++ b/hostd/src/cli/hostd_cli_request_resolution_support_tests.cpp
@@ -142,6 +142,29 @@ int main() {
       std::cout << "ok: hostd-cli-request-resolution-assignment\n";
     }
 
+    {
+      char command[] = "report-observed-state";
+      char node_flag[] = "--node";
+      char node_value[] = "delta";
+      char storage_flag[] = "--storage-root";
+      char storage_value[] = "/tmp/naim-storage-override";
+      char* argv[] = {
+          command,
+          command,
+          node_flag,
+          node_value,
+          storage_flag,
+          storage_value,
+      };
+      const naim::hostd::HostdCommandLine command_line(6, argv);
+      const auto request =
+          support.ResolveAssignmentRequest(command_line, node_config, "delta");
+      Expect(
+          request.common.storage_root == "/tmp/naim-storage-override",
+          "explicit storage root should override node config");
+      std::cout << "ok: hostd-cli-request-resolution-storage-root-override\n";
+    }
+
     return 0;
   } catch (const std::exception& ex) {
     std::cerr << ex.what() << '\n';

--- a/hostd/src/cli/hostd_command_line.cpp
+++ b/hostd/src/cli/hostd_command_line.cpp
@@ -15,10 +15,10 @@ void HostdCommandLine::PrintUsage(std::ostream& out) const {
       << "  naim-hostd show-state-ops --node <node-name> [--db <path>] [--artifacts-root <path>] [--runtime-root <path>] [--state-root <path>] [--config <path>]\n"
       << "  naim-hostd show-local-state --node <node-name> [--state-root <path>]\n"
       << "  naim-hostd show-runtime-status --node <node-name> [--state-root <path>]\n"
-      << "  naim-hostd report-observed-state --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--state-root <path>]\n"
-      << "  naim-hostd report-telemetry --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--state-root <path>] [--watch diagnostic] [--interval-ms <ms>] [--ttl-ms <ms>]\n"
-      << "  naim-hostd apply-state-ops --node <node-name> [--db <path>] [--artifacts-root <path>] [--runtime-root <path>] [--state-root <path>] [--compose-mode skip|exec] [--config <path>]\n"
-      << "  naim-hostd apply-next-assignment --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--runtime-root <path>] [--state-root <path>] [--compose-mode skip|exec] [--config <path>]\n";
+      << "  naim-hostd report-observed-state --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--storage-root <path>] [--state-root <path>]\n"
+      << "  naim-hostd report-telemetry --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--storage-root <path>] [--state-root <path>] [--watch diagnostic] [--interval-ms <ms>] [--ttl-ms <ms>]\n"
+      << "  naim-hostd apply-state-ops --node <node-name> [--db <path>] [--artifacts-root <path>] [--storage-root <path>] [--runtime-root <path>] [--state-root <path>] [--compose-mode skip|exec] [--config <path>]\n"
+      << "  naim-hostd apply-next-assignment --node <node-name> [--db <path> | --controller <url>] [--host-private-key <path>] [--controller-fingerprint <sha256>] [--onboarding-key <token>] [--storage-root <path>] [--runtime-root <path>] [--state-root <path>] [--compose-mode skip|exec] [--config <path>]\n";
 }
 
 bool HostdCommandLine::HasCommand() const {
@@ -43,6 +43,10 @@ std::optional<std::string> HostdCommandLine::controller() const {
 
 std::optional<std::string> HostdCommandLine::artifacts_root() const {
   return FindOptionValue("--artifacts-root");
+}
+
+std::optional<std::string> HostdCommandLine::storage_root() const {
+  return FindOptionValue("--storage-root");
 }
 
 std::optional<std::string> HostdCommandLine::runtime_root() const {

--- a/launcher/include/config/generated_config_loader.h
+++ b/launcher/include/config/generated_config_loader.h
@@ -29,6 +29,7 @@ struct GeneratedHostdConfig {
   std::optional<std::string> transport_mode;
   std::optional<std::string> execution_mode;
   std::optional<std::string> listen_address;
+  std::optional<fs::path> storage_root;
   std::optional<fs::path> runtime_root;
   std::optional<fs::path> state_root;
   std::optional<std::string> compose_mode;

--- a/launcher/include/config/launcher_options.h
+++ b/launcher/include/config/launcher_options.h
@@ -31,6 +31,7 @@ struct HostdInstallOptions {
   std::string transport_mode = "out";
   std::string execution_mode = "mixed";
   std::string listen_address;
+  std::string storage_root = "/var/lib/naim/storage";
   std::string compose_mode = "exec";
   int inventory_scan_interval_sec = 3600;
 };
@@ -52,6 +53,7 @@ struct ControllerRunOptions {
   std::string node_name = "local-hostd";
   fs::path runtime_root;
   fs::path state_root;
+  std::string storage_root;
   int hostd_poll_interval_sec = 2;
 };
 

--- a/launcher/src/cli/launcher_command_line.cpp
+++ b/launcher/src/cli/launcher_command_line.cpp
@@ -46,9 +46,9 @@ void LauncherCommandLine::PrintUsage(std::ostream& out) const {
       << "  naim-node version\n"
       << "  naim-node doctor [controller|hostd]\n"
       << "  naim-node run controller [--db <path>] [--artifacts-root <path>] [--listen-host <host>] [--listen-port <port>] [--internal-listen-host <host>] [--skills-factory-listen-port <port>] [--with-hostd] [--with-web-ui] [--hostd-compose-mode exec|skip]\n"
-      << "  naim-node run hostd [--node <name>] [--db <path>] [--controller <url>] [--controller-fingerprint <sha256>] [--runtime-root <path>] [--state-root <path>] [--compose-mode exec|skip]\n"
-      << "  naim-node install controller [--with-hostd] [--with-web-ui] [--listen-host <host>] [--listen-port <port>] [--internal-listen-host <host>] [--config <path>] [--state-root <path>] [--log-root <path>] [--systemd-dir <path>] [--skip-systemctl]\n"
-      << "  naim-node install hostd [--node <name>] [--controller <url>] [--controller-fingerprint <sha256>] [--onboarding-key <key>] [--transport out|in|hybrid] [--listen <addr>] [--config <path>] [--state-root <path>] [--log-root <path>] [--systemd-dir <path>] [--skip-systemctl]\n"
+      << "  naim-node run hostd [--node <name>] [--db <path>] [--controller <url>] [--controller-fingerprint <sha256>] [--storage-root <path>] [--runtime-root <path>] [--state-root <path>] [--compose-mode exec|skip]\n"
+      << "  naim-node install controller [--with-hostd] [--with-web-ui] [--listen-host <host>] [--listen-port <port>] [--internal-listen-host <host>] [--storage-root <path>] [--config <path>] [--state-root <path>] [--log-root <path>] [--systemd-dir <path>] [--skip-systemctl]\n"
+      << "  naim-node install hostd [--node <name>] [--controller <url>] [--controller-fingerprint <sha256>] [--onboarding-key <key>] [--transport out|in|hybrid] [--listen <addr>] [--storage-root <path>] [--config <path>] [--state-root <path>] [--log-root <path>] [--systemd-dir <path>] [--skip-systemctl]\n"
       << "  naim-node service status|start|stop|restart|uninstall|verify <controller|hostd|controller-hostd> [--systemd-dir <path>] [--skip-systemctl]\n"
       << "  naim-node connect-hostd --db <path> --node <name> --public-key <base64-or-file> [--address <hostd-url>] [--transport out|in|hybrid] [--controller-fingerprint <sha256>]\n";
 }

--- a/launcher/src/config/generated_config_loader.cpp
+++ b/launcher/src/config/generated_config_loader.cpp
@@ -117,6 +117,8 @@ GeneratedConfig GeneratedConfigLoader::Load(const fs::path& path) const {
         config.hostd.execution_mode = UnquoteTomlValue(raw_value);
       } else if (key == "listen_address") {
         config.hostd.listen_address = UnquoteTomlValue(raw_value);
+      } else if (key == "storage_root") {
+        config.hostd.storage_root = fs::path(UnquoteTomlValue(raw_value));
       } else if (key == "runtime_root") {
         config.hostd.runtime_root = fs::path(UnquoteTomlValue(raw_value));
       } else if (key == "state_root") {

--- a/launcher/src/config/generated_config_loader_tests.cpp
+++ b/launcher/src/config/generated_config_loader_tests.cpp
@@ -1,0 +1,52 @@
+#include "config/generated_config_loader.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void Expect(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+}  // namespace
+
+int main() {
+  try {
+    namespace fs = std::filesystem;
+    const fs::path temp_path =
+        fs::temp_directory_path() / "naim-generated-config-loader-tests.toml";
+    {
+      std::ofstream output(temp_path);
+      output << "[hostd]\n";
+      output << "node_name = \"local-hostd\"\n";
+      output << "storage_root = \"/tmp/naim-storage-from-generated-config\"\n";
+      output << "runtime_root = \"/tmp/naim-runtime\"\n";
+      output << "state_root = \"/tmp/naim-state\"\n";
+    }
+
+    const naim::launcher::InstallLayoutResolver install_layout_resolver;
+    const naim::launcher::GeneratedConfigLoader loader(install_layout_resolver);
+    const auto config = loader.Load(temp_path);
+    Expect(
+        config.hostd.storage_root.has_value(),
+        "generated hostd config should expose storage_root");
+    Expect(
+        config.hostd.storage_root->string() ==
+            "/tmp/naim-storage-from-generated-config",
+        "generated hostd config should preserve storage_root");
+
+    std::error_code cleanup_error;
+    fs::remove(temp_path, cleanup_error);
+    std::cout << "generated config loader tests passed\n";
+    return 0;
+  } catch (const std::exception& error) {
+    std::cerr << error.what() << "\n";
+    return 1;
+  }
+}

--- a/launcher/src/install/launcher_install_service.cpp
+++ b/launcher/src/install/launcher_install_service.cpp
@@ -10,6 +10,8 @@
 #include <stdexcept>
 #include <vector>
 
+#include <nlohmann/json.hpp>
+
 #include "naim/core/platform_compat.h"
 #include "naim/security/crypto_utils.h"
 #include "naim/state/sqlite_store.h"
@@ -101,6 +103,8 @@ void LauncherInstallService::InstallController(
   options.node_name = command_line.FindFlagValue("--node").value_or(options.node_name);
   options.with_hostd = command_line.HasFlag("--with-hostd");
   options.with_web_ui = command_line.HasFlag("--with-web-ui");
+  const std::string storage_root =
+      command_line.FindFlagValue("--storage-root").value_or(HostdInstallOptions{}.storage_root);
   const bool skip_systemctl = command_line.HasFlag("--skip-systemctl");
 
   const auto keys_root = options.layout.state_root / "keys";
@@ -129,6 +133,7 @@ void LauncherInstallService::InstallController(
         "out",
         "mixed",
         "",
+        storage_root,
         options.compose_mode,
     };
   }
@@ -148,6 +153,7 @@ void LauncherInstallService::InstallController(
       host.execution_mode = "mixed";
       host.registration_state = "registered";
       host.session_state = "disconnected";
+      host.capabilities_json = nlohmann::json{{"storage_root", storage_root}}.dump();
       host.status_message = "prepared by naim-node install controller";
       store.UpsertRegisteredHost(host);
     }
@@ -181,6 +187,7 @@ void LauncherInstallService::InstallController(
                 "out",
                 "mixed",
                 "",
+                storage_root,
                 options.compose_mode,
             },
             options.layout.config_path));
@@ -224,6 +231,8 @@ void LauncherInstallService::InstallHostd(
   options.execution_mode =
       command_line.FindFlagValue("--execution-mode").value_or(options.execution_mode);
   options.listen_address = command_line.FindFlagValue("--listen").value_or("");
+  options.storage_root =
+      command_line.FindFlagValue("--storage-root").value_or(options.storage_root);
   options.compose_mode =
       command_line.FindFlagValue("--compose-mode").value_or(options.compose_mode);
   const bool skip_systemctl = command_line.HasFlag("--skip-systemctl");
@@ -382,6 +391,7 @@ std::string LauncherInstallService::RenderConfigToml(
     out << "transport_mode = \"" << hostd->transport_mode << "\"\n";
     out << "execution_mode = \"" << hostd->execution_mode << "\"\n";
     out << "listen_address = \"" << hostd->listen_address << "\"\n";
+    out << "storage_root = \"" << hostd->storage_root << "\"\n";
     out << "runtime_root = \"" << (hostd->layout.state_root / "runtime").string() << "\"\n";
     out << "state_root = \"" << (hostd->layout.state_root / "hostd-state").string() << "\"\n";
     out << "compose_mode = \"" << hostd->compose_mode << "\"\n";
@@ -456,6 +466,7 @@ std::string LauncherInstallService::RenderHostdUnit(
   out << "ExecStart=" << options.binary_path.string()
       << " run hostd"
       << " --node " << options.node_name
+      << " --storage-root " << options.storage_root
       << " --runtime-root " << (options.layout.state_root / "runtime").string()
       << " --state-root " << (options.layout.state_root / "hostd-state").string()
       << " --compose-mode " << options.compose_mode;

--- a/launcher/src/run/launcher_run_service.cpp
+++ b/launcher/src/run/launcher_run_service.cpp
@@ -403,6 +403,11 @@ int LauncherRunService::RunController(
           .value_or(loaded_config && loaded_config->hostd.state_root.has_value()
                         ? loaded_config->hostd.state_root->string()
                         : install_layout_resolver_.DefaultHostdStateRoot().string());
+  options.storage_root =
+      command_line.FindFlagValue("--storage-root")
+          .value_or(loaded_config && loaded_config->hostd.storage_root.has_value()
+                        ? loaded_config->hostd.storage_root->string()
+                        : HostdInstallOptions{}.storage_root);
 
   const bool config_local_hostd_enabled =
       loaded_config && loaded_config->controller.local_hostd_enabled.value_or(false);
@@ -451,6 +456,7 @@ int LauncherRunService::RunController(
       install_args.insert(
           install_args.end(), {"--compose-mode", options.hostd_compose_mode});
       install_args.insert(install_args.end(), {"--node", options.node_name});
+      install_args.insert(install_args.end(), {"--storage-root", options.storage_root});
       if (options.with_hostd) {
         install_args.push_back("--with-hostd");
       }
@@ -516,7 +522,10 @@ int LauncherRunService::RunHostd(
                         ? loaded_config->hostd.state_root->string()
                         : install_layout_resolver_.DefaultHostdStateRoot().string());
   options.storage_root =
-      LoadStorageRootFromNodeConfig(command_line.FindFlagValue("--config"));
+      command_line.FindFlagValue("--storage-root")
+          .value_or(loaded_config && loaded_config->hostd.storage_root.has_value()
+                        ? loaded_config->hostd.storage_root->string()
+                        : LoadStorageRootFromNodeConfig(std::nullopt));
   options.host_private_key_path =
       command_line.FindFlagValue("--host-private-key")
           .value_or(loaded_config && loaded_config->hostd.host_private_key.has_value()
@@ -560,6 +569,7 @@ int LauncherRunService::RunHostd(
           install_args.end(), {"--controller-fingerprint", options.controller_fingerprint});
     }
     install_args.insert(install_args.end(), {"--node", options.node_name});
+    install_args.insert(install_args.end(), {"--storage-root", options.storage_root});
     install_args.insert(install_args.end(), {"--compose-mode", options.compose_mode});
     install_service_.InstallHostd(self_path, LauncherCommandLine(std::move(install_args)));
     std::cout << "service_mode=systemd\n";
@@ -591,6 +601,8 @@ int LauncherRunService::RunHostdLoop(
   constexpr int kTelemetryIntervalMs = 2000;
   constexpr int kTelemetryTtlMs = 10000;
   constexpr std::chrono::milliseconds kApplySessionHandoffGap(1500);
+  constexpr std::chrono::seconds kInventoryRetryWhenApplyActive(5);
+  constexpr std::chrono::seconds kInventoryRetryAfterFailure(10);
   auto next_inventory_report_at = std::chrono::steady_clock::now();
 #if defined(_WIN32)
   auto next_telemetry_report_at = std::chrono::steady_clock::now();
@@ -611,6 +623,8 @@ int LauncherRunService::RunHostdLoop(
         "apply-next-assignment",
         "--node",
         options.node_name,
+        "--storage-root",
+        options.storage_root,
         "--runtime-root",
         options.runtime_root.string(),
         "--state-root",
@@ -641,6 +655,8 @@ int LauncherRunService::RunHostdLoop(
         "report-observed-state",
         "--node",
         options.node_name,
+        "--storage-root",
+        options.storage_root,
         "--state-root",
         options.state_root.string(),
     };
@@ -670,6 +686,8 @@ int LauncherRunService::RunHostdLoop(
         "report-telemetry",
         "--node",
         options.node_name,
+        "--storage-root",
+        options.storage_root,
         "--state-root",
         options.state_root.string(),
         "--interval-ms",
@@ -704,13 +722,14 @@ int LauncherRunService::RunHostdLoop(
       return;
     }
     if (!options.controller_url.empty() && apply_session_owner_active.load()) {
-      next_inventory_report_at =
-          now + std::chrono::seconds(std::max(1, options.inventory_scan_interval_sec));
+      next_inventory_report_at = now + kInventoryRetryWhenApplyActive;
       return;
     }
     const int report_code = process_runner_.RunCommand(build_report_args());
     if (report_code != 0) {
       std::cerr << "naim-node: hostd report-observed-state exit=" << report_code << "\n";
+      next_inventory_report_at = now + kInventoryRetryAfterFailure;
+      return;
     }
     next_inventory_report_at =
         now + std::chrono::seconds(std::max(1, options.inventory_scan_interval_sec));
@@ -928,6 +947,7 @@ int LauncherRunService::RunHostdLoop(
       return wait_for_self_update_recreate();
     }
     if (apply_pid <= 0 && std::chrono::steady_clock::now() >= next_apply_spawn_at) {
+      run_report_if_due();
       apply_session_owner_active.store(true);
       const auto wait_until =
           std::chrono::steady_clock::now() + kApplySessionHandoffGap;
@@ -1107,12 +1127,14 @@ int LauncherRunService::RunControllerSupervisor(
     host.execution_mode = "mixed";
     host.registration_state = "registered";
     host.session_state = "disconnected";
+    host.capabilities_json = nlohmann::json{{"storage_root", options.storage_root}}.dump();
     host.status_message = "auto-registered local hostd by naim-node run controller";
     store.UpsertRegisteredHost(host);
 
     hostd_pid = static_cast<pid_t>(process_runner_.SpawnCommand({
         self_path.string(), "run", "hostd", "--controller", local_controller_url,
         "--controller-fingerprint", controller_fingerprint, "--node", options.node_name,
+        "--storage-root", options.storage_root,
         "--runtime-root", options.runtime_root.string(), "--state-root",
         options.state_root.string(), "--host-private-key",
         (options.state_root.parent_path() / "keys" / "hostd.key.b64").string(),

--- a/scripts/install-single-node.sh
+++ b/scripts/install-single-node.sh
@@ -339,6 +339,7 @@ install_args=(
   --with-hostd
   --listen-port "${listen_port}"
   --node "${node_name}"
+  --storage-root "${storage_root}"
 )
 if [[ "${with_web_ui}" == "yes" ]]; then
   install_args+=(--with-web-ui)


### PR DESCRIPTION
## Summary
- preserve slow disk telemetry when fast telemetry frames omit disk payloads
- thread storage_root through naim-node/hostd install and run flows
- persist generated hostd storage_root config and add targeted tests

## Local tests
- ./build/codex-hostd-telemetry/naim-telemetry-live-store-tests
- ./build/codex-hostd-telemetry/naim-generated-config-loader-tests
- ./build/codex-hostd-telemetry/naim-hostd-reporting-support-tests
- ./build/codex-hostd-telemetry/naim-hostd-cli-request-resolution-support-tests