### PR TITLE
Extend Knowledge Vault hostd proxy timeout

### DIFF
--- a/controller/src/knowledge/knowledge_vault_service.cpp
+++ b/controller/src/knowledge/knowledge_vault_service.cpp
@@ -15,6 +15,8 @@
 namespace naim::controller {
 namespace {
 
+constexpr int kHostdRuntimeProxyTimeoutMs = 120000;
+
 bool IsSelectedStorageNode(const ModelLibraryNodeSummary& summary) {
   return summary.registration_state == "registered" &&
          summary.session_state == "connected" &&
@@ -526,7 +528,7 @@ HttpResponse KnowledgeVaultService::SendHostdRuntimeProxy(
   const auto started_at = std::chrono::steady_clock::now();
   while (std::chrono::duration_cast<std::chrono::milliseconds>(
              std::chrono::steady_clock::now() - started_at)
-             .count() < 30000) {
+             .count() < kHostdRuntimeProxyTimeoutMs) {
     const auto current = store.LoadHostAssignment(assignment_id);
     if (!current.has_value()) {
       return BuildJsonResponse(


### PR DESCRIPTION
## Summary
- extend the synchronous Knowledge Vault hostd proxy wait window to cover real out-transport polling latency
- prevents false 504 responses when hostd applies the runtime proxy assignment successfully after the previous 30s timeout

## Tests
- cmake --build build/codex-hostd-telemetry --target naim-controller naim-knowledge-vault-service-tests
- ./build/codex-hostd-telemetry/naim-knowledge-vault-service-tests