### PR TITLE
Refresh skills runtime after state file apply

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,10 +433,13 @@ add_executable(
   controller/src/bundle/bundle_cli_service.cpp
   controller/src/bundle/bundle_cli_service_tests.cpp
   controller/src/infra/controller_action.cpp
+  controller/src/http/controller_http_transport.cpp
+  controller/src/infra/controller_network_manager.cpp
   controller/src/infra/controller_print_service.cpp
   controller/src/infra/controller_runtime_support_service.cpp
   controller/src/plane/desired_state_policy_service.cpp
   controller/src/plane/plane_realization_service.cpp
+  controller/src/skills/plane_skills_target_resolver.cpp
 )
 target_include_directories(
   naim-controller-apply-state-tests PRIVATE common/include controller/include)

--- a/controller/src/bundle/bundle_cli_service.cpp
+++ b/controller/src/bundle/bundle_cli_service.cpp
@@ -17,10 +17,13 @@
 #include "naim/state/state_json.h"
 #include "skills/knowledge_vault_common_skills.h"
 #include "skills/maglev_workflow_skills.h"
+#include "skills/plane_skills_target_resolver.h"
 
 namespace naim::controller {
 
 namespace {
+
+constexpr int kSkillsRuntimeSyncTimeoutMs = 5000;
 
 void PrintPreviewSummary(const naim::DesiredState& state) {
   std::cout << "preview:\n";
@@ -135,6 +138,45 @@ void DetachRemovedFactorySkillBindings(
     if (next_ids.count(skill_id) == 0) {
       store.DeletePlaneSkillBinding(next_state.plane_name, skill_id);
     }
+  }
+}
+
+void RequestSkillsRuntimeRefresh(
+    const std::string& db_path,
+    const naim::DesiredState& desired_state,
+    const std::string& source_label) {
+  if (!desired_state.skills.has_value() || !desired_state.skills->enabled) {
+    return;
+  }
+  naim::ControllerStore store(db_path);
+  store.Initialize();
+  const auto plane = store.LoadPlane(desired_state.plane_name);
+  if (!plane.has_value() || plane->applied_generation <= 0 || plane->state != "running") {
+    return;
+  }
+  const auto target = PlaneSkillsTargetResolver::ResolvePlaneLocalTarget(desired_state);
+  if (!target.has_value()) {
+    return;
+  }
+  try {
+    const auto response = PlaneSkillsTargetResolver::SendPlaneLocalRequest(
+        db_path,
+        desired_state.plane_name,
+        *target,
+        "POST",
+        "/v1/sync",
+        "{}",
+        PlaneSkillsTargetResolver::DefaultJsonHeaders(),
+        kSkillsRuntimeSyncTimeoutMs);
+    if (response.status_code < 200 || response.status_code >= 300) {
+      std::cerr << "[naim-controller] skills runtime sync warning plane="
+                << desired_state.plane_name << " source=" << source_label
+                << " status=" << response.status_code << "\n";
+    }
+  } catch (const std::exception& error) {
+    std::cerr << "[naim-controller] skills runtime sync warning plane="
+              << desired_state.plane_name << " source=" << source_label
+              << " error=" << error.what() << "\n";
   }
 }
 
@@ -324,6 +366,7 @@ int BundleCliService::ImportBundle(
   store.UpdatePlaneArtifactsRoot(desired_state.plane_name, default_artifacts_root_);
   store.ClearSchedulerPlaneRuntime(desired_state.plane_name);
   store.ReplaceRolloutActions(desired_state.plane_name, desired_generation, {});
+  RequestSkillsRuntimeRefresh(db_path, desired_state, "import-bundle");
   AppendEvent(
       store,
       "bundle",
@@ -379,6 +422,7 @@ int BundleCliService::ApplyBundle(
   store.UpdatePlaneArtifactsRoot(desired_state.plane_name, artifacts_root);
   store.ClearSchedulerPlaneRuntime(desired_state.plane_name);
   store.ReplaceRolloutActions(desired_state.plane_name, desired_generation, {});
+  RequestSkillsRuntimeRefresh(db_path, desired_state, "apply-bundle");
   AppendEvent(
       store,
       "bundle",
@@ -453,6 +497,7 @@ int BundleCliService::ApplyDesiredState(
   store.UpdatePlaneArtifactsRoot(effective_desired_state.plane_name, artifacts_root);
   store.ClearSchedulerPlaneRuntime(effective_desired_state.plane_name);
   store.ReplaceRolloutActions(effective_desired_state.plane_name, desired_generation, {});
+  RequestSkillsRuntimeRefresh(db_path, effective_desired_state, source_label);
 
   const bool existed = current_state.has_value();
   AppendEvent(

--- a/controller/src/plane/plane_mutation_service.cpp
+++ b/controller/src/plane/plane_mutation_service.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "naim/state/desired_state_v2_renderer.h"
+#include "naim/state/sqlite_store.h"
 #include "naim/state/state_json.h"
 #include "skills/plane_skills_target_resolver.h"
 
@@ -16,6 +17,12 @@ void SyncSkillsRuntimeAfterDesiredStateApply(
     const std::string& db_path,
     const naim::DesiredState& desired_state) {
   if (!desired_state.skills.has_value() || !desired_state.skills->enabled) {
+    return;
+  }
+  ControllerStore store(db_path);
+  store.Initialize();
+  const auto plane = store.LoadPlane(desired_state.plane_name);
+  if (!plane.has_value() || plane->applied_generation <= 0 || plane->state != "running") {
     return;
   }
   const auto target = PlaneSkillsTargetResolver::ResolvePlaneLocalTarget(desired_state);


### PR DESCRIPTION
## Summary
- request skills runtime refresh from bundle/state-file apply paths as well as API plane mutation paths
- skip runtime refresh for planes that do not yet have an applied running runtime
- include the skills target resolver in apply-state test coverage

## Tests
- git diff --check
- cmake --build build/skills-sync-fix --target naim-controller naim-controller-apply-state-tests naim-skills-factory-tests naim-plane-skills-tests
- ./build/skills-sync-fix/naim-controller-apply-state-tests
- ./build/skills-sync-fix/naim-skills-factory-tests
- ./build/skills-sync-fix/naim-plane-skills-tests