### PR TITLE
Add Maglev workflow skills

### DIFF
--- a/config/v2-maglev-35b-2gpu/desired-state.v2.json
+++ b/config/v2-maglev-35b-2gpu/desired-state.v2.json
@@ -75,13 +75,26 @@
   "skills": {
     "enabled": true,
     "factory_skill_ids": [
+      "code-agent-api-contract-guard",
+      "code-agent-deploy-path-check",
+      "code-agent-issue-closeout",
+      "code-agent-plane-lifecycle-check",
+      "code-agent-refactor-rules-enforcer",
       "code-agent-root-cause-debug",
       "code-agent-repo-map",
       "code-agent-safe-change",
+      "code-agent-skill-authoring",
+      "code-agent-state-schema-guard",
+      "code-agent-test-first-fix",
+      "code-agent-ui-runtime-parity",
       "skill-1775349375638-5",
       "skill-1775349890476-6",
       "skill-1775349890482-7",
-      "skill-1775349890489-8"
+      "skill-1775349890489-8",
+      "maglev-client-workflow",
+      "maglev-client-knowledge-vault-local-first",
+      "maglev-client-skills-factory-workflow",
+      "maglev-client-sync-and-conflicts"
     ],
     "publish": [
       {

--- a/controller/include/skills/maglev_workflow_skills.h
+++ b/controller/include/skills/maglev_workflow_skills.h
@@ -1,0 +1,170 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "naim/state/models.h"
+#include "naim/state/sqlite_store.h"
+
+namespace naim::controller {
+
+struct MaglevWorkflowSkillDefinition {
+  const char* id;
+  const char* name;
+  const char* description;
+  const char* content;
+  std::vector<std::string> match_terms;
+};
+
+inline const std::vector<MaglevWorkflowSkillDefinition>&
+MaglevWorkflowSkillDefinitions() {
+  static const std::vector<MaglevWorkflowSkillDefinition> definitions{
+      {
+          "maglev-client-workflow",
+          "Maglev client workflow",
+          "Guide Maglev client users through dialog-first local workflow.",
+          "Use this skill when the user asks how to work inside Maglev, which slash "
+          "commands are available, or how to avoid leaving the dialog for normal "
+          "actions. Treat the Maglev client as the user's primary workspace. Prefer "
+          "dialog commands such as /auth, /skills, /skill-add, /skill-delete, "
+          "/skill-use, /skill-clear, /client-sync, /kv, and /remember. Explain the "
+          "shortest local-first path and avoid sending the user to controller UI or "
+          "plane internals unless they ask for administration or recovery steps.",
+          {
+              "maglev workflow",
+              "maglev client",
+              "dialog command",
+              "slash command",
+              "inside dialog",
+              "/auth",
+              "/skills",
+              "/skill-add",
+              "/skill-delete",
+              "/client-sync",
+              "workflow maglev",
+              "команды maglev",
+              "внутри диалога",
+              "слеш команды",
+              "клиент maglev",
+              "маглев workflow",
+          },
+      },
+      {
+          "maglev-client-knowledge-vault-local-first",
+          "Maglev local Knowledge Vault",
+          "Use Maglev's client-owned Knowledge Vault copy before remote plane APIs.",
+          "Use this skill when the user asks to remember, recall, search, cite, "
+          "delete, clean up, or reason over Knowledge Vault data from Maglev. The "
+          "normal request-time path is local-first: use the client-owned SQLite "
+          "Knowledge Vault projection and cite local knowledge_id or block_id when "
+          "available. Plane-owned Knowledge Vault APIs are bootstrap, sync, and "
+          "fallback channels. Use /remember for local writes, /kv status/search/"
+          "graph/delete/cleanup for local inspection and maintenance, and "
+          "/client-sync push or pull when remote reconciliation is needed.",
+          {
+              "maglev knowledge vault",
+              "local knowledge vault",
+              "client-owned knowledge",
+              "client owned knowledge",
+              "local-first knowledge",
+              "/remember",
+              "/kv",
+              "kv search",
+              "kv status",
+              "knowledge citations",
+              "local sqlite",
+              "локальный knowledge vault",
+              "локальная память",
+              "запомни",
+              "найди в памяти",
+              "цитаты knowledge",
+          },
+      },
+      {
+          "maglev-client-skills-factory-workflow",
+          "Maglev local skills workflow",
+          "Manage Maglev skills through the client-owned runtime and dialog commands.",
+          "Use this skill when the user asks to list, add, delete, select, clear, or "
+          "inspect skills from Maglev. Prefer the client-owned skills copy during "
+          "normal work. Use /skills to inspect local skills, /skill-add <path> to "
+          "import a skill JSON file, /skill-delete <name-or-id> to remove one, "
+          "/skill-use to pin a skill for the dialog, and /skill-clear to return to "
+          "automatic skill resolution. Treat the controller SkillsFactory as the "
+          "canonical bootstrap and sync source, not as the request-time selector.",
+          {
+              "maglev skills",
+              "local skills",
+              "client-owned skills",
+              "skill json",
+              "add skill",
+              "delete skill",
+              "remove skill",
+              "/skill-add",
+              "/skill-delete",
+              "/skill-use",
+              "/skill-clear",
+              "/skills-session",
+              "добавить скилл",
+              "удалить скилл",
+              "локальные скиллы",
+              "json скилла",
+          },
+      },
+      {
+          "maglev-client-sync-and-conflicts",
+          "Maglev sync and conflicts",
+          "Explain Maglev client sync, offline outbox, and conflict review behavior.",
+          "Use this skill when the user asks about Maglev bootstrap, sync status, "
+          "offline operation, outbox, conflicts, or why local state differs from the "
+          "plane. Maglev should use local state immediately after activation. Plane "
+          "sync pulls authorized Skills and Knowledge Vault data, pushes queued local "
+          "writes when reachable, and keeps conflicts for review rather than silently "
+          "overwriting remote changes. Recommend /client-sync status before diagnosis "
+          "and /client-sync pull or push only when the user wants reconciliation.",
+          {
+              "maglev sync",
+              "client sync",
+              "sync conflict",
+              "offline outbox",
+              "bootstrap maglev",
+              "client runtime status",
+              "/client-sync status",
+              "/client-sync pull",
+              "/client-sync push",
+              "conflict review",
+              "outbox",
+              "синхронизация maglev",
+              "конфликт синхронизации",
+              "оффлайн очередь",
+              "статус синхронизации",
+          },
+      },
+  };
+  return definitions;
+}
+
+inline std::vector<std::string> MaglevWorkflowSkillIds() {
+  std::vector<std::string> ids;
+  for (const auto& definition : MaglevWorkflowSkillDefinitions()) {
+    ids.push_back(definition.id);
+  }
+  return ids;
+}
+
+inline void EnsureMaglevWorkflowSkillRecords(naim::ControllerStore& store) {
+  for (const auto& definition : MaglevWorkflowSkillDefinitions()) {
+    store.UpsertSkillsFactorySkill(naim::SkillsFactorySkillRecord{
+        definition.id,
+        definition.name,
+        "maglev",
+        definition.description,
+        definition.content,
+        definition.match_terms,
+        false,
+        "",
+        "",
+    });
+  }
+}
+
+}  // namespace naim::controller

--- a/controller/src/bundle/bundle_cli_service.cpp
+++ b/controller/src/bundle/bundle_cli_service.cpp
@@ -16,6 +16,7 @@
 #include "naim/planning/reconcile.h"
 #include "naim/state/state_json.h"
 #include "skills/knowledge_vault_common_skills.h"
+#include "skills/maglev_workflow_skills.h"
 
 namespace naim::controller {
 
@@ -416,6 +417,7 @@ int BundleCliService::ApplyDesiredState(
   desired_state_policy_service_.ResolveDesiredStateDynamicPlacements(
       store, &effective_desired_state);
   EnsureKnowledgeVaultCommonSkills(store, &effective_desired_state);
+  EnsureMaglevWorkflowSkillRecords(store);
   desired_state_policy_service_.ValidateDesiredStateForControllerAdmission(
       store,
       effective_desired_state);

--- a/controller/src/plane/plane_lifecycle_support.cpp
+++ b/controller/src/plane/plane_lifecycle_support.cpp
@@ -2,6 +2,7 @@
 
 #include "app/controller_composition_support.h"
 #include "skills/knowledge_vault_common_skills.h"
+#include "skills/maglev_workflow_skills.h"
 
 namespace naim::controller {
 
@@ -19,6 +20,7 @@ void ControllerPlaneLifecycleSupport::PrepareDesiredState(
   desired_state_policy_service_.ApplyRegisteredHostExecutionModes(store, desired_state);
   desired_state_policy_service_.ResolveDesiredStateDynamicPlacements(store, desired_state);
   EnsureKnowledgeVaultCommonSkills(store, desired_state);
+  EnsureMaglevWorkflowSkillRecords(store);
   desired_state_policy_service_.ValidateDesiredStateForControllerAdmission(
       store,
       *desired_state);

--- a/controller/src/skills/plane_skills_service_tests.cpp
+++ b/controller/src/skills/plane_skills_service_tests.cpp
@@ -22,6 +22,7 @@
 #include "browsing/plane_browsing_service.h"
 #include "plane/plane_dashboard_skills_summary_service.h"
 #include "skills/knowledge_vault_common_skills.h"
+#include "skills/maglev_workflow_skills.h"
 #include "skills/plane_skill_contextual_resolver_service.h"
 #include "skills/plane_skills_service.h"
 
@@ -1515,6 +1516,22 @@ std::string MakeInvalidUtf8Text() {
   return std::string("broken-\xC3\x28-value", 15);
 }
 
+json BuildMaglevWorkflowRuntimeSkills() {
+  json skills = json::array();
+  for (const auto& definition :
+       naim::controller::MaglevWorkflowSkillDefinitions()) {
+    skills.push_back(json{
+        {"id", definition.id},
+        {"name", definition.name},
+        {"description", definition.description},
+        {"content", definition.content},
+        {"match_terms", definition.match_terms},
+        {"enabled", true},
+    });
+  }
+  return skills;
+}
+
 }  // namespace
 
 int main() {
@@ -2543,6 +2560,69 @@ int main() {
                   selection.selected_skill_ids.end(),
           "resolver should select common Knowledge Vault search skill");
       std::cout << "ok: contextual-resolver-selects-knowledge-vault-common-skill" << '\n';
+    }
+
+    {
+      SkillRuntimeTestServer runtime(BuildMaglevWorkflowRuntimeSkills());
+      auto desired_state =
+          BuildDesiredState("maglev-service", naim::controller::MaglevWorkflowSkillIds());
+      desired_state.instances =
+          BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
+
+      naim::controller::PlaneInteractionResolution resolution;
+      resolution.desired_state = desired_state;
+
+      const auto selection =
+          naim::controller::PlaneSkillContextualResolverService().Resolve(
+              "",
+              resolution,
+              json{{"messages",
+                    json::array(
+                        {json{{"role", "user"},
+                              {"content",
+                               "Какие slash commands есть внутри Maglev dialog workflow?"}}})}});
+      Expect(
+          selection.mode == "contextual" &&
+              selection.candidate_count == 4 &&
+              std::find(
+                  selection.selected_skill_ids.begin(),
+                  selection.selected_skill_ids.end(),
+                  "maglev-client-workflow") !=
+                  selection.selected_skill_ids.end(),
+          "resolver should select Maglev workflow skill for dialog command prompts");
+      std::cout << "ok: contextual-resolver-selects-maglev-client-workflow-skill" << '\n';
+    }
+
+    {
+      SkillRuntimeTestServer runtime(BuildMaglevWorkflowRuntimeSkills());
+      auto desired_state =
+          BuildDesiredState("maglev-service", naim::controller::MaglevWorkflowSkillIds());
+      desired_state.instances =
+          BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
+
+      naim::controller::PlaneInteractionResolution resolution;
+      resolution.desired_state = desired_state;
+
+      const auto selection =
+          naim::controller::PlaneSkillContextualResolverService().Resolve(
+              "",
+              resolution,
+              json{{"messages",
+                    json::array(
+                        {json{{"role", "user"},
+                              {"content",
+                               "Запомни это через /remember и потом найди в локальном "
+                               "Knowledge Vault с цитатами."}}})}});
+      Expect(
+          selection.mode == "contextual" &&
+              selection.candidate_count == 4 &&
+              std::find(
+                  selection.selected_skill_ids.begin(),
+                  selection.selected_skill_ids.end(),
+                  "maglev-client-knowledge-vault-local-first") !=
+                  selection.selected_skill_ids.end(),
+          "resolver should select Maglev local Knowledge Vault skill");
+      std::cout << "ok: contextual-resolver-selects-maglev-local-kv-skill" << '\n';
     }
 
     {

--- a/controller/src/skills/skills_factory_service.cpp
+++ b/controller/src/skills/skills_factory_service.cpp
@@ -10,6 +10,7 @@
 #include "naim/state/sqlite_store.h"
 #include "naim/state/state_json.h"
 #include "skills/knowledge_vault_common_skills.h"
+#include "skills/maglev_workflow_skills.h"
 
 namespace naim::controller {
 
@@ -254,6 +255,7 @@ nlohmann::json SkillsFactoryService::BuildListPayload(const std::string& db_path
   naim::ControllerStore store(db_path);
   store.Initialize();
   EnsureKnowledgeVaultCommonSkillRecords(store);
+  EnsureMaglevWorkflowSkillRecords(store);
   json items = json::array();
   for (const auto& skill : store.LoadSkillsFactorySkills()) {
     items.push_back(BuildSkillPayload(db_path, skill));
@@ -271,6 +273,7 @@ nlohmann::json SkillsFactoryService::BuildSkillPayload(
   naim::ControllerStore store(db_path);
   store.Initialize();
   EnsureKnowledgeVaultCommonSkillRecords(store);
+  EnsureMaglevWorkflowSkillRecords(store);
   const auto skill = store.LoadSkillsFactorySkill(skill_id);
   if (!skill.has_value()) {
     throw std::runtime_error("skill '" + skill_id + "' not found");

--- a/controller/src/skills/skills_factory_service_tests.cpp
+++ b/controller/src/skills/skills_factory_service_tests.cpp
@@ -11,6 +11,7 @@
 #include "naim/state/sqlite_store.h"
 #include "plane/plane_mutation_service.h"
 #include "skills/knowledge_vault_common_skills.h"
+#include "skills/maglev_workflow_skills.h"
 #include "skills/plane_skill_catalog_service.h"
 #include "skills/skills_factory_service.h"
 
@@ -132,7 +133,7 @@ int main() {
             return fallback;
           });
       const auto payload = factory_service.BuildListPayload(db_path.string());
-      Expect(payload.at("skills").size() == 4, "factory list should contain seeded common skills");
+      Expect(payload.at("skills").size() == 8, "factory list should contain seeded built-in skills");
       Expect(payload.at("groups").size() == 0, "factory list should start without explicit groups");
       const auto& item = FindSkillById(payload.at("skills"), "skill-alpha");
       Expect(item.at("id").get<std::string>() == "skill-alpha", "factory skill id mismatch");
@@ -158,6 +159,18 @@ int main() {
       Expect(
           !common_item.at("internal").get<bool>(),
           "common Knowledge Vault skill should be user-visible");
+      const auto& maglev_item =
+          FindSkillById(payload.at("skills"), "maglev-client-workflow");
+      Expect(
+          maglev_item.at("group_path").get<std::string>() == "maglev",
+          "Maglev workflow skill should belong to the maglev group");
+      Expect(
+          !maglev_item.at("internal").get<bool>(),
+          "Maglev workflow skill should be user-visible");
+      Expect(
+          store.LoadSkillsFactorySkill("maglev-client-knowledge-vault-local-first")
+              .has_value(),
+          "Maglev Knowledge Vault skill record should be seeded");
 
       const auto deleted =
           factory_service.DeleteSkill(db_path.string(), "skill-alpha", temp_root.string());

--- a/docs/skills-factory.md
+++ b/docs/skills-factory.md
@@ -143,6 +143,22 @@ desired-state preparation appends these ids to `skills.factory_skill_ids[]` if t
 The skills do not add a new tool-calling API; they steer the model to use the existing
 controller-injected Knowledge Vault context for the current plane only.
 
+### Maglev Workflow Skills
+
+`naim-node` also seeds Maglev-specific SkillsFactory records for the `maglev-service`
+plane:
+
+- `maglev-client-workflow`
+- `maglev-client-knowledge-vault-local-first`
+- `maglev-client-skills-factory-workflow`
+- `maglev-client-sync-and-conflicts`
+
+These records use the `maglev` group path and are intended to be attached explicitly by
+the Maglev desired state, not auto-attached to every LLM plane. They steer the model to
+treat Maglev as a dialog-first client with client-owned Skills and Knowledge Vault state.
+The normal request-time path is local-first; controller and plane APIs are bootstrap,
+sync, administration, and fallback channels.
+
 ## Operator UI
 
 ### Sidebar


### PR DESCRIPTION
Adds Maglev-specific workflow skills, binds them to maglev-service desired state, and covers SkillsFactory/contextual resolver behavior with tests.