### PR TITLE
Allow Knowledge Vault DELETE via hostd proxy

### DIFF
--- a/hostd/include/app/hostd_runtime_http_proxy.h
+++ b/hostd/include/app/hostd_runtime_http_proxy.h
@@ -41,6 +41,9 @@ class HostdRuntimeHttpProxy final {
   static bool IsAllowedRuntimeProxyPath(
       const std::string& method,
       const std::string& path);
+#ifdef NAIM_HOSTD_RUNTIME_HTTP_PROXY_TESTING
+ public:
+#endif
   static bool IsAllowedProxyPath(
       HostdRuntimeProxyPolicy policy,
       const std::string& method,

--- a/hostd/src/app/hostd_runtime_http_proxy.cpp
+++ b/hostd/src/app/hostd_runtime_http_proxy.cpp
@@ -200,7 +200,8 @@ bool HostdRuntimeHttpProxy::IsAllowedProxyPath(
     if (method == "GET" && route == "/health") {
       return true;
     }
-    if ((method == "GET" || method == "POST" || method == "PUT") &&
+    if ((method == "GET" || method == "POST" || method == "PUT" ||
+         method == "DELETE") &&
         route.rfind("/v1/", 0) == 0) {
       return true;
     }

--- a/hostd/src/app/hostd_runtime_http_proxy_tests.cpp
+++ b/hostd/src/app/hostd_runtime_http_proxy_tests.cpp
@@ -48,10 +48,32 @@ void TestChunkedRuntimeResponseIsDecoded() {
       "decoded proxy response should not retain transfer-encoding");
 }
 
+void TestKnowledgeVaultPolicyAllowsDeleteRoutes() {
+  Expect(
+      naim::hostd::HostdRuntimeHttpProxy::IsAllowedProxyPath(
+          naim::hostd::HostdRuntimeProxyPolicy::KnowledgeVault,
+          "DELETE",
+          "/v1/blocks/kv-delete-test"),
+      "knowledge vault proxy should allow block delete routes");
+  Expect(
+      naim::hostd::HostdRuntimeHttpProxy::IsAllowedProxyPath(
+          naim::hostd::HostdRuntimeProxyPolicy::KnowledgeVault,
+          "DELETE",
+          "/v1/relations/rel-delete-test"),
+      "knowledge vault proxy should allow relation delete routes");
+  Expect(
+      naim::hostd::HostdRuntimeHttpProxy::IsAllowedProxyPath(
+          naim::hostd::HostdRuntimeProxyPolicy::KnowledgeVault,
+          "DELETE",
+          "/v1/sources/source-delete-test"),
+      "knowledge vault proxy should allow source delete routes");
+}
+
 }  // namespace
 
 int main() {
   TestChunkedRuntimeResponseIsDecoded();
+  TestKnowledgeVaultPolicyAllowsDeleteRoutes();
   std::cout << "hostd runtime HTTP proxy tests passed\n";
   return 0;
 }


### PR DESCRIPTION
## Summary
- allow DELETE /v1/* under the Knowledge Vault runtime proxy policy
- cover block/relation/source delete routes in hostd runtime proxy tests

## Tests
- cmake --build build/codex-hostd-telemetry --target naim-hostd-runtime-http-proxy-tests naim-knowledge-store-tests naim-knowledge-vault-service-tests naim-controller
- ./build/codex-hostd-telemetry/naim-hostd-runtime-http-proxy-tests
- ./build/codex-hostd-telemetry/naim-knowledge-store-tests
- ./build/codex-hostd-telemetry/naim-knowledge-vault-service-tests