### PR TITLE
Refresh skills runtime after plane updates

### DIFF
--- a/controller/include/plane/plane_mutation_service.h
+++ b/controller/include/plane/plane_mutation_service.h
@@ -23,6 +23,7 @@ class PlaneMutationService {
   struct Deps {
     ApplyDesiredStateFn apply_desired_state;
     MakePlaneServiceFn make_plane_service;
+    bool enable_runtime_sync_after_apply = true;
   };
 
   explicit PlaneMutationService(Deps deps);

--- a/controller/include/skills/plane_skills_target_resolver.h
+++ b/controller/include/skills/plane_skills_target_resolver.h
@@ -24,7 +24,8 @@ class PlaneSkillsTargetResolver final {
       const std::string& method,
       const std::string& path,
       const std::string& body,
-      const std::vector<std::pair<std::string, std::string>>& headers);
+      const std::vector<std::pair<std::string, std::string>>& headers,
+      int timeout_ms = 30000);
   static std::string NormalizeSkillPathSuffix(const std::string& path_suffix);
 };
 

--- a/controller/src/plane/plane_mutation_service.cpp
+++ b/controller/src/plane/plane_mutation_service.cpp
@@ -1,9 +1,49 @@
 #include "plane/plane_mutation_service.h"
 
+#include <iostream>
+
 #include "naim/state/desired_state_v2_renderer.h"
 #include "naim/state/state_json.h"
+#include "skills/plane_skills_target_resolver.h"
 
 namespace naim::controller {
+
+namespace {
+
+constexpr int kSkillsRuntimeSyncTimeoutMs = 5000;
+
+void SyncSkillsRuntimeAfterDesiredStateApply(
+    const std::string& db_path,
+    const naim::DesiredState& desired_state) {
+  if (!desired_state.skills.has_value() || !desired_state.skills->enabled) {
+    return;
+  }
+  const auto target = PlaneSkillsTargetResolver::ResolvePlaneLocalTarget(desired_state);
+  if (!target.has_value()) {
+    return;
+  }
+  try {
+    const auto response = PlaneSkillsTargetResolver::SendPlaneLocalRequest(
+        db_path,
+        desired_state.plane_name,
+        *target,
+        "POST",
+        "/v1/sync",
+        "{}",
+        PlaneSkillsTargetResolver::DefaultJsonHeaders(),
+        kSkillsRuntimeSyncTimeoutMs);
+    if (response.status_code < 200 || response.status_code >= 300) {
+      std::cerr << "[naim-controller] skills runtime sync warning plane="
+                << desired_state.plane_name << " status=" << response.status_code
+                << "\n";
+    }
+  } catch (const std::exception& error) {
+    std::cerr << "[naim-controller] skills runtime sync warning plane="
+              << desired_state.plane_name << " error=" << error.what() << "\n";
+  }
+}
+
+}  // namespace
 
 PlaneMutationService::PlaneMutationService(Deps deps) : deps_(std::move(deps)) {}
 
@@ -27,11 +67,15 @@ ControllerActionResult PlaneMutationService::ExecuteUpsertPlaneStateAction(
               "plane name mismatch: expected '" + *expected_plane_name +
               "' but payload contains '" + desired_state.plane_name + "'");
         }
-        return deps_.apply_desired_state(
+        const int result = deps_.apply_desired_state(
             db_path,
             desired_state,
             artifacts_root,
             source_label);
+        if (result == 0 && deps_.enable_runtime_sync_after_apply) {
+          SyncSkillsRuntimeAfterDesiredStateApply(db_path, desired_state);
+        }
+        return result;
       });
 }
 

