### PR TITLE
Clarify Maglev skill import guidance

### DIFF
--- a/controller/include/skills/maglev_workflow_skills.h
+++ b/controller/include/skills/maglev_workflow_skills.h
@@ -29,7 +29,10 @@ MaglevWorkflowSkillDefinitions() {
           "dialog commands such as /auth, /skills, /skill-add, /skill-delete, "
           "/skill-use, /skill-clear, /client-sync, /kv, and /remember. Explain the "
           "shortest local-first path and avoid sending the user to controller UI or "
-          "plane internals unless they ask for administration or recovery steps.",
+          "plane internals unless they ask for administration or recovery steps. "
+          "For skill import, /skill-add requires a relative or absolute path to a "
+          "skill JSON file; do not describe a pasted-JSON prompt flow unless the "
+          "client explicitly implements one.",
           {
               "maglev workflow",
               "maglev client",
@@ -89,8 +92,9 @@ MaglevWorkflowSkillDefinitions() {
           "normal work. Use /skills to inspect local skills, /skill-add <path> to "
           "import a skill JSON file, /skill-delete <name-or-id> to remove one, "
           "/skill-use to pin a skill for the dialog, and /skill-clear to return to "
-          "automatic skill resolution. Treat the controller SkillsFactory as the "
-          "canonical bootstrap and sync source, not as the request-time selector.",
+          "automatic skill resolution. /skill-add accepts a relative or absolute "
+          "file path, not pasted JSON content. Treat the controller SkillsFactory "
+          "as the canonical bootstrap and sync source, not as the request-time selector.",
           {
               "maglev skills",
               "local skills",

--- a/controller/src/skills/skills_factory_service_tests.cpp
+++ b/controller/src/skills/skills_factory_service_tests.cpp
@@ -169,6 +169,14 @@ int main() {
           !maglev_item.at("internal").get<bool>(),
           "Maglev workflow skill should be user-visible");
       Expect(
+          maglev_item.at("content").get<std::string>().find("/skill-add requires") !=
+              std::string::npos,
+          "Maglev workflow skill should document file-path skill import");
+      Expect(
+          maglev_item.at("content").get<std::string>().find("pasted-JSON prompt flow") !=
+              std::string::npos,
+          "Maglev workflow skill should guard against pasted JSON prompt guidance");
+      Expect(
           store.LoadSkillsFactorySkill("maglev-client-knowledge-vault-local-first")
               .has_value(),
           "Maglev Knowledge Vault skill record should be seeded");


### PR DESCRIPTION
## Summary
- clarify that Maglev /skill-add imports from a relative or absolute JSON file path
- guard the Maglev workflow skill against invented pasted-JSON prompt guidance
- add a SkillsFactory regression assertion for the wording

## Tests
- git diff --check
- cmake --build build/skills-sync-fix --target naim-skills-factory-tests naim-controller
- ./build/skills-sync-fix/naim-skills-factory-tests