### PR TITLE
Fix voice runtime release image build

### DIFF
--- a/scripts/build-runtime-images.sh
+++ b/scripts/build-runtime-images.sh
@@ -106,6 +106,10 @@ voice_module_tag="${11:-naim/voice-module:dev}"
 build_dir="$("${script_dir}/print-build-dir.sh")"
 turboquant_build_dir="${NAIM_TURBOQUANT_BUILD_DIR:-${repo_root}/build-turboquant/linux/x64}"
 image_work_root="${NAIM_RUNTIME_IMAGE_CONTEXT_ROOT:-${build_dir}/image-contexts}"
+cmake_exe="$("${script_dir}/find-cmake.sh")"
+
+"${cmake_exe}" --build "${build_dir}" --target naim-voice-module-runtime-all
+
 mkdir -p "${image_work_root}"
 image_context="$(mktemp -d "${image_work_root}/runtime-image-context.XXXXXX")"
 cleanup_image_context() {

--- a/scripts/ci/detect-release-scope.sh
+++ b/scripts/ci/detect-release-scope.sh
@@ -42,6 +42,9 @@ is_native_build_sensitive_path() {
     Dockerfile|*/Dockerfile|**/Dockerfile|docker/*|docker/**)
       return 0
       ;;
+    scripts/build-runtime-images.sh|scripts/release/build-and-push-images.sh)
+      return 0
+      ;;
   esac
 
   return 1


### PR DESCRIPTION
## Summary
- rebuild naim-voice-module-runtime-all before assembling runtime image contexts
- prevent release image pushes from re-tagging a stale naim-voice-moduled binary

## Tests
- bash -n scripts/build-runtime-images.sh scripts/release/build-and-push-images.sh
- cmake --build build/voice-route-debug --target naim-voice-module-runtime-all -j4