### PR TITLE
Fix voice binary proxy requests

### DIFF
--- a/controller/src/voice/plane_voice_service.cpp
+++ b/controller/src/voice/plane_voice_service.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <thread>
 
+#include "naim/security/crypto_utils.h"
 #include "naim/state/sqlite_store.h"
 
 namespace naim::controller {
@@ -62,6 +63,14 @@ json BuildHeaderArray(
     result.push_back(json::array({key, value}));
   }
   return result;
+}
+
+std::string EncodeBodyBase64(const std::string& body) {
+  if (body.empty()) {
+    return "";
+  }
+  return naim::EncodeBytesBase64(
+      std::vector<unsigned char>(body.begin(), body.end()));
 }
 
 HttpResponse BuildProxyErrorResponse(
@@ -149,7 +158,7 @@ HttpResponse SendPlaneVoiceRequest(
           {"target_port", target.port},
           {"method", method},
           {"path", path},
-          {"body", body},
+          {"body_base64", EncodeBodyBase64(body)},
           {"headers", BuildHeaderArray(headers)},
           {"request_id", request_id},
           {"policy", "voice-listener"},

--- a/hostd/src/app/hostd_app_assignment_support.cpp
+++ b/hostd/src/app/hostd_app_assignment_support.cpp
@@ -566,7 +566,14 @@ void HostdAppAssignmentSupport::ExecuteRuntimeHttpProxy(
   const int port = payload.value("target_port", 0);
   const std::string method = payload.value("method", std::string{});
   const std::string path = payload.value("path", std::string{});
-  const std::string body = payload.value("body", std::string{});
+  std::string body = payload.value("body", std::string{});
+  if (payload.contains("body_base64") && payload.at("body_base64").is_string()) {
+    const auto encoded_body = payload.at("body_base64").get<std::string>();
+    if (!encoded_body.empty()) {
+      const auto bytes = naim::DecodeBytesBase64(encoded_body);
+      body.assign(bytes.begin(), bytes.end());
+    }
+  }
   const std::string policy_name = payload.value("policy", std::string("runtime"));
   HostdRuntimeProxyPolicy policy = HostdRuntimeProxyPolicy::Runtime;
   if (policy_name == "knowledge-vault") {


### PR DESCRIPTION
## Summary
- encode runtime-proxy request bodies as base64 in controller assignments
- decode base64 bodies in hostd before forwarding to node-local voice runtimes

## Tests
- cmake --build build/voice-route-debug --target naim-hostd-runtime-http-proxy-tests naim-controller -j4
- ./build/voice-route-debug/naim-hostd-runtime-http-proxy-tests