### PR TITLE
Fix maglev skills runtime sync

### DIFF
--- a/common/src/state/desired_state_repository.cpp
+++ b/common/src/state/desired_state_repository.cpp
@@ -55,6 +55,67 @@ std::optional<DesiredState> LoadDesiredStateFromJson(
   return state;
 }
 
+void ReconcilePlaneSkillBindings(sqlite3* db, const DesiredState& state) {
+  if (!state.skills.has_value() || !state.skills->enabled) {
+    Statement delete_statement(
+        db,
+        "DELETE FROM plane_skill_bindings WHERE plane_name = ?1;");
+    delete_statement.BindText(1, state.plane_name);
+    delete_statement.StepDone();
+    return;
+  }
+
+  std::set<std::string> desired_skill_ids;
+  for (const auto& skill_id : state.skills->factory_skill_ids) {
+    if (!skill_id.empty()) {
+      desired_skill_ids.insert(skill_id);
+    }
+  }
+
+  if (desired_skill_ids.empty()) {
+    Statement delete_statement(
+        db,
+        "DELETE FROM plane_skill_bindings WHERE plane_name = ?1;");
+    delete_statement.BindText(1, state.plane_name);
+    delete_statement.StepDone();
+    return;
+  }
+
+  std::string placeholders;
+  int index = 2;
+  for (std::size_t i = 0; i < desired_skill_ids.size(); ++i) {
+    if (!placeholders.empty()) {
+      placeholders += ", ";
+    }
+    placeholders += "?" + std::to_string(index++);
+  }
+
+  Statement delete_stale_statement(
+      db,
+      "DELETE FROM plane_skill_bindings WHERE plane_name = ?1 AND skill_id NOT IN (" +
+          placeholders + ");");
+  delete_stale_statement.BindText(1, state.plane_name);
+  index = 2;
+  for (const auto& skill_id : desired_skill_ids) {
+    delete_stale_statement.BindText(index++, skill_id);
+  }
+  delete_stale_statement.StepDone();
+
+  for (const auto& skill_id : desired_skill_ids) {
+    Statement insert_statement(
+        db,
+        "INSERT INTO plane_skill_bindings("
+        "plane_name, skill_id, enabled, session_ids_json, naim_links_json"
+        ") "
+        "SELECT ?1, ?2, 1, '[]', '[]' "
+        "WHERE EXISTS(SELECT 1 FROM skills_factory_skills WHERE id = ?2) "
+        "ON CONFLICT(plane_name, skill_id) DO NOTHING;");
+    insert_statement.BindText(1, state.plane_name);
+    insert_statement.BindText(2, skill_id);
+    insert_statement.StepDone();
+  }
+}
+
 DesiredState LoadPlaneBaseState(sqlite3* db, const std::string& plane_name) {
   Statement statement(
       db,
@@ -453,6 +514,8 @@ void DesiredStateRepository::ReplaceDesiredState(
       statement.BindInt(11, rebalance_iteration);
       statement.StepDone();
     }
+
+    ReconcilePlaneSkillBindings(db_, state);
 
     for (const auto& node : state.nodes) {
       Statement node_statement(

--- a/controller/src/http/controller_http_router.cpp
+++ b/controller/src/http/controller_http_router.cpp
@@ -94,6 +94,60 @@ bool IsPlaneBrowsingRequest(const std::string& path) {
   return ExtractPlaneFeatureRequestName(path, "/webgateway").has_value();
 }
 
+bool IsPlaneSkillsRootRequest(
+    const std::string& path,
+    const std::string& plane_name) {
+  const std::string root = "/api/v1/planes/" + plane_name + "/skills";
+  return path == root || path == root + "/";
+}
+
+bool IsTrustedPlaneRuntimeSkillsSyncRequest(
+    const HttpRequest& request,
+    const std::string& plane_name,
+    const naim::DesiredState& desired_state) {
+  if (request.method != "GET" ||
+      !IsPlaneSkillsRootRequest(request.path, plane_name) ||
+      !desired_state.skills.has_value() ||
+      !desired_state.skills->enabled) {
+    return false;
+  }
+
+  const auto role =
+      ControllerHttpServerSupport::FindHeaderString(
+          request,
+          "x-naim-plane-runtime-role");
+  const auto header_plane =
+      ControllerHttpServerSupport::FindHeaderString(
+          request,
+          "x-naim-plane-runtime-plane");
+  const auto instance_name =
+      ControllerHttpServerSupport::FindHeaderString(
+          request,
+          "x-naim-plane-runtime-instance");
+  const auto node_name =
+      ControllerHttpServerSupport::FindHeaderString(
+          request,
+          "x-naim-plane-runtime-node");
+  if (!role.has_value() ||
+      !header_plane.has_value() ||
+      !instance_name.has_value() ||
+      !node_name.has_value() ||
+      *role != "skills" ||
+      *header_plane != plane_name) {
+    return false;
+  }
+
+  for (const auto& instance : desired_state.instances) {
+    if (instance.role == naim::InstanceRole::Skills &&
+        instance.plane_name == plane_name &&
+        instance.name == *instance_name &&
+        instance.node_name == *node_name) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool IsHostdStorageRoleRequest(const std::string& path) {
   if (!ControllerHttpServerSupport::StartsWithPath(
           path,
@@ -779,6 +833,10 @@ HttpResponse ControllerHttpRouter::HandleRequest(
         if (plane_name.has_value()) {
           const auto desired_state = store.LoadDesiredState(*plane_name);
           if (desired_state.has_value() && desired_state->protected_plane &&
+              !IsTrustedPlaneRuntimeSkillsSyncRequest(
+                  request,
+                  *plane_name,
+                  *desired_state) &&
               !auth_support_
                    .AuthenticateProtectedPlaneRequest(
                        store,

--- a/controller/src/skills/skills_factory_service_tests.cpp
+++ b/controller/src/skills/skills_factory_service_tests.cpp
@@ -217,6 +217,77 @@ int main() {
       naim::ControllerStore store(db_path.string());
       store.Initialize();
       store.UpsertSkillsFactorySkill(naim::SkillsFactorySkillRecord{
+          "skill-mirror-a",
+          "Mirror A",
+          "test/mirror",
+          "Mirror A description",
+          "Mirror A content",
+          {"mirror-a"},
+          false,
+          "",
+          "",
+      });
+      store.UpsertSkillsFactorySkill(naim::SkillsFactorySkillRecord{
+          "skill-mirror-b",
+          "Mirror B",
+          "test/mirror",
+          "Mirror B description",
+          "Mirror B content",
+          {"mirror-b"},
+          false,
+          "",
+          "",
+      });
+
+      SeedDesiredState(
+          store,
+          BuildDesiredState(
+              "binding-mirror-plane",
+              {"skill-mirror-a", "skill-mirror-b"}),
+          7);
+      const auto first_binding =
+          store.LoadPlaneSkillBinding("binding-mirror-plane", "skill-mirror-a");
+      Expect(
+          first_binding.has_value(),
+          "desired-state save should create missing skill binding");
+      Expect(
+          first_binding->enabled,
+          "auto-created skill binding should default to enabled");
+
+      store.UpsertPlaneSkillBinding(naim::PlaneSkillBindingRecord{
+          "binding-mirror-plane",
+          "skill-mirror-a",
+          false,
+          {"session-preserved"},
+          {"naim://preserved"},
+          "",
+          "",
+      });
+      SeedDesiredState(
+          store,
+          BuildDesiredState("binding-mirror-plane", {"skill-mirror-a"}),
+          8);
+      const auto preserved =
+          store.LoadPlaneSkillBinding("binding-mirror-plane", "skill-mirror-a");
+      Expect(
+          preserved.has_value(),
+          "desired-state save should preserve kept skill binding");
+      Expect(
+          !preserved->enabled,
+          "desired-state save should not overwrite binding enabled flag");
+      Expect(
+          preserved->session_ids == std::vector<std::string>({"session-preserved"}),
+          "desired-state save should preserve binding session ids");
+      Expect(
+          !store.LoadPlaneSkillBinding("binding-mirror-plane", "skill-mirror-b").has_value(),
+          "desired-state save should remove detached skill binding");
+      std::cout << "ok: desired-state-mirrors-plane-skill-bindings" << '\n';
+    }
+
+    {
+      naim::ControllerStore store(db_path.string());
+      store.Initialize();
+      store.UpsertSkillsFactorySkill(naim::SkillsFactorySkillRecord{
           "skill-grouped",
           "Grouped skill",
           "lt-cypher/market/forecast",

--- a/runtime/skills/src/skills_server.cpp
+++ b/runtime/skills/src/skills_server.cpp
@@ -305,7 +305,14 @@ void SkillsServer::SyncFromController() {
         "GET",
         path,
         "",
-        {{"Accept", "application/json"}, {"Cache-Control", "no-store"}});
+        {
+            {"Accept", "application/json"},
+            {"Cache-Control", "no-store"},
+            {"X-Naim-Plane-Runtime-Role", "skills"},
+            {"X-Naim-Plane-Runtime-Plane", config_.plane_name},
+            {"X-Naim-Plane-Runtime-Instance", config_.instance_name},
+            {"X-Naim-Plane-Runtime-Node", config_.node_name},
+        });
     if (response.status_code != 200) {
       std::cerr << "[naim-skills] controller sync skipped: status="
                 << response.status_code << " path=" << path << "\n";


### PR DESCRIPTION
## Summary
- mirror desired-state skills into plane skill bindings during desired-state replacement
- allow read-only skills runtime sync for protected planes when the request matches a declared skills instance
- send plane runtime identity headers from skillsd sync requests

## Tests
- cmake --build build/skills-sync-fix --target naim-skills-factory-tests naim-plane-skills-tests naim-auth-http-tests naim-skillsd naim-controller
- ./build/skills-sync-fix/naim-skills-factory-tests
- ./build/skills-sync-fix/naim-plane-skills-tests
- ./build/skills-sync-fix/naim-auth-http-tests