### PR TITLE
Allow skills runtime sync through hostd proxy

### DIFF
--- a/hostd/src/app/hostd_runtime_http_proxy.cpp
+++ b/hostd/src/app/hostd_runtime_http_proxy.cpp
@@ -189,6 +189,9 @@ bool HostdRuntimeHttpProxy::IsAllowedProxyPath(
     if (route == "/v1/skills/resolve" && method == "POST") {
       return true;
     }
+    if (route == "/v1/sync" && method == "POST") {
+      return true;
+    }
     if (route.rfind("/v1/skills/", 0) == 0 &&
         (method == "GET" || method == "PUT" || method == "PATCH" ||
          method == "DELETE")) {

--- a/hostd/src/app/hostd_runtime_http_proxy_tests.cpp
+++ b/hostd/src/app/hostd_runtime_http_proxy_tests.cpp
@@ -69,11 +69,21 @@ void TestKnowledgeVaultPolicyAllowsDeleteRoutes() {
       "knowledge vault proxy should allow source delete routes");
 }
 
+void TestSkillsPolicyAllowsSyncRoute() {
+  Expect(
+      naim::hostd::HostdRuntimeHttpProxy::IsAllowedProxyPath(
+          naim::hostd::HostdRuntimeProxyPolicy::Skills,
+          "POST",
+          "/v1/sync"),
+      "skills proxy should allow explicit sync route");
+}
+
 }  // namespace
 
 int main() {
   TestChunkedRuntimeResponseIsDecoded();
   TestKnowledgeVaultPolicyAllowsDeleteRoutes();
+  TestSkillsPolicyAllowsSyncRoute();
   std::cout << "hostd runtime HTTP proxy tests passed\n";
   return 0;
 }


### PR DESCRIPTION
## Summary
- allow skills runtime proxy policy to forward POST /v1/sync
- add a hostd proxy allowlist regression test

## Tests
- git diff --check
- cmake --build build/skills-sync-fix --target naim-hostd-runtime-http-proxy-tests naim-hostd naim-controller
- ./build/skills-sync-fix/naim-hostd-runtime-http-proxy-tests