--- a/controller/src/skills/plane_skills_target_resolver.cpp
+++ b/controller/src/skills/plane_skills_target_resolver.cpp
@@ -133,7 +133,8 @@ PlaneSkillsTargetResolver::ResolvePlaneLocalTarget(
     const std::string& method,
     const std::string& path,
     const std::string& body,
-    const std::vector<std::pair<std::string, std::string>>& headers) {
+    const std::vector<std::pair<std::string, std::string>>& headers,
+    int timeout_ms) {
   if (!target.route_via_hostd_proxy) {
     return SendControllerHttpRequest(target, method, path, body, headers);
   }
@@ -195,7 +196,7 @@ PlaneSkillsTargetResolver::ResolvePlaneLocalTarget(
   const auto started_at = std::chrono::steady_clock::now();
   while (std::chrono::duration_cast<std::chrono::milliseconds>(
              std::chrono::steady_clock::now() - started_at)
-             .count() < 30000) {
+             .count() < timeout_ms) {
     const auto current = store.LoadHostAssignment(assignment_id);
     if (!current.has_value()) {
       return BuildProxyErrorResponse(

--- a/controller/src/skills/skills_factory_service_tests.cpp
+++ b/controller/src/skills/skills_factory_service_tests.cpp
@@ -70,6 +70,7 @@ naim::controller::PlaneMutationService MakeMutationService() {
       [](const std::string&) -> naim::controller::PlaneService {
         throw std::runtime_error("plane service should not be used in skills tests");
       };
+  deps.enable_runtime_sync_after_apply = false;
   return naim::controller::PlaneMutationService(std::move(deps));
 }
 

--- a/docs/skills-factory.md
+++ b/docs/skills-factory.md
@@ -93,14 +93,17 @@ Deleting from `SkillsFactory` is global detach:
 ### Runtime synchronization
 
 Each `skills-<plane>` runtime owns a local SQLite replica of the skills attached to its
-plane. That runtime pulls its selected factory skills from the controller on a timer:
+plane. That runtime pulls its selected factory skills from the controller at startup and
+on its fallback timer. Controller-side desired-state updates also ask the plane-owned
+runtime to refresh immediately through its local `/v1/sync` endpoint:
 
-- sync runs from the plane-owned skills runtime, not from controller request paths
-- the sync interval is one hour
-- startup participates in the same timer loop, then the runtime waits one hour between pulls
-- create/update/delete/attach/detach APIs update controller state only; they do not push runtime syncs
-- scheduler ticks and interaction requests do not trigger skills synchronization
-- deselection removes runtime copies on the next hourly sync
+- the runtime remains the owner of its SQLite replica; controller paths only request refresh
+- startup participates in the same pull loop
+- the fallback sync interval is one hour
+- create/update/delete/attach/detach APIs and desired-state apply trigger a best-effort runtime refresh
+- refresh uses direct local runtime HTTP when possible, or the node-aware hostd runtime proxy for remote nodes
+- if the runtime is not reachable yet, the controller logs a warning and the fallback timer still converges
+- deselection removes runtime copies on the next successful refresh
 - interaction-time resolution still reads only the plane-local runtime copy
 
 ### Contextual interaction-time activation

--- a/runtime/skills/include/skills/skills_server.h
+++ b/runtime/skills/include/skills/skills_server.h
@@ -51,7 +51,7 @@ class SkillsServer final {
   static nlohmann::json ParseJsonBody(const HttpRequest& request);
   HttpResponse BuildJsonResponse(int status_code, const nlohmann::json& payload) const;
   void StartControllerSyncLoop();
-  void SyncFromController();
+  nlohmann::json SyncFromController();
   void WriteRuntimeStatus(const std::string& phase, bool ready) const;
   void SetReadyFile(bool ready) const;
 

--- a/runtime/skills/src/skills_server.cpp
+++ b/runtime/skills/src/skills_server.cpp
@@ -205,6 +205,9 @@ HttpResponse SkillsServer::HandlePost(const HttpRequest& request) {
   if (parts.size() == 2 && parts[0] == "v1" && parts[1] == "skills") {
     return BuildJsonResponse(201, store_.CreateSkill(ParseJsonBody(request)));
   }
+  if (parts.size() == 2 && parts[0] == "v1" && parts[1] == "sync") {
+    return BuildJsonResponse(200, SyncFromController());
+  }
   if (parts.size() == 3 && parts[0] == "v1" && parts[1] == "skills" && parts[2] == "resolve") {
     return BuildJsonResponse(200, store_.ResolveSkills(ParseJsonBody(request)));
   }
@@ -290,10 +293,13 @@ void SkillsServer::StartControllerSyncLoop() {
   });
 }
 
-void SkillsServer::SyncFromController() {
+nlohmann::json SkillsServer::SyncFromController() {
   if (config_.controller_url.empty() || config_.plane_name.empty() ||
       config_.plane_name == "unknown") {
-    return;
+    return nlohmann::json{
+        {"status", "skipped"},
+        {"reason", "controller_url_or_plane_name_missing"},
+    };
   }
 
   try {
@@ -316,14 +322,21 @@ void SkillsServer::SyncFromController() {
     if (response.status_code != 200) {
       std::cerr << "[naim-skills] controller sync skipped: status="
                 << response.status_code << " path=" << path << "\n";
-      return;
+      return nlohmann::json{
+          {"status", "skipped"},
+          {"reason", "controller_status"},
+          {"status_code", response.status_code},
+      };
     }
 
     const auto payload = nlohmann::json::parse(response.body, nullptr, false);
     if (payload.is_discarded() || !payload.is_object() ||
         !payload.contains("skills") || !payload.at("skills").is_array()) {
       std::cerr << "[naim-skills] controller sync skipped: malformed payload\n";
-      return;
+      return nlohmann::json{
+          {"status", "skipped"},
+          {"reason", "malformed_controller_payload"},
+      };
     }
 
     std::set<std::string> selected_ids;
@@ -355,8 +368,17 @@ void SkillsServer::SyncFromController() {
     }
 
     std::cout << "[naim-skills] controller sync ok skills=" << synced_count << "\n";
+    return nlohmann::json{
+        {"status", "ok"},
+        {"skills", synced_count},
+        {"plane_name", config_.plane_name},
+    };
   } catch (const std::exception& error) {
     std::cerr << "[naim-skills] controller sync failed: " << error.what() << "\n";
+    return nlohmann::json{
+        {"status", "error"},
+        {"message", error.what()},
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- add an explicit skills runtime sync endpoint
- request best-effort skills runtime refresh after desired-state apply
- keep the hourly runtime pull loop as fallback and document the new behavior

## Tests
- git diff --check
- cmake --build build/skills-sync-fix --target naim-controller naim-skillsd naim-skills-factory-tests naim-plane-skills-tests
- ./build/skills-sync-fix/naim-skills-factory-tests
- ./build/skills-sync-fix/naim-plane-skills-tests