### PR TITLE
Honor v2 interaction completion policies

### DIFF
--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -13,6 +13,7 @@
 
 #include "naim/runtime/infer_runtime_config.h"
 #include "naim/state/desired_state_v2_validator.h"
+#include "naim/state/state_json_settings_codecs.h"
 #include "naim/state/worker_group_topology.h"
 
 namespace naim {
@@ -510,37 +511,21 @@ void DesiredStateV2Renderer::RenderInteraction() {
     return;
   }
 
-  InteractionSettings interaction;
   const auto& interaction_json = value_.at("interaction");
-  if (interaction_json.contains("image") && interaction_json.at("image").is_string()) {
-    interaction.image = interaction_json.at("image").get<std::string>();
+  InteractionSettings interaction =
+      StateJsonSettingsCodecs::InteractionSettingsFromJson(interaction_json);
+  if (interaction.default_response_language.empty()) {
+    interaction.default_response_language = "en";
   }
-  if (interaction_json.contains("system_prompt") && interaction_json.at("system_prompt").is_string()) {
-    interaction.system_prompt = interaction_json.at("system_prompt").get<std::string>();
-  }
-  interaction.thinking_enabled =
-      interaction_json.value("thinking_enabled", interaction.thinking_enabled);
-  if (interaction_json.contains("default_temperature") &&
-      !interaction_json.at("default_temperature").is_null()) {
-    interaction.default_temperature =
-        interaction_json.at("default_temperature").get<double>();
-  }
-  if (interaction_json.contains("default_top_p") &&
-      !interaction_json.at("default_top_p").is_null()) {
-    interaction.default_top_p = interaction_json.at("default_top_p").get<double>();
-  }
-  interaction.default_response_language =
-      interaction_json.value("default_response_language", std::string("en"));
-  interaction.follow_user_language = interaction_json.value("follow_user_language", true);
-  if (interaction_json.contains("supported_response_languages") &&
-      interaction_json.at("supported_response_languages").is_array()) {
-    interaction.supported_response_languages =
-        interaction_json.at("supported_response_languages").get<std::vector<std::string>>();
-  } else {
+  if (interaction.supported_response_languages.empty()) {
     interaction.supported_response_languages = {"en", "es", "pt", "zh"};
   }
-  interaction.completion_policy = DefaultCompletionPolicy();
-  interaction.long_completion_policy = DefaultLongCompletionPolicy();
+  if (!interaction.completion_policy.has_value()) {
+    interaction.completion_policy = DefaultCompletionPolicy();
+  }
+  if (!interaction.long_completion_policy.has_value()) {
+    interaction.long_completion_policy = DefaultLongCompletionPolicy();
+  }
   state_.interaction = std::move(interaction);
 }
 

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -375,6 +375,24 @@ int main() {
                {"default_response_language", "es"},
                {"follow_user_language", true},
                {"supported_response_languages", json::array({"es", "en"})},
+               {"completion_policy",
+                {
+                    {"response_mode", "normal"},
+                    {"max_tokens", 2048},
+                    {"max_continuations", 0},
+                    {"max_total_completion_tokens", 2048},
+                    {"max_elapsed_time_ms", 90000},
+                }},
+               {"long_completion_policy",
+                {
+                    {"response_mode", "very_long"},
+                    {"max_tokens", 2048},
+                    {"max_continuations", 6},
+                    {"max_total_completion_tokens", 12288},
+                    {"max_elapsed_time_ms", 180000},
+                    {"semantic_goal",
+                     "complete the requested artifact fully before emitting [[TASK_COMPLETE]]"},
+                }},
            }},
           {"runtime",
            {
@@ -397,6 +415,14 @@ int main() {
       Expect(loaded->interaction.has_value(), "state-file-v2-thinking: interaction missing");
       Expect(loaded->interaction->thinking_enabled,
              "state-file-v2-thinking: thinking_enabled should survive apply-state-file path");
+      Expect(loaded->interaction->completion_policy.has_value(),
+             "state-file-v2-thinking: completion_policy should survive v2 render");
+      Expect(loaded->interaction->completion_policy->max_tokens == 2048,
+             "state-file-v2-thinking: completion_policy max_tokens should survive v2 render");
+      Expect(loaded->interaction->long_completion_policy.has_value(),
+             "state-file-v2-thinking: long_completion_policy should survive v2 render");
+      Expect(loaded->interaction->long_completion_policy->max_total_completion_tokens == 12288,
+             "state-file-v2-thinking: long_completion_policy budget should survive v2 render");
       std::cout << "ok: state-file-v2-thinking" << '\n';
     }
 


### PR DESCRIPTION
## Summary
- preserve v2 interaction completion policies during desired-state rendering
- keep default normal/long policies only when plane config omits them
- add regression coverage for v2 completion policy persistence

## Tests
- ./build/codex-hostd-telemetry/naim-state-v2-tests