### PR TITLE
Update Maglev skills catalog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,7 @@ naim_enable_strict_warnings(naim-model-library-tests)
 add_executable(
   naim-controller-apply-state-tests
   controller/src/bundle/bundle_cli_service.cpp
+  controller/src/skills/maglev_workflow_skill_catalog.cpp
   controller/src/bundle/bundle_cli_service_tests.cpp
   controller/src/infra/controller_action.cpp
   controller/src/http/controller_http_transport.cpp
@@ -480,6 +481,7 @@ add_executable(
   controller/src/interaction/interaction_utf8_payload_sanitizer.cpp
   controller/src/interaction/interaction_service.cpp
   controller/src/plane/plane_dashboard_skills_summary_service.cpp
+  controller/src/skills/maglev_workflow_skill_catalog.cpp
   controller/src/skills/plane_skill_contextual_resolver_service.cpp
   controller/src/skills/plane_skills_target_resolver.cpp
   controller/src/skills/plane_skills_service.cpp
@@ -502,6 +504,7 @@ add_executable(
   controller/src/plane/plane_deletion_support.cpp
   controller/src/plane/plane_service.cpp
   controller/src/skills/plane_skill_contextual_resolver_service.cpp
+  controller/src/skills/maglev_workflow_skill_catalog.cpp
   controller/src/skills/plane_skill_catalog_service.cpp
   controller/src/skills/plane_skills_target_resolver.cpp
   controller/src/skills/plane_skills_service.cpp
@@ -1512,6 +1515,7 @@ add_executable(
   controller/src/scheduler/scheduler_view_service.cpp
   controller/src/plane/plane_service.cpp
   controller/src/skills/plane_skill_contextual_resolver_service.cpp
+  controller/src/skills/maglev_workflow_skill_catalog.cpp
   controller/src/skills/plane_skill_catalog_service.cpp
   controller/src/skills/plane_skills_target_resolver.cpp
   controller/src/skills/plane_skills_service.cpp

--- a/controller/include/read_model/state_aggregate_loader.h
+++ b/controller/include/read_model/state_aggregate_loader.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 
-#include "infra/controller_runtime_support_service.h"
 #include "observation/plane_observation_matcher.h"
 #include "plane/dashboard_service.h"
 #include "scheduler/scheduler_domain_service.h"
@@ -20,7 +19,6 @@ class StateAggregateLoader {
   StateAggregateLoader(
       const SchedulerDomainService& scheduler_domain_service,
       const SchedulerViewService& scheduler_view_service,
-      ControllerRuntimeSupportService runtime_support_service,
       int maximum_rebalance_iterations);
 
   RolloutActionsViewData LoadRolloutActionsViewData(
@@ -46,7 +44,6 @@ class StateAggregateLoader {
 
   const SchedulerDomainService& scheduler_domain_service_;
   const SchedulerViewService& scheduler_view_service_;
-  ControllerRuntimeSupportService runtime_support_service_;
   PlaneObservationMatcher plane_observation_matcher_;
   int maximum_rebalance_iterations_ = 1;
 };

--- a/controller/include/skills/maglev_workflow_skills.h
+++ b/controller/include/skills/maglev_workflow_skills.h
@@ -3,7 +3,6 @@
 #include <string>
 #include <vector>
 
-#include "naim/state/models.h"
 #include "naim/state/sqlite_store.h"
 
 namespace naim::controller {
@@ -16,159 +15,11 @@ struct MaglevWorkflowSkillDefinition {
   std::vector<std::string> match_terms;
 };
 
-inline const std::vector<MaglevWorkflowSkillDefinition>&
-MaglevWorkflowSkillDefinitions() {
-  static const std::vector<MaglevWorkflowSkillDefinition> definitions{
-      {
-          "maglev-client-workflow",
-          "Maglev client workflow",
-          "Guide Maglev client users through dialog-first local workflow.",
-          "Use this skill when the user asks how to work inside Maglev, which slash "
-          "commands are available, or how to avoid leaving the dialog for normal "
-          "actions. Treat the Maglev client as the user's primary workspace. Prefer "
-          "dialog commands such as /auth, /skills, /skill-add, /skill-delete, "
-          "/skill-use, /skill-clear, /client-sync, /kv, and /remember. Explain the "
-          "shortest local-first path and avoid sending the user to controller UI or "
-          "plane internals unless they ask for administration or recovery steps. "
-          "For skill import, /skill-add requires a relative or absolute path to a "
-          "skill JSON file; do not describe a pasted-JSON prompt flow unless the "
-          "client explicitly implements one.",
-          {
-              "maglev workflow",
-              "maglev client",
-              "dialog command",
-              "slash command",
-              "inside dialog",
-              "/auth",
-              "/skills",
-              "/skill-add",
-              "/skill-delete",
-              "/client-sync",
-              "workflow maglev",
-              "команды maglev",
-              "внутри диалога",
-              "слеш команды",
-              "клиент maglev",
-              "маглев workflow",
-          },
-      },
-      {
-          "maglev-client-knowledge-vault-local-first",
-          "Maglev local Knowledge Vault",
-          "Use Maglev's client-owned Knowledge Vault copy before remote plane APIs.",
-          "Use this skill when the user asks to remember, recall, search, cite, "
-          "delete, clean up, or reason over Knowledge Vault data from Maglev. The "
-          "normal request-time path is local-first: use the client-owned SQLite "
-          "Knowledge Vault projection and cite local knowledge_id or block_id when "
-          "available. Plane-owned Knowledge Vault APIs are bootstrap, sync, and "
-          "fallback channels. Use /remember for local writes, /kv status/search/"
-          "graph/delete/cleanup for local inspection and maintenance, and "
-          "/client-sync push or pull when remote reconciliation is needed.",
-          {
-              "maglev knowledge vault",
-              "local knowledge vault",
-              "client-owned knowledge",
-              "client owned knowledge",
-              "local-first knowledge",
-              "/remember",
-              "/kv",
-              "kv search",
-              "kv status",
-              "knowledge citations",
-              "local sqlite",
-              "локальный knowledge vault",
-              "локальная память",
-              "запомни",
-              "найди в памяти",
-              "цитаты knowledge",
-          },
-      },
-      {
-          "maglev-client-skills-factory-workflow",
-          "Maglev local skills workflow",
-          "Manage Maglev skills through the client-owned runtime and dialog commands.",
-          "Use this skill when the user asks to list, add, delete, select, clear, or "
-          "inspect skills from Maglev. Prefer the client-owned skills copy during "
-          "normal work. Use /skills to inspect local skills, /skill-add <path> to "
-          "import a skill JSON file, /skill-delete <name-or-id> to remove one, "
-          "/skill-use to pin a skill for the dialog, and /skill-clear to return to "
-          "automatic skill resolution. /skill-add accepts a relative or absolute "
-          "file path, not pasted JSON content. Treat the controller SkillsFactory "
-          "as the canonical bootstrap and sync source, not as the request-time selector.",
-          {
-              "maglev skills",
-              "local skills",
-              "client-owned skills",
-              "skill json",
-              "add skill",
-              "delete skill",
-              "remove skill",
-              "/skill-add",
-              "/skill-delete",
-              "/skill-use",
-              "/skill-clear",
-              "/skills-session",
-              "добавить скилл",
-              "удалить скилл",
-              "локальные скиллы",
-              "json скилла",
-          },
-      },
-      {
-          "maglev-client-sync-and-conflicts",
-          "Maglev sync and conflicts",
-          "Explain Maglev client sync, offline outbox, and conflict review behavior.",
-          "Use this skill when the user asks about Maglev bootstrap, sync status, "
-          "offline operation, outbox, conflicts, or why local state differs from the "
-          "plane. Maglev should use local state immediately after activation. Plane "
-          "sync pulls authorized Skills and Knowledge Vault data, pushes queued local "
-          "writes when reachable, and keeps conflicts for review rather than silently "
-          "overwriting remote changes. Recommend /client-sync status before diagnosis "
-          "and /client-sync pull or push only when the user wants reconciliation.",
-          {
-              "maglev sync",
-              "client sync",
-              "sync conflict",
-              "offline outbox",
-              "bootstrap maglev",
-              "client runtime status",
-              "/client-sync status",
-              "/client-sync pull",
-              "/client-sync push",
-              "conflict review",
-              "outbox",
-              "синхронизация maglev",
-              "конфликт синхронизации",
-              "оффлайн очередь",
-              "статус синхронизации",
-          },
-      },
-  };
-  return definitions;
-}
-
-inline std::vector<std::string> MaglevWorkflowSkillIds() {
-  std::vector<std::string> ids;
-  for (const auto& definition : MaglevWorkflowSkillDefinitions()) {
-    ids.push_back(definition.id);
-  }
-  return ids;
-}
-
-inline void EnsureMaglevWorkflowSkillRecords(naim::ControllerStore& store) {
-  for (const auto& definition : MaglevWorkflowSkillDefinitions()) {
-    store.UpsertSkillsFactorySkill(naim::SkillsFactorySkillRecord{
-        definition.id,
-        definition.name,
-        "maglev",
-        definition.description,
-        definition.content,
-        definition.match_terms,
-        false,
-        "",
-        "",
-    });
-  }
-}
+class MaglevWorkflowSkillCatalog final {
+ public:
+  static const std::vector<MaglevWorkflowSkillDefinition>& Definitions();
+  static std::vector<std::string> SkillIds();
+  static void EnsureRecords(naim::ControllerStore& store);
+};
 
 }  // namespace naim::controller

--- a/controller/src/app/controller_plane_component_factory.cpp
+++ b/controller/src/app/controller_plane_component_factory.cpp
@@ -240,7 +240,6 @@ ControllerPlaneComponentFactory::StateAggregateLoaderInstance() const {
   static const StateAggregateLoader state_aggregate_loader(
       SchedulerDomainServiceInstance(),
       SchedulerViewServiceInstance(),
-      RuntimeSupportService(),
       Defaults().MaximumRebalanceIterationsPerGeneration());
   return state_aggregate_loader;
 }

--- a/controller/src/app/controller_read_model_component_factory.cpp
+++ b/controller/src/app/controller_read_model_component_factory.cpp
@@ -95,7 +95,6 @@ ControllerReadModelComponentFactory::StateAggregateLoaderInstance() const {
   static const StateAggregateLoader state_aggregate_loader(
       SchedulerDomainServiceInstance(),
       SchedulerViewServiceInstance(),
-      RuntimeSupportService(),
       Defaults().MaximumRebalanceIterationsPerGeneration());
   return state_aggregate_loader;
 }

--- a/controller/src/app/controller_scheduler_component_factory.cpp
+++ b/controller/src/app/controller_scheduler_component_factory.cpp
@@ -91,7 +91,6 @@ ControllerSchedulerComponentFactory::StateAggregateLoaderInstance() const {
   static const StateAggregateLoader state_aggregate_loader(
       SchedulerDomainServiceInstance(),
       SchedulerViewServiceInstance(),
-      RuntimeSupportService(),
       Defaults().MaximumRebalanceIterationsPerGeneration());
   return state_aggregate_loader;
 }

--- a/controller/src/bundle/bundle_cli_service.cpp
+++ b/controller/src/bundle/bundle_cli_service.cpp
@@ -461,7 +461,7 @@ int BundleCliService::ApplyDesiredState(
   desired_state_policy_service_.ResolveDesiredStateDynamicPlacements(
       store, &effective_desired_state);
   EnsureKnowledgeVaultCommonSkills(store, &effective_desired_state);
-  EnsureMaglevWorkflowSkillRecords(store);
+  MaglevWorkflowSkillCatalog::EnsureRecords(store);
   desired_state_policy_service_.ValidateDesiredStateForControllerAdmission(
       store,
       effective_desired_state);

--- a/controller/src/plane/dashboard_service_tests.cpp
+++ b/controller/src/plane/dashboard_service_tests.cpp
@@ -271,7 +271,6 @@ naim::controller::DashboardService MakeDashboardService() {
   static const naim::controller::StateAggregateLoader state_aggregate_loader(
       scheduler_domain_service,
       scheduler_view_service,
-      runtime_support_service,
       1);
   static const naim::controller::DashboardService dashboard_service(
       naim::controller::DashboardService::Deps{

--- a/controller/src/plane/plane_lifecycle_support.cpp
+++ b/controller/src/plane/plane_lifecycle_support.cpp
@@ -20,7 +20,7 @@ void ControllerPlaneLifecycleSupport::PrepareDesiredState(
   desired_state_policy_service_.ApplyRegisteredHostExecutionModes(store, desired_state);
   desired_state_policy_service_.ResolveDesiredStateDynamicPlacements(store, desired_state);
   EnsureKnowledgeVaultCommonSkills(store, desired_state);
-  EnsureMaglevWorkflowSkillRecords(store);
+  MaglevWorkflowSkillCatalog::EnsureRecords(store);
   desired_state_policy_service_.ValidateDesiredStateForControllerAdmission(
       store,
       *desired_state);

--- a/controller/src/read_model/state_aggregate_loader.cpp
+++ b/controller/src/read_model/state_aggregate_loader.cpp
@@ -1,18 +1,15 @@
 #include "read_model/state_aggregate_loader.h"
 
 #include <set>
-#include <utility>
 
 namespace naim::controller {
 
 StateAggregateLoader::StateAggregateLoader(
     const SchedulerDomainService& scheduler_domain_service,
     const SchedulerViewService& scheduler_view_service,
-    ControllerRuntimeSupportService runtime_support_service,
     int maximum_rebalance_iterations)
     : scheduler_domain_service_(scheduler_domain_service),
       scheduler_view_service_(scheduler_view_service),
-      runtime_support_service_(std::move(runtime_support_service)),
       maximum_rebalance_iterations_(maximum_rebalance_iterations) {}
 
 SchedulerRuntimeView StateAggregateLoader::LoadSchedulerRuntimeView(

--- a/controller/src/skills/maglev_workflow_skill_catalog.cpp
+++ b/controller/src/skills/maglev_workflow_skill_catalog.cpp
@@ -1,0 +1,241 @@
+#include "skills/maglev_workflow_skills.h"
+
+namespace naim::controller {
+
+const std::vector<MaglevWorkflowSkillDefinition>&
+MaglevWorkflowSkillCatalog::Definitions() {
+  static const std::vector<MaglevWorkflowSkillDefinition> definitions{
+      {
+          "maglev-client-workflow",
+          "Maglev client workflow",
+          "Guide Maglev client users through dialog-first local workflow.",
+          "Use this skill when the user asks how to work inside Maglev, which slash "
+          "commands are available, or how to avoid leaving the dialog for normal "
+          "actions. Treat the Maglev client as the user's primary workspace. Prefer "
+          "dialog commands such as /auth, /skills, /skill-add, /skill-delete, "
+          "/skill-use, /skill-clear, /client-sync, /kv, and /remember. Explain the "
+          "shortest local-first path and avoid sending the user to controller UI or "
+          "plane internals unless they ask for administration or recovery steps. "
+          "For skill import, /skill-add requires a relative or absolute path to a "
+          "skill JSON file; do not describe a pasted-JSON prompt flow unless the "
+          "client explicitly implements one.",
+          {
+              "maglev workflow",
+              "maglev client",
+              "dialog command",
+              "slash command",
+              "inside dialog",
+              "/auth",
+              "/skills",
+              "/skill-add",
+              "/skill-delete",
+              "/client-sync",
+              "workflow maglev",
+              "команды maglev",
+              "внутри диалога",
+              "слеш команды",
+              "клиент maglev",
+              "маглев workflow",
+          },
+      },
+      {
+          "maglev-client-knowledge-vault-local-first",
+          "Maglev local Knowledge Vault",
+          "Use Maglev's client-owned Knowledge Vault copy before remote plane APIs.",
+          "Use this skill when the user asks to remember, recall, search, cite, "
+          "delete, clean up, or reason over Knowledge Vault data from Maglev. The "
+          "normal request-time path is local-first: use the client-owned SQLite "
+          "Knowledge Vault projection and cite local knowledge_id or block_id when "
+          "available. Plane-owned Knowledge Vault APIs are bootstrap, sync, and "
+          "fallback channels. Use /remember for local writes, /kv status/search/"
+          "graph/delete/cleanup for local inspection and maintenance, and "
+          "/client-sync push or pull when remote reconciliation is needed.",
+          {
+              "maglev knowledge vault",
+              "local knowledge vault",
+              "client-owned knowledge",
+              "client owned knowledge",
+              "local-first knowledge",
+              "/remember",
+              "/kv",
+              "kv search",
+              "kv status",
+              "knowledge citations",
+              "local sqlite",
+              "локальный knowledge vault",
+              "локальная память",
+              "запомни",
+              "найди в памяти",
+              "цитаты knowledge",
+          },
+      },
+      {
+          "maglev-client-skills-factory-workflow",
+          "Maglev local skills workflow",
+          "Manage Maglev skills through the client-owned runtime and dialog commands.",
+          "Use this skill when the user asks to list, add, delete, select, clear, or "
+          "inspect skills from Maglev. Prefer the client-owned skills copy during "
+          "normal work. Use /skills to inspect local skills, /skill-add <path> to "
+          "import a skill JSON file, /skill-delete <name-or-id> to remove one, "
+          "/skill-use to pin a skill for the dialog, and /skill-clear to return to "
+          "automatic skill resolution. /skill-add accepts a relative or absolute "
+          "file path, not pasted JSON content. Treat the controller SkillsFactory "
+          "as the canonical bootstrap and sync source, not as the request-time selector.",
+          {
+              "maglev skills",
+              "local skills",
+              "client-owned skills",
+              "skill json",
+              "add skill",
+              "delete skill",
+              "remove skill",
+              "/skill-add",
+              "/skill-delete",
+              "/skill-use",
+              "/skill-clear",
+              "/skills-session",
+              "добавить скилл",
+              "удалить скилл",
+              "локальные скиллы",
+              "json скилла",
+          },
+      },
+      {
+          "maglev-client-sync-and-conflicts",
+          "Maglev sync and conflicts",
+          "Explain Maglev client sync, offline outbox, and conflict review behavior.",
+          "Use this skill when the user asks about Maglev bootstrap, sync status, "
+          "offline operation, outbox, conflicts, or why local state differs from the "
+          "plane. Maglev should use local state immediately after activation. Plane "
+          "sync pulls authorized Skills and Knowledge Vault data, pushes queued local "
+          "writes when reachable, and keeps conflicts for review rather than silently "
+          "overwriting remote changes. Recommend /client-sync status before diagnosis "
+          "and /client-sync pull or push only when the user wants reconciliation.",
+          {
+              "maglev sync",
+              "client sync",
+              "sync conflict",
+              "offline outbox",
+              "bootstrap maglev",
+              "client runtime status",
+              "/client-sync status",
+              "/client-sync pull",
+              "/client-sync push",
+              "conflict review",
+              "outbox",
+              "синхронизация maglev",
+              "конфликт синхронизации",
+              "оффлайн очередь",
+              "статус синхронизации",
+          },
+      },
+      {
+          "maglev-secure-browsing-local-runtime",
+          "Maglev Secure Browsing",
+          "Use Maglev's local isolated browsing runtime for web research.",
+          "Use this skill when the user asks Maglev to search the web, fetch a page, "
+          "summarize a URL, inspect a JavaScript-heavy page, or cite external web "
+          "sources. Secure Browsing is a client-owned Maglev module, not a controller "
+          "runtime container. Prefer local isolated browsing commands and artifacts; "
+          "fall back to plane or controller channels only for bootstrap, policy, or "
+          "recovery. For JS sites, use the render-capable isolated browsing path and "
+          "report if the page requires login, blocks automation, or cannot be cited.",
+          {
+              "maglev secure browsing",
+              "isolated browsing",
+              "safe browsing",
+              "web research",
+              "search web",
+              "fetch url",
+              "javascript page",
+              "render page",
+              "x.com",
+              "browser isolation",
+              "безопасный браузинг",
+              "поиск в интернете",
+              "изолированный браузер",
+              "js сайт",
+          },
+      },
+      {
+          "maglev-plane-voice-capability",
+          "Maglev plane voice capability",
+          "Route Maglev voice recognition through the plane-owned Voice Listener.",
+          "Use this skill when the user asks about voice input, speech recognition, "
+          "wake phrase behavior, ASR latency, microphone flow, or voice commands in "
+          "Maglev. Voice recognition is a plane capability for maglev-service. The "
+          "client should call the plane Voice Listener API when voice is enabled, "
+          "surface clear status and errors in the dialog, and avoid describing a "
+          "separate local ASR container as the normal architecture.",
+          {
+              "maglev voice",
+              "voice command",
+              "speech recognition",
+              "asr",
+              "voice listener",
+              "wake phrase",
+              "microphone",
+              "распознавание речи",
+              "голосовые команды",
+              "voice module",
+              "whisper",
+          },
+      },
+      {
+          "maglev-code-cicd-agent",
+          "Maglev code and CI/CD agent",
+          "Use Maglev as a coding assistant with CI/CD control and administration.",
+          "Use this skill when the user asks Maglev to inspect a codebase, plan code "
+          "changes, edit files, standardize code, run tests, inspect CI status, read "
+          "CI logs, rerun or cancel jobs, plan deployments, or prepare rollback. "
+          "Prefer dialog-first commands such as /code plan, /code edit, /code "
+          "standardize, /code test, /ci status, /ci logs, /ci rerun, /ci cancel, "
+          "/deploy status, /deploy plan, and /deploy rollback. Keep destructive "
+          "or remote actions behind Maglev tool policy and explicit approval gates.",
+          {
+              "maglev code",
+              "coding agent",
+              "ci status",
+              "ci logs",
+              "ci/cd",
+              "deploy plan",
+              "rollback",
+              "/code",
+              "/ci",
+              "/deploy",
+              "standardize code",
+              "run tests",
+              "кодинг агент",
+              "проверить ci",
+              "деплой",
+          },
+      },
+  };
+  return definitions;
+}
+
+std::vector<std::string> MaglevWorkflowSkillCatalog::SkillIds() {
+  std::vector<std::string> ids;
+  for (const auto& definition : Definitions()) {
+    ids.push_back(definition.id);
+  }
+  return ids;
+}
+
+void MaglevWorkflowSkillCatalog::EnsureRecords(naim::ControllerStore& store) {
+  for (const auto& definition : Definitions()) {
+    store.UpsertSkillsFactorySkill(naim::SkillsFactorySkillRecord{
+        definition.id,
+        definition.name,
+        "maglev",
+        definition.description,
+        definition.content,
+        definition.match_terms,
+        false,
+        "",
+        "",
+    });
+  }
+}
+
+}  // namespace naim::controller

--- a/controller/src/skills/plane_skills_service_tests.cpp
+++ b/controller/src/skills/plane_skills_service_tests.cpp
@@ -1519,7 +1519,7 @@ std::string MakeInvalidUtf8Text() {
 json BuildMaglevWorkflowRuntimeSkills() {
   json skills = json::array();
   for (const auto& definition :
-       naim::controller::MaglevWorkflowSkillDefinitions()) {
+       naim::controller::MaglevWorkflowSkillCatalog::Definitions()) {
     skills.push_back(json{
         {"id", definition.id},
         {"name", definition.name},
@@ -2565,7 +2565,7 @@ int main() {
     {
       SkillRuntimeTestServer runtime(BuildMaglevWorkflowRuntimeSkills());
       auto desired_state =
-          BuildDesiredState("maglev-service", naim::controller::MaglevWorkflowSkillIds());
+          BuildDesiredState("maglev-service", naim::controller::MaglevWorkflowSkillCatalog::SkillIds());
       desired_state.instances =
           BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
 
@@ -2583,7 +2583,7 @@ int main() {
                                "Какие slash commands есть внутри Maglev dialog workflow?"}}})}});
       Expect(
           selection.mode == "contextual" &&
-              selection.candidate_count == 4 &&
+              selection.candidate_count == 7 &&
               std::find(
                   selection.selected_skill_ids.begin(),
                   selection.selected_skill_ids.end(),
@@ -2596,7 +2596,7 @@ int main() {
     {
       SkillRuntimeTestServer runtime(BuildMaglevWorkflowRuntimeSkills());
       auto desired_state =
-          BuildDesiredState("maglev-service", naim::controller::MaglevWorkflowSkillIds());
+          BuildDesiredState("maglev-service", naim::controller::MaglevWorkflowSkillCatalog::SkillIds());
       desired_state.instances =
           BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
 
@@ -2615,7 +2615,7 @@ int main() {
                                "Knowledge Vault с цитатами."}}})}});
       Expect(
           selection.mode == "contextual" &&
-              selection.candidate_count == 4 &&
+              selection.candidate_count == 7 &&
               std::find(
                   selection.selected_skill_ids.begin(),
                   selection.selected_skill_ids.end(),
@@ -2623,6 +2623,101 @@ int main() {
                   selection.selected_skill_ids.end(),
           "resolver should select Maglev local Knowledge Vault skill");
       std::cout << "ok: contextual-resolver-selects-maglev-local-kv-skill" << '\n';
+    }
+
+    {
+      SkillRuntimeTestServer runtime(BuildMaglevWorkflowRuntimeSkills());
+      auto desired_state =
+          BuildDesiredState("maglev-service", naim::controller::MaglevWorkflowSkillCatalog::SkillIds());
+      desired_state.instances =
+          BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
+
+      naim::controller::PlaneInteractionResolution resolution;
+      resolution.desired_state = desired_state;
+
+      const auto selection =
+          naim::controller::PlaneSkillContextualResolverService().Resolve(
+              "",
+              resolution,
+              json{{"messages",
+                    json::array(
+                        {json{{"role", "user"},
+                              {"content",
+                               "Найди информацию в интернете через isolated secure browsing "
+                               "и открой JS страницу вроде x.com."}}})}});
+      Expect(
+          selection.mode == "contextual" &&
+              selection.candidate_count == 7 &&
+              std::find(
+                  selection.selected_skill_ids.begin(),
+                  selection.selected_skill_ids.end(),
+                  "maglev-secure-browsing-local-runtime") !=
+                  selection.selected_skill_ids.end(),
+          "resolver should select Maglev local Secure Browsing skill");
+      std::cout << "ok: contextual-resolver-selects-maglev-secure-browsing-skill" << '\n';
+    }
+
+    {
+      SkillRuntimeTestServer runtime(BuildMaglevWorkflowRuntimeSkills());
+      auto desired_state =
+          BuildDesiredState("maglev-service", naim::controller::MaglevWorkflowSkillCatalog::SkillIds());
+      desired_state.instances =
+          BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
+
+      naim::controller::PlaneInteractionResolution resolution;
+      resolution.desired_state = desired_state;
+
+      const auto selection =
+          naim::controller::PlaneSkillContextualResolverService().Resolve(
+              "",
+              resolution,
+              json{{"messages",
+                    json::array(
+                        {json{{"role", "user"},
+                              {"content",
+                               "Проверь voice commands, ASR latency и wake phrase в maglev."}}})}});
+      Expect(
+          selection.mode == "contextual" &&
+              selection.candidate_count == 7 &&
+              std::find(
+                  selection.selected_skill_ids.begin(),
+                  selection.selected_skill_ids.end(),
+                  "maglev-plane-voice-capability") !=
+                  selection.selected_skill_ids.end(),
+          "resolver should select Maglev plane voice capability skill");
+      std::cout << "ok: contextual-resolver-selects-maglev-voice-skill" << '\n';
+    }
+
+    {
+      SkillRuntimeTestServer runtime(BuildMaglevWorkflowRuntimeSkills());
+      auto desired_state =
+          BuildDesiredState("maglev-service", naim::controller::MaglevWorkflowSkillCatalog::SkillIds());
+      desired_state.instances =
+          BuildDesiredStateWithSkillsPort("127.0.0.1", runtime.port()).instances;
+
+      naim::controller::PlaneInteractionResolution resolution;
+      resolution.desired_state = desired_state;
+
+      const auto selection =
+          naim::controller::PlaneSkillContextualResolverService().Resolve(
+              "",
+              resolution,
+              json{{"messages",
+                    json::array(
+                        {json{{"role", "user"},
+                              {"content",
+                               "Используй Maglev как coding agent: проверь CI logs, "
+                               "запусти tests и подготовь deploy rollback plan."}}})}});
+      Expect(
+          selection.mode == "contextual" &&
+              selection.candidate_count == 7 &&
+              std::find(
+                  selection.selected_skill_ids.begin(),
+                  selection.selected_skill_ids.end(),
+                  "maglev-code-cicd-agent") !=
+                  selection.selected_skill_ids.end(),
+          "resolver should select Maglev code and CI/CD skill");
+      std::cout << "ok: contextual-resolver-selects-maglev-code-cicd-skill" << '\n';
     }
 
     {

--- a/controller/src/skills/skills_factory_service.cpp
+++ b/controller/src/skills/skills_factory_service.cpp
@@ -257,7 +257,7 @@ nlohmann::json SkillsFactoryService::BuildListPayload(const std::string& db_path
   store.Initialize();
   EnsureCodeAgentCommonSkillRecords(store);
   EnsureKnowledgeVaultCommonSkillRecords(store);
-  EnsureMaglevWorkflowSkillRecords(store);
+  MaglevWorkflowSkillCatalog::EnsureRecords(store);
   json items = json::array();
   for (const auto& skill : store.LoadSkillsFactorySkills()) {
     items.push_back(BuildSkillPayload(db_path, skill));
@@ -276,7 +276,7 @@ nlohmann::json SkillsFactoryService::BuildSkillPayload(
   store.Initialize();
   EnsureCodeAgentCommonSkillRecords(store);
   EnsureKnowledgeVaultCommonSkillRecords(store);
-  EnsureMaglevWorkflowSkillRecords(store);
+  MaglevWorkflowSkillCatalog::EnsureRecords(store);
   const auto skill = store.LoadSkillsFactorySkill(skill_id);
   if (!skill.has_value()) {
     throw std::runtime_error("skill '" + skill_id + "' not found");

--- a/controller/src/skills/skills_factory_service_tests.cpp
+++ b/controller/src/skills/skills_factory_service_tests.cpp
@@ -135,8 +135,12 @@ int main() {
             return fallback;
           });
       const auto payload = factory_service.BuildListPayload(db_path.string());
+      const auto expected_seeded_skill_count =
+          1 + naim::controller::CodeAgentCommonSkillIds().size() +
+          naim::controller::KnowledgeVaultCommonSkillIds().size() +
+          naim::controller::MaglevWorkflowSkillCatalog::SkillIds().size();
       Expect(
-          payload.at("skills").size() == 24,
+          payload.at("skills").size() == expected_seeded_skill_count,
           "factory list should contain seeded built-in skills");
       Expect(payload.at("groups").size() == 0, "factory list should start without explicit groups");
       const auto& item = FindSkillById(payload.at("skills"), "skill-alpha");
@@ -183,6 +187,17 @@ int main() {
           store.LoadSkillsFactorySkill("maglev-client-knowledge-vault-local-first")
               .has_value(),
           "Maglev Knowledge Vault skill record should be seeded");
+      Expect(
+          store.LoadSkillsFactorySkill("maglev-secure-browsing-local-runtime")
+              .has_value(),
+          "Maglev Secure Browsing skill record should be seeded");
+      Expect(
+          store.LoadSkillsFactorySkill("maglev-plane-voice-capability")
+              .has_value(),
+          "Maglev voice capability skill record should be seeded");
+      Expect(
+          store.LoadSkillsFactorySkill("maglev-code-cicd-agent").has_value(),
+          "Maglev code and CI/CD skill record should be seeded");
       const auto& remote_ops_item = FindSkillById(payload.at("skills"), "code-agent-remote-ops");
       Expect(
           remote_ops_item.at("group_path").get<std::string>() ==

--- a/docs/skills-factory.md
+++ b/docs/skills-factory.md
@@ -155,12 +155,17 @@ plane:
 - `maglev-client-knowledge-vault-local-first`
 - `maglev-client-skills-factory-workflow`
 - `maglev-client-sync-and-conflicts`
+- `maglev-secure-browsing-local-runtime`
+- `maglev-plane-voice-capability`
+- `maglev-code-cicd-agent`
 
 These records use the `maglev` group path and are intended to be attached explicitly by
 the Maglev desired state, not auto-attached to every LLM plane. They steer the model to
 treat Maglev as a dialog-first client with client-owned Skills and Knowledge Vault state.
 The normal request-time path is local-first; controller and plane APIs are bootstrap,
-sync, administration, and fallback channels.
+sync, administration, and fallback channels. Secure Browsing is local to the client,
+Voice Listener remains a plane capability, and CI/CD or deployment operations stay behind
+Maglev's local tool policy and approval gates.
 
 ## Operator UI
 


### PR DESCRIPTION
## Summary
- move Maglev workflow skill seeding into MaglevWorkflowSkillCatalog
- seed Maglev Secure Browsing, plane Voice Listener, and code/CI/CD skills
- remove unused StateAggregateLoader runtime support dependency

## Validation
- cmake --build build/codex-debug --target naim-skills-factory-tests
- ./build/codex-debug/naim-skills-factory-tests
- cmake --build build/codex-debug --target naim-plane-skills-tests
- ./build/codex-debug/naim-plane-skills-tests
- cmake --build build/codex-debug --target naim-controller-apply-state-tests
- ./build/codex-debug/naim-controller-apply-state-tests
- cmake --build build/codex-debug --target naim-dashboard-service-tests
- ./build/codex-debug/naim-dashboard-service-tests
- cmake --build build/codex-debug --target naim-controller
- git diff --check