### PR TITLE
Fix plane feature proxy readiness

### DIFF
--- a/controller/src/plane/plane_http_service.cpp
+++ b/controller/src/plane/plane_http_service.cpp
@@ -335,12 +335,8 @@ HttpResponse PlaneHttpService::HandlePlanePath(
         const std::optional<std::string> plane_state =
             plane.has_value() ? std::optional<std::string>(plane->state) : std::nullopt;
         const bool plane_runtime_ready =
-            plane.has_value() && plane->state == "running" &&
-            plane->generation <= plane->applied_generation;
+            plane.has_value() && plane->state == "running";
         std::optional<std::string> webgateway_plane_state = plane_state;
-        if (plane.has_value() && plane->state == "running" && !plane_runtime_ready) {
-          webgateway_plane_state = "starting";
-        }
         const naim::controller::PlaneBrowsingService browsing_service;
         if (path_suffix.empty() || path_suffix == "/" || path_suffix == "/status") {
           if (request.method != "GET") {
@@ -419,12 +415,8 @@ HttpResponse PlaneHttpService::HandlePlanePath(
         const std::optional<std::string> plane_state =
             plane.has_value() ? std::optional<std::string>(plane->state) : std::nullopt;
         const bool plane_runtime_ready =
-            plane.has_value() && plane->state == "running" &&
-            plane->generation <= plane->applied_generation;
+            plane.has_value() && plane->state == "running";
         std::optional<std::string> voice_plane_state = plane_state;
-        if (plane.has_value() && plane->state == "running" && !plane_runtime_ready) {
-          voice_plane_state = "starting";
-        }
         const naim::controller::PlaneVoiceService voice_service;
         if (path_suffix.empty() || path_suffix == "/" || path_suffix == "/status") {
           if (request.method != "GET") {


### PR DESCRIPTION
## Summary
- let plane-owned webgateway and voice listener proxies use running plane state instead of generation convergence
- avoid reporting feature status as starting when metadata generation drifts beyond applied runtime generation

## Tests
- cmake --build build/voice-route-debug --target naim-controller -j4
- build/macos/arm64/naim-plane-skills-tests
- build/macos/arm64/naim-dashboard-service-tests
- build/macos/arm64/naim-hostd-runtime-http-proxy-tests