### PR TITLE
Add Knowledge Vault client sync API

### DIFF
--- a/controller/src/knowledge/knowledge_vault_http_service.cpp
+++ b/controller/src/knowledge/knowledge_vault_http_service.cpp
@@ -23,7 +23,8 @@ bool IsPlaneScopedKnowledgeRoute(const std::string& path) {
          suffix.rfind("blocks/", 0) == 0 ||
          suffix.rfind("relations/", 0) == 0 ||
          suffix.rfind("sources/", 0) == 0 ||
-         suffix.rfind("replica-merges", 0) == 0;
+         suffix.rfind("replica-merges", 0) == 0 ||
+         suffix.rfind("client-sync/", 0) == 0;
 }
 
 nlohmann::json SelectedKnowledgeIds(const naim::DesiredState& desired_state) {
@@ -86,6 +87,7 @@ std::optional<HttpResponse> KnowledgeVaultHttpService::HandleRequest(
         suffix.rfind("/jobs", 0) == 0 ||
         suffix.rfind("/markdown-export", 0) == 0 ||
         suffix.rfind("/markdown-import", 0) == 0 ||
+        suffix.rfind("/client-sync", 0) == 0 ||
         suffix.rfind("/graph-neighborhood", 0) == 0 ||
         suffix.rfind("/catalog", 0) == 0) {
       return service_.ProxyServiceRequest(db_path, request, "/v1" + suffix);

--- a/controller/src/knowledge/knowledge_vault_service_tests.cpp
+++ b/controller/src/knowledge/knowledge_vault_service_tests.cpp
@@ -301,6 +301,29 @@ void TestPlaneScopedDeleteRequestsCarryProtectedPlane() {
       "delete reason should be preserved");
 }
 
+void TestPlaneScopedClientSyncRequestAddsPlane() {
+  HttpRequest request;
+  request.method = "POST";
+  request.path = "/api/v1/planes/knowledge-plane/knowledge-vault/client-sync/export";
+  request.headers["Content-Type"] = "application/json";
+  request.body = R"({"include_blocks":true})";
+
+  const auto rewritten =
+      naim::controller::KnowledgeVaultHttpService::BuildPlaneScopedRequest(
+          request,
+          BuildKnowledgePlaneState(),
+          "knowledge-plane");
+  const auto body = nlohmann::json::parse(rewritten.body);
+
+  Expect(
+      rewritten.path == "/api/v1/knowledge-vault/client-sync/export",
+      "plane client sync path should rewrite to canonical knowledge route");
+  Expect(
+      body.value("plane_id", std::string{}) == "knowledge-plane",
+      "plane client sync should include plane id");
+  Expect(body.value("include_blocks", false), "client sync request body should be preserved");
+}
+
 }  // namespace
 
 int main() {
@@ -312,5 +335,6 @@ int main() {
   TestPlaneScopedSearchRequestKeepsExplicitBody();
   TestPlaneScopedMutationRequestsCarryProtectedPlane();
   TestPlaneScopedDeleteRequestsCarryProtectedPlane();
+  TestPlaneScopedClientSyncRequestAddsPlane();
   return 0;
 }

--- a/runtime/knowledge/include/knowledge/knowledge_store.h
+++ b/runtime/knowledge/include/knowledge/knowledge_store.h
@@ -53,6 +53,8 @@ class KnowledgeStore final {
   nlohmann::json CatalogQuery(const nlohmann::json& payload) const;
   nlohmann::json QueryRoute(const nlohmann::json& payload) const;
   nlohmann::json ReconcileDailyReplicaSchedules(const nlohmann::json& payload);
+  nlohmann::json ClientSyncExport(const nlohmann::json& payload) const;
+  nlohmann::json ClientSyncPush(const nlohmann::json& payload);
 
  private:
   std::string UtcNow() const;

--- a/runtime/knowledge/src/knowledge_server.cpp
+++ b/runtime/knowledge/src/knowledge_server.cpp
@@ -263,6 +263,14 @@ HttpResponse KnowledgeServer::HandlePost(const HttpRequest& request) {
   if (parts.size() == 2 && parts[0] == "v1" && parts[1] == "graph-neighborhood") {
     return BuildJsonResponse(200, store_.GraphNeighborhood(ParseJsonBody(request)));
   }
+  if (parts.size() == 3 && parts[0] == "v1" && parts[1] == "client-sync" &&
+      parts[2] == "export") {
+    return BuildJsonResponse(200, store_.ClientSyncExport(ParseJsonBody(request)));
+  }
+  if (parts.size() == 3 && parts[0] == "v1" && parts[1] == "client-sync" &&
+      parts[2] == "push") {
+    return BuildJsonResponse(200, store_.ClientSyncPush(ParseJsonBody(request)));
+  }
   if (parts.size() == 2 && parts[0] == "v1" && parts[1] == "catalog") {
     return BuildJsonResponse(200, store_.CatalogUpsert(ParseJsonBody(request)));
   }

--- a/runtime/knowledge/src/knowledge_store.cpp
+++ b/runtime/knowledge/src/knowledge_store.cpp
@@ -52,6 +52,10 @@ std::string RelationSearchText(const nlohmann::json& relation) {
       relation.value("to_block_id", std::string{}));
 }
 
+std::string JsonPayloadHash(const nlohmann::json& payload) {
+  return "sha256:" + naim::ComputeSha256Hex(payload.dump());
+}
+
 std::vector<std::string> QueryTerms(const std::string& query) {
   static const std::set<std::string> kIgnoredTerms = {
       "a", "an", "and", "are", "for", "in", "is", "of", "on", "or", "the",
@@ -1825,6 +1829,118 @@ nlohmann::json KnowledgeStore::QueryRoute(const nlohmann::json& payload) const {
       {"redacted", redacted},
       {"warnings", warnings},
       {"partial", !warnings.empty()},
+  };
+}
+
+nlohmann::json KnowledgeStore::ClientSyncExport(const nlohmann::json& payload) const {
+  std::vector<std::string> requested_scopes;
+  if (payload.contains("scope_ids") && payload.at("scope_ids").is_array()) {
+    requested_scopes = JsonStringArray(payload.at("scope_ids"));
+  }
+  const bool include_blocks = payload.value("include_blocks", true);
+  const bool include_relations = payload.value("include_relations", true);
+
+  nlohmann::json blocks = nlohmann::json::array();
+  if (include_blocks) {
+    for (const auto& [key, block] : repository_->ScanJson("blocks:")) {
+      (void)key;
+      if (!ScopeAllowed(block.value("scope_ids", nlohmann::json::array()), requested_scopes)) {
+        continue;
+      }
+      nlohmann::json item = block;
+      item["_sync_hash"] = JsonPayloadHash(block);
+      blocks.push_back(item);
+    }
+  }
+
+  nlohmann::json relations = nlohmann::json::array();
+  std::set<std::string> seen_relations;
+  if (include_relations) {
+    for (const auto& [key, relation] : repository_->ScanJson("edges_out:")) {
+      const std::string relation_id = relation.value("relation_id", key);
+      if (!seen_relations.insert(relation_id).second) {
+        continue;
+      }
+      nlohmann::json item = relation;
+      item["_sync_hash"] = JsonPayloadHash(relation);
+      relations.push_back(item);
+    }
+  }
+
+  return nlohmann::json{
+      {"status", "ok"},
+      {"revision", nlohmann::json{{"latest_event_sequence", LatestEventSequence()}}},
+      {"blocks", blocks},
+      {"relations", relations},
+  };
+}
+
+nlohmann::json KnowledgeStore::ClientSyncPush(const nlohmann::json& payload) {
+  nlohmann::json accepted = nlohmann::json::array();
+  nlohmann::json conflicts = nlohmann::json::array();
+  for (const auto& write : payload.value("writes", nlohmann::json::array())) {
+    if (!write.is_object()) {
+      continue;
+    }
+    const std::string outbox_id = write.value("outbox_id", std::string{});
+    const std::string entity_type = write.value("entity_type", std::string{});
+    const std::string entity_id = write.value("entity_id", std::string{});
+    const std::string operation = write.value("operation", std::string{"upsert"});
+    const std::string base_hash = write.value("base_hash", std::string{});
+    const nlohmann::json local_payload = write.value("payload", nlohmann::json::object());
+
+    if (entity_type == "kv_block") {
+      const auto remote = repository_->GetJson("blocks:" + entity_id);
+      const std::string remote_hash = remote.has_value() ? JsonPayloadHash(*remote) : std::string{};
+      if (!base_hash.empty() && remote.has_value() && remote_hash != base_hash) {
+        conflicts.push_back(nlohmann::json{
+            {"outbox_id", outbox_id},
+            {"entity_type", entity_type},
+            {"entity_id", entity_id},
+            {"reason", "remote_changed"},
+            {"local_payload", local_payload},
+            {"remote_payload", *remote},
+        });
+        continue;
+      }
+      if (operation == "delete") {
+        conflicts.push_back(nlohmann::json{
+            {"outbox_id", outbox_id},
+            {"entity_type", entity_type},
+            {"entity_id", entity_id},
+            {"reason", "delete_not_supported"},
+            {"local_payload", local_payload},
+            {"remote_payload", remote.value_or(nlohmann::json::object())},
+        });
+        continue;
+      }
+      WriteBlock(local_payload);
+      accepted.push_back(outbox_id);
+      continue;
+    }
+
+    if (entity_type == "kv_relation") {
+      if (operation == "delete") {
+        conflicts.push_back(nlohmann::json{
+            {"outbox_id", outbox_id},
+            {"entity_type", entity_type},
+            {"entity_id", entity_id},
+            {"reason", "delete_not_supported"},
+            {"local_payload", local_payload},
+            {"remote_payload", nlohmann::json::object()},
+        });
+        continue;
+      }
+      WriteRelation(local_payload);
+      accepted.push_back(outbox_id);
+    }
+  }
+
+  return nlohmann::json{
+      {"status", conflicts.empty() ? "ok" : "conflicts"},
+      {"accepted_outbox_ids", accepted},
+      {"conflicts", conflicts},
+      {"revision", nlohmann::json{{"latest_event_sequence", LatestEventSequence()}}},
   };
 }
 

--- a/runtime/knowledge/src/knowledge_store_tests.cpp
+++ b/runtime/knowledge/src/knowledge_store_tests.cpp
@@ -84,6 +84,67 @@ int main() {
           "lt-cypher-ai.market.assets",
       "token search should rank the matching deterministic market block first");
 
+  const auto client_export = store.ClientSyncExport(nlohmann::json{
+      {"scope_ids", nlohmann::json::array({"scope.default"})},
+  });
+  Expect(client_export.value("status", std::string{}) == "ok", "client sync export should succeed");
+  Expect(!client_export.value("blocks", nlohmann::json::array()).empty(), "client sync export should include blocks");
+  Expect(
+      client_export.at("blocks").front().contains("_sync_hash"),
+      "client sync export should include block sync hashes");
+
+  const auto client_push = store.ClientSyncPush(nlohmann::json{
+      {"writes",
+       nlohmann::json::array({nlohmann::json{
+           {"outbox_id", "outbox-1"},
+           {"entity_type", "kv_block"},
+           {"entity_id", "maglev.client.block"},
+           {"operation", "upsert"},
+           {"base_hash", ""},
+           {"payload",
+            nlohmann::json{
+                {"block_id", "maglev.client.block"},
+                {"knowledge_id", "maglev.client.block"},
+                {"title", "Maglev Client Block"},
+                {"body", "Client-owned Knowledge Vault write."},
+                {"scope_ids", nlohmann::json::array({"scope.default"})},
+            }},
+       }})},
+  });
+  Expect(
+      client_push.at("accepted_outbox_ids") == nlohmann::json::array({"outbox-1"}),
+      "client sync push should accept non-conflicting block writes");
+  Expect(
+      store.ReadBlock("maglev.client.block").value("block", nlohmann::json::object())
+          .value("title", std::string{}) == "Maglev Client Block",
+      "client sync push should persist accepted block");
+
+  const auto conflicting_push = store.ClientSyncPush(nlohmann::json{
+      {"writes",
+       nlohmann::json::array({nlohmann::json{
+           {"outbox_id", "outbox-2"},
+           {"entity_type", "kv_block"},
+           {"entity_id", "maglev.client.block"},
+           {"operation", "upsert"},
+           {"base_hash", "sha256:not-current"},
+           {"payload",
+            nlohmann::json{
+                {"block_id", "maglev.client.block"},
+                {"knowledge_id", "maglev.client.block"},
+                {"title", "Conflicting Maglev Client Block"},
+                {"body", "This should not overwrite remote state."},
+                {"scope_ids", nlohmann::json::array({"scope.default"})},
+            }},
+       }})},
+  });
+  Expect(
+      !conflicting_push.value("conflicts", nlohmann::json::array()).empty(),
+      "client sync push should report stale-base conflicts");
+  Expect(
+      store.ReadBlock("maglev.client.block").value("block", nlohmann::json::object())
+          .value("title", std::string{}) == "Maglev Client Block",
+      "client sync conflict should not overwrite remote block");
+
   const auto redacted = store.Search(nlohmann::json{
       {"query", "scheduled merge"},
       {"scope_id", "scope.other"},


### PR DESCRIPTION
Adds lossless Knowledge Vault client sync endpoints for Maglev client-owned runtime bootstrap and push.\n\nValidation:\n- cmake --build build/macos/arm64 --target naim-knowledge-store-tests naim-knowledge-vault-service-tests naim-knowledged\n- ./build/macos/arm64/naim-knowledge-store-tests\n- ./build/macos/arm64/naim-knowledge-vault-service-tests