### PR TITLE
Add Knowledge Vault delete and cleanup routes

### DIFF
--- a/controller/src/http/controller_http_router.cpp
+++ b/controller/src/http/controller_http_router.cpp
@@ -1,6 +1,7 @@
 #include "http/controller_http_router.h"
 
 #include <cctype>
+#include <string_view>
 
 #include "infra/controller_action.h"
 #include "http/controller_http_server_support.h"
@@ -127,10 +128,21 @@ int InteractionErrorStatusCode(const InteractionValidationError& error) {
 }  // namespace
 
 bool ControllerHttpRouter::IsKnowledgeVaultRequest(const std::string& path) {
-  return path == "/api/v1/knowledge-vault/status" ||
-         ControllerHttpServerSupport::StartsWithPath(
-             path,
-             "/api/v1/knowledge-vault/");
+  if (path == "/api/v1/knowledge-vault/status" ||
+      ControllerHttpServerSupport::StartsWithPath(path, "/api/v1/knowledge-vault/")) {
+    return true;
+  }
+  constexpr std::string_view kPlanePrefix = "/api/v1/planes/";
+  constexpr std::string_view kPlaneKnowledgeSegment = "/knowledge-vault";
+  if (!ControllerHttpServerSupport::StartsWithPath(path, std::string(kPlanePrefix))) {
+    return false;
+  }
+  const auto segment = path.find(std::string(kPlaneKnowledgeSegment), kPlanePrefix.size());
+  if (segment == std::string::npos) {
+    return false;
+  }
+  const auto end = segment + kPlaneKnowledgeSegment.size();
+  return end == path.size() || path[end] == '/';
 }
 
 ControllerHttpRouter::ControllerHttpRouter(

--- a/controller/src/knowledge/knowledge_vault_http_service.cpp
+++ b/controller/src/knowledge/knowledge_vault_http_service.cpp
@@ -16,9 +16,13 @@ bool IsPlaneScopedKnowledgeRoute(const std::string& path) {
          suffix == "context" ||
          suffix == "query-route" ||
          suffix == "source-ingest" ||
+         suffix == "cleanup" ||
          suffix == "graph-neighborhood" ||
          suffix == "overlays" ||
          suffix == "markdown-import" ||
+         suffix.rfind("blocks/", 0) == 0 ||
+         suffix.rfind("relations/", 0) == 0 ||
+         suffix.rfind("sources/", 0) == 0 ||
          suffix.rfind("replica-merges", 0) == 0;
 }
 
@@ -77,6 +81,8 @@ std::optional<HttpResponse> KnowledgeVaultHttpService::HandleRequest(
         suffix.rfind("/replica-merges", 0) == 0 ||
         suffix.rfind("/reviews", 0) == 0 ||
         suffix.rfind("/repair", 0) == 0 ||
+        suffix.rfind("/cleanup", 0) == 0 ||
+        suffix.rfind("/sources", 0) == 0 ||
         suffix.rfind("/jobs", 0) == 0 ||
         suffix.rfind("/markdown-export", 0) == 0 ||
         suffix.rfind("/markdown-import", 0) == 0 ||
@@ -121,7 +127,8 @@ HttpRequest KnowledgeVaultHttpService::BuildPlaneScopedRequest(
   const std::string suffix = remainder.substr(separator);
   rewritten.path = "/api/v1" + suffix;
 
-  if (request.method != "POST" || !IsPlaneScopedKnowledgeRoute(rewritten.path)) {
+  const bool scoped_method = request.method == "POST" || request.method == "DELETE";
+  if (!scoped_method || !IsPlaneScopedKnowledgeRoute(rewritten.path)) {
     return rewritten;
   }
 

--- a/controller/src/knowledge/knowledge_vault_service_tests.cpp
+++ b/controller/src/knowledge/knowledge_vault_service_tests.cpp
@@ -273,6 +273,34 @@ void TestPlaneScopedMutationRequestsCarryProtectedPlane() {
       "protected plane replica merge should carry protected_plane flag");
 }
 
+void TestPlaneScopedDeleteRequestsCarryProtectedPlane() {
+  HttpRequest delete_request;
+  delete_request.method = "DELETE";
+  delete_request.path = "/api/v1/planes/knowledge-plane/knowledge-vault/blocks/blk-test";
+  delete_request.headers["Content-Type"] = "application/json";
+  delete_request.body = R"({"reason":"operator cleanup"})";
+
+  const auto rewritten =
+      naim::controller::KnowledgeVaultHttpService::BuildPlaneScopedRequest(
+          delete_request,
+          BuildProtectedKnowledgePlaneState(),
+          "knowledge-plane");
+  const auto body = nlohmann::json::parse(rewritten.body);
+
+  Expect(
+      rewritten.path == "/api/v1/knowledge-vault/blocks/blk-test",
+      "plane delete path should rewrite to canonical knowledge route");
+  Expect(
+      body.value("plane_id", std::string{}) == "knowledge-plane",
+      "plane delete should include plane id");
+  Expect(
+      body.value("protected_plane", false),
+      "protected plane delete should carry protected_plane flag");
+  Expect(
+      body.value("reason", std::string{}) == "operator cleanup",
+      "delete reason should be preserved");
+}
+
 }  // namespace
 
 int main() {
@@ -283,5 +311,6 @@ int main() {
   TestPlaneScopedGraphRequestDefaultsToSelectedKnowledge();
   TestPlaneScopedSearchRequestKeepsExplicitBody();
   TestPlaneScopedMutationRequestsCarryProtectedPlane();
+  TestPlaneScopedDeleteRequestsCarryProtectedPlane();
   return 0;
 }

--- a/runtime/knowledge/include/knowledge/knowledge_server.h
+++ b/runtime/knowledge/include/knowledge/knowledge_server.h
@@ -51,6 +51,7 @@ class KnowledgeServer final {
   HttpResponse HandleGet(const HttpRequest& request);
   HttpResponse HandlePost(const HttpRequest& request);
   HttpResponse HandlePut(const HttpRequest& request);
+  HttpResponse HandleDelete(const HttpRequest& request);
   std::vector<std::string> SplitPath(const std::string& path) const;
   static nlohmann::json ParseJsonBody(const HttpRequest& request);
   HttpResponse BuildJsonResponse(int status_code, const nlohmann::json& payload) const;

--- a/runtime/knowledge/include/knowledge/knowledge_store.h
+++ b/runtime/knowledge/include/knowledge/knowledge_store.h
@@ -28,6 +28,10 @@ class KnowledgeStore final {
   nlohmann::json ResolveHead(const std::string& knowledge_id) const;
   nlohmann::json UpdateHead(const std::string& knowledge_id, const nlohmann::json& payload);
   nlohmann::json WriteRelation(const nlohmann::json& payload);
+  nlohmann::json DeleteBlock(const std::string& block_id, const nlohmann::json& payload);
+  nlohmann::json DeleteRelation(const std::string& relation_id, const nlohmann::json& payload);
+  nlohmann::json DeleteSource(const std::string& source_ref, const nlohmann::json& payload);
+  nlohmann::json Cleanup(const nlohmann::json& payload);
   nlohmann::json Neighbors(const std::string& block_id) const;
   nlohmann::json Search(const nlohmann::json& payload) const;
   nlohmann::json Context(const nlohmann::json& payload) const;

--- a/runtime/knowledge/src/knowledge_server.cpp
+++ b/runtime/knowledge/src/knowledge_server.cpp
@@ -147,6 +147,9 @@ HttpResponse KnowledgeServer::HandleRequest(const HttpRequest& request) {
   if (request.method == "PUT") {
     return HandlePut(request);
   }
+  if (request.method == "DELETE") {
+    return HandleDelete(request);
+  }
   throw ApiError(405, "method_not_allowed", "method not allowed");
 }
 
@@ -248,6 +251,9 @@ HttpResponse KnowledgeServer::HandlePost(const HttpRequest& request) {
   if (parts.size() == 2 && parts[0] == "v1" && parts[1] == "repair") {
     return BuildJsonResponse(200, store_.RunRepair(ParseJsonBody(request)));
   }
+  if (parts.size() == 2 && parts[0] == "v1" && parts[1] == "cleanup") {
+    return BuildJsonResponse(200, store_.Cleanup(ParseJsonBody(request)));
+  }
   if (parts.size() == 2 && parts[0] == "v1" && parts[1] == "markdown-export") {
     return BuildJsonResponse(200, store_.MarkdownExport(ParseJsonBody(request)));
   }
@@ -270,6 +276,32 @@ HttpResponse KnowledgeServer::HandlePut(const HttpRequest& request) {
   }
   if (parts.size() == 3 && parts[0] == "v1" && parts[1] == "reviews") {
     const auto result = store_.DecideReviewItem(parts[2], ParseJsonBody(request));
+    if (result.contains("error")) {
+      throw ApiError(404, result.value("error", "not_found"), result.value("message", "not found"));
+    }
+    return BuildJsonResponse(200, result);
+  }
+  throw ApiError(404, "not_found", "route not found");
+}
+
+HttpResponse KnowledgeServer::HandleDelete(const HttpRequest& request) {
+  const auto parts = SplitPath(request.path);
+  if (parts.size() == 3 && parts[0] == "v1" && parts[1] == "blocks") {
+    const auto result = store_.DeleteBlock(parts[2], ParseJsonBody(request));
+    if (result.contains("error")) {
+      throw ApiError(404, result.value("error", "not_found"), result.value("message", "not found"));
+    }
+    return BuildJsonResponse(200, result);
+  }
+  if (parts.size() == 3 && parts[0] == "v1" && parts[1] == "relations") {
+    const auto result = store_.DeleteRelation(parts[2], ParseJsonBody(request));
+    if (result.contains("error")) {
+      throw ApiError(404, result.value("error", "not_found"), result.value("message", "not found"));
+    }
+    return BuildJsonResponse(200, result);
+  }
+  if (parts.size() == 3 && parts[0] == "v1" && parts[1] == "sources") {
+    const auto result = store_.DeleteSource(parts[2], ParseJsonBody(request));
     if (result.contains("error")) {
       throw ApiError(404, result.value("error", "not_found"), result.value("message", "not found"));
     }

--- a/runtime/knowledge/src/knowledge_store.cpp
+++ b/runtime/knowledge/src/knowledge_store.cpp
@@ -25,6 +25,17 @@ bool StringSetContains(const std::set<std::string>& values, const std::string& v
   return values.empty() || values.find(value) != values.end();
 }
 
+bool IsDeletedRecord(const nlohmann::json& value) {
+  return value.value("deleted", false) ||
+         value.value("status", std::string{}) == "deleted" ||
+         value.value("tombstone", false);
+}
+
+bool KeyEndsWith(const std::string& key, const std::string& suffix) {
+  return key.size() >= suffix.size() &&
+         key.compare(key.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
 std::string BlockSearchText(const nlohmann::json& block) {
   return KnowledgeTextProcessor::Lowercase(
       block.value("title", std::string{}) + "\n" +
@@ -155,11 +166,22 @@ nlohmann::json KnowledgeStore::ReadBlock(const std::string& block_id) const {
   if (!block.has_value()) {
     return nlohmann::json{{"error", "not_found"}, {"message", "block not found"}};
   }
+  if (IsDeletedRecord(*block)) {
+    return nlohmann::json{{"status", "deleted"}, {"block", *block}};
+  }
   return nlohmann::json{{"block", *block}};
 }
 
 nlohmann::json KnowledgeStore::ResolveHead(const std::string& knowledge_id) const {
   const auto head = repository_->GetJson("heads:" + knowledge_id);
+  if (head.has_value()) {
+    const std::string block_id = head->value("head_block_id", std::string{});
+    const auto block = block_id.empty() ? std::optional<nlohmann::json>{}
+                                        : repository_->GetJson("blocks:" + block_id);
+    if (!block.has_value() || IsDeletedRecord(*block)) {
+      return nlohmann::json{{"head", nullptr}};
+    }
+  }
   return nlohmann::json{{"head", head.has_value() ? *head : nlohmann::json(nullptr)}};
 }
 
@@ -171,7 +193,8 @@ nlohmann::json KnowledgeStore::UpdateHead(
     throw std::runtime_error("head_block_id is required");
   }
   const auto block_payload = ReadBlock(head_block_id);
-  if (block_payload.contains("error")) {
+  if (block_payload.contains("error") ||
+      block_payload.value("status", std::string{}) == "deleted") {
     throw std::runtime_error("head block does not exist");
   }
   const auto block = block_payload.at("block");
@@ -224,16 +247,304 @@ nlohmann::json KnowledgeStore::WriteRelation(const nlohmann::json& payload) {
   return nlohmann::json{{"relation", relation_json}, {"event_sequence", sequence}};
 }
 
+nlohmann::json KnowledgeStore::DeleteRelation(
+    const std::string& relation_id,
+    const nlohmann::json& payload) {
+  if (relation_id.empty()) {
+    throw std::runtime_error("relation_id is required");
+  }
+
+  nlohmann::json deleted = nlohmann::json::array();
+  rocksdb::WriteBatch batch;
+  for (const auto& [key, relation] : repository_->ScanJson("edges_out:")) {
+    if (relation.value("relation_id", std::string{}) != relation_id) {
+      continue;
+    }
+    batch.Delete(key);
+    const std::string from = relation.value("from_block_id", std::string{});
+    const std::string to = relation.value("to_block_id", std::string{});
+    const std::string type = relation.value("type", std::string{});
+    batch.Delete("edges_in:" + to + ":" + type + ":" + from + ":" + relation_id);
+    auto tombstone = relation;
+    tombstone["deleted"] = true;
+    tombstone["deleted_at"] = UtcNow();
+    tombstone["deleted_by"] = payload.value("deleted_by", std::string("naim-knowledged"));
+    tombstone["delete_reason"] = payload.value("reason", std::string{});
+    batch.Put("tombstones:relations:" + relation_id, tombstone.dump());
+    deleted.push_back(tombstone);
+  }
+
+  if (deleted.empty()) {
+    return nlohmann::json{{"error", "not_found"}, {"message", "relation not found"}};
+  }
+
+  repository_->Write(batch, "delete knowledge relation");
+  const int sequence = AppendEvent(
+      "relation.deleted",
+      {},
+      {},
+      nlohmann::json{{"relation_id", relation_id}, {"reason", payload.value("reason", std::string{})}});
+  return nlohmann::json{
+      {"status", "deleted"},
+      {"relation_id", relation_id},
+      {"relations", deleted},
+      {"event_sequence", sequence},
+  };
+}
+
+nlohmann::json KnowledgeStore::DeleteBlock(
+    const std::string& block_id,
+    const nlohmann::json& payload) {
+  const auto current = repository_->GetJson("blocks:" + block_id);
+  if (!current.has_value()) {
+    return nlohmann::json{{"error", "not_found"}, {"message", "block not found"}};
+  }
+
+  auto block = *current;
+  const std::string knowledge_id = block.value("knowledge_id", std::string{});
+  block["deleted"] = true;
+  block["status"] = "deleted";
+  block["deleted_at"] = UtcNow();
+  block["deleted_by"] = payload.value("deleted_by", std::string("naim-knowledged"));
+  block["delete_reason"] = payload.value("reason", std::string{});
+
+  rocksdb::WriteBatch batch;
+  batch.Put("blocks:" + block_id, block.dump());
+  batch.Put("tombstones:blocks:" + block_id, block.dump());
+  for (const auto& [key, value] : repository_->ScanRaw("terms:")) {
+    if (KeyEndsWith(key, ":" + block_id)) {
+      batch.Delete(key);
+    }
+  }
+  for (const auto& [key, value] : repository_->ScanRaw("acl:")) {
+    if (KeyEndsWith(key, ":" + block_id)) {
+      batch.Delete(key);
+    }
+  }
+  for (const auto& [key, relation] : repository_->ScanJson("edges_out:")) {
+    const std::string from = relation.value("from_block_id", std::string{});
+    const std::string to = relation.value("to_block_id", std::string{});
+    if (from != block_id && to != block_id) {
+      continue;
+    }
+    const std::string type = relation.value("type", std::string{});
+    const std::string relation_id = relation.value("relation_id", std::string{});
+    batch.Delete(key);
+    batch.Delete("edges_in:" + to + ":" + type + ":" + from + ":" + relation_id);
+    auto tombstone = relation;
+    tombstone["deleted"] = true;
+    tombstone["deleted_at"] = block["deleted_at"];
+    tombstone["deleted_by"] = block["deleted_by"];
+    tombstone["delete_reason"] = "endpoint block deleted";
+    batch.Put("tombstones:relations:" + relation_id, tombstone.dump());
+  }
+  for (const auto& [key, head] : repository_->ScanJson("heads:")) {
+    if (head.value("head_block_id", std::string{}) == block_id ||
+        head.value("knowledge_id", std::string{}) == knowledge_id) {
+      batch.Delete(key);
+    }
+  }
+  repository_->Write(batch, "delete knowledge block");
+  const int sequence = AppendEvent(
+      "block.deleted",
+      knowledge_id.empty() ? std::vector<std::string>{} : std::vector<std::string>{knowledge_id},
+      {block_id},
+      nlohmann::json{{"block_id", block_id}, {"knowledge_id", knowledge_id}, {"reason", payload.value("reason", std::string{})}});
+  return nlohmann::json{
+      {"status", "deleted"},
+      {"block_id", block_id},
+      {"knowledge_id", knowledge_id},
+      {"event_sequence", sequence},
+  };
+}
+
+nlohmann::json KnowledgeStore::DeleteSource(
+    const std::string& source_ref,
+    const nlohmann::json& payload) {
+  if (source_ref.empty()) {
+    throw std::runtime_error("source id is required");
+  }
+
+  std::optional<std::string> source_key;
+  std::optional<nlohmann::json> source_record;
+  for (const auto& [key, value] : repository_->ScanJson("sources:")) {
+    if (key == "sources:" + source_ref ||
+        value.value("source_key", std::string{}) == source_ref ||
+        value.value("block_id", std::string{}) == source_ref ||
+        value.value("source_ref", std::string{}) == source_ref) {
+      source_key = value.value("source_key", key.substr(std::string("sources:").size()));
+      source_record = value;
+      break;
+    }
+  }
+  if (!source_key.has_value() || !source_record.has_value()) {
+    return nlohmann::json{{"error", "not_found"}, {"message", "source not found"}};
+  }
+
+  const std::string block_id = source_record->value("block_id", std::string{});
+  auto block_result = block_id.empty()
+                          ? nlohmann::json{{"status", "not_applicable"}}
+                          : DeleteBlock(block_id, payload);
+
+  rocksdb::WriteBatch batch;
+  batch.Delete("sources:" + *source_key);
+  for (const auto& [key, value] : repository_->ScanRaw("source_hash:")) {
+    if (key.find(":" + *source_key) != std::string::npos) {
+      batch.Delete(key);
+    }
+  }
+  for (const auto& [key, chunk] : repository_->ScanJson("source_chunks:")) {
+    if (chunk.value("source_key", std::string{}) == *source_key ||
+        chunk.value("block_id", std::string{}) == block_id) {
+      batch.Delete(key);
+    }
+  }
+  for (const auto& [key, claim] : repository_->ScanJson("source_claims:")) {
+    if (claim.value("source_key", std::string{}) == *source_key ||
+        claim.value("block_id", std::string{}) == block_id) {
+      batch.Delete(key);
+    }
+  }
+  auto tombstone = *source_record;
+  tombstone["deleted"] = true;
+  tombstone["deleted_at"] = UtcNow();
+  tombstone["deleted_by"] = payload.value("deleted_by", std::string("naim-knowledged"));
+  tombstone["delete_reason"] = payload.value("reason", std::string{});
+  batch.Put("tombstones:sources:" + *source_key, tombstone.dump());
+  repository_->Write(batch, "delete knowledge source");
+  const int sequence = AppendEvent(
+      "source.deleted",
+      {},
+      block_id.empty() ? std::vector<std::string>{} : std::vector<std::string>{block_id},
+      nlohmann::json{{"source_key", *source_key}, {"block_id", block_id}, {"reason", payload.value("reason", std::string{})}});
+  return nlohmann::json{
+      {"status", "deleted"},
+      {"source_key", *source_key},
+      {"source_block_id", block_id},
+      {"block_delete", block_result},
+      {"event_sequence", sequence},
+  };
+}
+
+nlohmann::json KnowledgeStore::Cleanup(const nlohmann::json& payload) {
+  const bool apply = payload.value("apply", true);
+  int purged_blocks = 0;
+  int purged_relations = 0;
+  int purged_sources = 0;
+  int purged_index_keys = 0;
+  rocksdb::WriteBatch batch;
+
+  for (const auto& [key, block] : repository_->ScanJson("blocks:")) {
+    if (!IsDeletedRecord(block)) {
+      continue;
+    }
+    const std::string block_id = block.value("block_id", key.substr(std::string("blocks:").size()));
+    if (apply) {
+      batch.Delete(key);
+    }
+    ++purged_blocks;
+    for (const auto& [index_key, value] : repository_->ScanRaw("terms:")) {
+      if (KeyEndsWith(index_key, ":" + block_id)) {
+        if (apply) {
+          batch.Delete(index_key);
+        }
+        ++purged_index_keys;
+      }
+    }
+    for (const auto& [acl_key, value] : repository_->ScanRaw("acl:")) {
+      if (KeyEndsWith(acl_key, ":" + block_id)) {
+        if (apply) {
+          batch.Delete(acl_key);
+        }
+        ++purged_index_keys;
+      }
+    }
+    for (const auto& [head_key, head] : repository_->ScanJson("heads:")) {
+      if (head.value("head_block_id", std::string{}) == block_id) {
+        if (apply) {
+          batch.Delete(head_key);
+        }
+        ++purged_index_keys;
+      }
+    }
+  }
+
+  for (const auto& [key, source] : repository_->ScanJson("tombstones:sources:")) {
+    const std::string source_key = source.value("source_key", key.substr(std::string("tombstones:sources:").size()));
+    if (apply) {
+      batch.Delete("sources:" + source_key);
+    }
+    ++purged_sources;
+    for (const auto& [hash_key, value] : repository_->ScanRaw("source_hash:")) {
+      if (hash_key.find(":" + source_key) != std::string::npos) {
+        if (apply) {
+          batch.Delete(hash_key);
+        }
+        ++purged_index_keys;
+      }
+    }
+  }
+
+  for (const auto& [key, relation] : repository_->ScanJson("tombstones:relations:")) {
+    const std::string relation_id = relation.value("relation_id", key.substr(std::string("tombstones:relations:").size()));
+    const std::string from = relation.value("from_block_id", std::string{});
+    const std::string to = relation.value("to_block_id", std::string{});
+    const std::string type = relation.value("type", std::string{});
+    if (apply) {
+      batch.Delete("edges_out:" + from + ":" + type + ":" + to + ":" + relation_id);
+      batch.Delete("edges_in:" + to + ":" + type + ":" + from + ":" + relation_id);
+    }
+    ++purged_relations;
+  }
+
+  if (apply) {
+    repository_->Write(batch, "cleanup knowledge vault tombstones");
+  }
+  const int sequence = AppendEvent(
+      "cleanup.completed",
+      {},
+      {},
+      nlohmann::json{
+          {"apply", apply},
+          {"purged_blocks", purged_blocks},
+          {"purged_relations", purged_relations},
+          {"purged_sources", purged_sources},
+          {"purged_index_keys", purged_index_keys},
+      });
+  return nlohmann::json{
+      {"status", apply ? "completed" : "planned"},
+      {"purged_blocks", purged_blocks},
+      {"purged_relations", purged_relations},
+      {"purged_sources", purged_sources},
+      {"purged_index_keys", purged_index_keys},
+      {"event_sequence", sequence},
+  };
+}
+
 nlohmann::json KnowledgeStore::Neighbors(const std::string& block_id) const {
   nlohmann::json items = nlohmann::json::array();
   std::set<std::string> seen;
   for (const auto& [key, value] : repository_->ScanJson("edges_out:" + block_id + ":")) {
+    if (IsDeletedRecord(value)) {
+      continue;
+    }
+    const auto to = repository_->GetJson("blocks:" + value.value("to_block_id", std::string{}));
+    if (!to.has_value() || IsDeletedRecord(*to)) {
+      continue;
+    }
     const std::string relation_id = value.value("relation_id", key);
     if (seen.insert(relation_id).second) {
       items.push_back(value);
     }
   }
   for (const auto& [key, value] : repository_->ScanJson("edges_in:" + block_id + ":")) {
+    if (IsDeletedRecord(value)) {
+      continue;
+    }
+    const auto from = repository_->GetJson("blocks:" + value.value("from_block_id", std::string{}));
+    if (!from.has_value() || IsDeletedRecord(*from)) {
+      continue;
+    }
     const std::string relation_id = value.value("relation_id", key);
     if (seen.insert(relation_id).second) {
       items.push_back(value);
@@ -267,6 +578,9 @@ nlohmann::json KnowledgeStore::Search(const nlohmann::json& payload) const {
   const auto query_terms = QueryTerms(query);
   std::vector<std::pair<int, nlohmann::json>> scored_results;
   for (const auto& [key, block] : repository_->ScanJson("blocks:")) {
+    if (IsDeletedRecord(block)) {
+      continue;
+    }
     const std::string knowledge_id = block.value("knowledge_id", std::string{});
     if (!StringSetContains(selected_filter, knowledge_id)) {
       continue;
@@ -283,7 +597,7 @@ nlohmann::json KnowledgeStore::Search(const nlohmann::json& payload) const {
       const std::string neighbor_id =
           from == block.value("block_id", std::string{}) ? to : from;
       const auto neighbor = repository_->GetJson("blocks:" + neighbor_id);
-      if (neighbor.has_value()) {
+      if (neighbor.has_value() && !IsDeletedRecord(*neighbor)) {
         score += TokenSearchScore(lowered_query, query_terms, BlockSearchText(*neighbor), 3);
       }
     }
@@ -1058,6 +1372,9 @@ nlohmann::json KnowledgeStore::RunRepair(const nlohmann::json& payload) {
     }
   }
   for (const auto& [key, block] : repository_->ScanJson("blocks:")) {
+    if (IsDeletedRecord(block)) {
+      continue;
+    }
     const std::string block_id = block.value("block_id", std::string{});
     if (block_id.empty()) {
       continue;
@@ -1158,10 +1475,16 @@ nlohmann::json KnowledgeStore::MarkdownExport(const nlohmann::json& payload) con
   nlohmann::json warnings = nlohmann::json::array();
   std::map<std::string, std::string> titles;
   for (const auto& [key, block] : repository_->ScanJson("blocks:")) {
+    if (IsDeletedRecord(block)) {
+      continue;
+    }
     titles[block.value("block_id", std::string{})] =
         block.value("title", block.value("knowledge_id", std::string{}));
   }
   for (const auto& [key, block] : repository_->ScanJson("blocks:")) {
+    if (IsDeletedRecord(block)) {
+      continue;
+    }
     const auto scope_ids = block.value("scope_ids", nlohmann::json::array());
     if (!ScopeAllowed(scope_ids, requested_scopes)) {
       warnings.push_back(nlohmann::json{
@@ -1351,6 +1674,9 @@ nlohmann::json KnowledgeStore::GraphNeighborhood(const nlohmann::json& payload) 
       }
     }
     for (const auto& [key, block] : repository_->ScanJson("blocks:")) {
+      if (IsDeletedRecord(block)) {
+        continue;
+      }
       if (block.value("knowledge_id", std::string{}) == knowledge_id) {
         const std::string block_id = block.value("block_id", std::string{});
         if (!block_id.empty()) {
@@ -1371,7 +1697,7 @@ nlohmann::json KnowledgeStore::GraphNeighborhood(const nlohmann::json& payload) 
         continue;
       }
       const auto block = ReadBlock(block_id);
-      if (!block.contains("error")) {
+      if (!block.contains("error") && block.value("status", std::string{}) != "deleted") {
         nodes.push_back(block.value("block", nlohmann::json::object()));
       }
       const auto neighbors = Neighbors(block_id).value("neighbors", nlohmann::json::array());

--- a/runtime/knowledge/src/knowledge_store_tests.cpp
+++ b/runtime/knowledge/src/knowledge_store_tests.cpp
@@ -208,6 +208,50 @@ int main() {
   });
   Expect(!context.value("context", nlohmann::json::array()).empty(), "context should return bundle");
 
+  const std::string source_block_id = ingest.value("source_block_id", std::string{});
+  const auto linked = store.WriteBlock(nlohmann::json{
+      {"block_id", "delete-linked-block"},
+      {"knowledge_id", "knowledge.delete-linked"},
+      {"title", "Delete Linked Block"},
+      {"body", "A linked block used to verify relation cleanup."},
+      {"scope_ids", nlohmann::json::array({"scope.default"})},
+  });
+  (void)linked;
+  const auto relation = store.WriteRelation(nlohmann::json{
+      {"relation_id", "rel-delete-test"},
+      {"from_block_id", source_block_id},
+      {"to_block_id", "delete-linked-block"},
+      {"type", "related"},
+  });
+  Expect(relation.at("relation").value("relation_id", std::string{}) == "rel-delete-test", "relation should be written");
+  Expect(
+      !store.Neighbors(source_block_id).value("neighbors", nlohmann::json::array()).empty(),
+      "relation should be visible before delete");
+  const auto relation_delete = store.DeleteRelation("rel-delete-test", nlohmann::json{{"reason", "test relation cleanup"}});
+  Expect(relation_delete.value("status", std::string{}) == "deleted", "relation delete should succeed");
+  Expect(
+      store.Neighbors(source_block_id).value("neighbors", nlohmann::json::array()).empty(),
+      "relation should be hidden after delete");
+
+  const auto source_delete = store.DeleteSource(source_block_id, nlohmann::json{{"reason", "test source cleanup"}});
+  Expect(source_delete.value("status", std::string{}) == "deleted", "source delete should succeed by block id");
+  const auto deleted_search = store.Search(nlohmann::json{
+      {"query", "scheduled merge"},
+      {"scope_id", "scope.default"},
+  });
+  Expect(
+      deleted_search.dump().find(source_block_id) == std::string::npos,
+      "deleted source block should not be searchable");
+  const auto deleted_graph = store.GraphNeighborhood(nlohmann::json{{"center_id", source_block_id}});
+  Expect(
+      deleted_graph.value("nodes", nlohmann::json::array()).empty(),
+      "deleted source block should not appear in graph");
+  const auto cleanup_plan = store.Cleanup(nlohmann::json{{"apply", false}});
+  Expect(cleanup_plan.value("status", std::string{}) == "planned", "cleanup dry-run should plan");
+  const auto cleanup = store.Cleanup(nlohmann::json{{"apply", true}});
+  Expect(cleanup.value("status", std::string{}) == "completed", "cleanup should complete");
+  Expect(store.ReadBlock(source_block_id).contains("error"), "cleanup should physically purge deleted block");
+
   const auto repair = store.RunRepair(nlohmann::json{{"apply", true}, {"full_rebuild", true}});
   Expect(repair.contains("report_id"), "repair should persist a report");
 


### PR DESCRIPTION
## Summary
- add block/relation/source delete and cleanup operations to the Knowledge Vault runtime
- proxy delete/cleanup through controller plane-scoped KV routes
- classify plane knowledge-vault routes before generic plane interaction routing

## Tests
- cmake --build build/codex-hostd-telemetry --target naim-knowledge-store-tests naim-knowledge-vault-service-tests naim-controller
- ./build/codex-hostd-telemetry/naim-knowledge-store-tests
- ./build/codex-hostd-telemetry/naim-knowledge-vault-service-tests