### PR TITLE
Fix voice runtime external rebuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1864,6 +1864,7 @@ if(NOT WIN32)
       SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/runtime/voice"
       BINARY_DIR "${_naim_voice_module_build_dir}"
       CMAKE_ARGS ${_naim_voice_module_cmake_args}
+      BUILD_ALWAYS TRUE
       BUILD_COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target naim-voice-moduled
       INSTALL_COMMAND
         "${CMAKE_COMMAND}" -E copy_if_different


### PR DESCRIPTION
## Summary
- mark the voice-module ExternalProject as BUILD_ALWAYS
- ensure the release image build gets a fresh naim-voice-moduled when runtime/voice sources change

## Tests
- cmake --build build/voice-route-debug --target naim-voice-module-runtime-all -j4