### PR TITLE
Add OmniVoice Voice Maker plane feature

### DIFF
--- a/common/include/naim/state/desired_state_v2_projector.h
+++ b/common/include/naim/state/desired_state_v2_projector.h
@@ -32,6 +32,7 @@ class DesiredStateV2Projector final {
   void ProjectBrowsing();
   void ProjectKnowledge();
   void ProjectVoiceListener();
+  void ProjectVoiceMaker();
   void ProjectResources();
 
   bool ShouldEmitTopology() const;
@@ -58,6 +59,7 @@ class DesiredStateV2Projector final {
   const InstanceSpec* skills_instance_ = nullptr;
   const InstanceSpec* browsing_instance_ = nullptr;
   const InstanceSpec* voice_module_instance_ = nullptr;
+  const InstanceSpec* voice_maker_instance_ = nullptr;
   std::vector<const InstanceSpec*> worker_instances_;
   const DiskSpec* shared_disk_ = nullptr;
 };

--- a/common/include/naim/state/desired_state_v2_projector_support.h
+++ b/common/include/naim/state/desired_state_v2_projector_support.h
@@ -19,6 +19,7 @@ class DesiredStateV2ProjectorSupport {
   static constexpr int kDefaultSkillsPrivateDiskSizeGb = 1;
   static constexpr int kDefaultWebGatewayPrivateDiskSizeGb = 1;
   static constexpr int kDefaultVoiceModulePrivateDiskSizeGb = 1;
+  static constexpr int kDefaultVoiceMakerPrivateDiskSizeGb = 8;
 
   static constexpr std::string_view kDefaultInferImage = "naim/infer-runtime:dev";
   static constexpr std::string_view kDefaultWorkerImage = "naim/worker-runtime:dev";
@@ -26,6 +27,7 @@ class DesiredStateV2ProjectorSupport {
   static constexpr std::string_view kDefaultWebGatewayImage =
       "naim/webgateway-runtime:dev";
   static constexpr std::string_view kDefaultVoiceModuleImage = "naim/voice-module:dev";
+  static constexpr std::string_view kDefaultVoiceMakerImage = "naim/voice-maker:dev";
 
   static constexpr std::string_view kDefaultInferCommand =
       "/runtime/bin/naim-inferctl container-boot";
@@ -37,6 +39,8 @@ class DesiredStateV2ProjectorSupport {
       "/runtime/bin/naim-webgatewayd";
   static constexpr std::string_view kDefaultVoiceModuleCommand =
       "/runtime/bin/naim-voice-moduled";
+  static constexpr std::string_view kDefaultVoiceMakerCommand =
+      "python3 /runtime/voice-maker/server.py";
 
   static nlohmann::json ProjectServiceStart(
       const InstanceSpec& instance,

--- a/common/include/naim/state/desired_state_v2_renderer.h
+++ b/common/include/naim/state/desired_state_v2_renderer.h
@@ -32,6 +32,7 @@ class DesiredStateV2Renderer final {
   void RenderWebGatewayInstance();
   void RenderInteractionInstance();
   void RenderVoiceModuleInstance();
+  void RenderVoiceMakerInstance();
 
   bool InferEnabled() const;
   int InferReplicaCount() const;
@@ -48,6 +49,8 @@ class DesiredStateV2Renderer final {
   std::optional<std::string> ResolveWorkerGpuDevice(int worker_index) const;
   const nlohmann::json& VoiceModuleResources() const;
   bool VoiceModuleGpuEnabled() const;
+  const nlohmann::json& VoiceMakerResources() const;
+  bool VoiceMakerGpuEnabled() const;
   std::optional<std::string> ResolveLegacyServiceNodeName(
       const nlohmann::json& service_json,
       const char* service_name) const;
@@ -66,6 +69,7 @@ class DesiredStateV2Renderer final {
   std::string BuildWebGatewayInstanceName() const;
   std::string BuildInteractionInstanceName() const;
   std::string BuildVoiceModuleInstanceName() const;
+  std::string BuildVoiceMakerInstanceName() const;
   int BuildInferApiPort(int infer_index) const;
   int BuildInferGatewayPort(int infer_index) const;
   int BuildInferLlamaPort(int infer_index) const;
@@ -73,6 +77,7 @@ class DesiredStateV2Renderer final {
   int BuildWebGatewayHostPort() const;
   int BuildInteractionHostPort() const;
   int BuildVoiceModuleHostPort() const;
+  int BuildVoiceMakerHostPort() const;
   std::string BuildReplicaUpstreams(const std::vector<InstanceSpec>& infer_instances) const;
   std::string InferInstanceNameForWorker(int worker_index) const;
   std::string BuildPlaneSharedHostPath() const;
@@ -113,6 +118,7 @@ class DesiredStateV2Renderer final {
   nlohmann::json resources_json_;
   nlohmann::json worker_resources_json_;
   nlohmann::json voice_module_resources_json_;
+  nlohmann::json voice_maker_resources_json_;
   nlohmann::json app_json_;
   std::vector<nlohmann::json> apps_json_;
   nlohmann::json skills_json_;

--- a/common/include/naim/state/models.h
+++ b/common/include/naim/state/models.h
@@ -16,6 +16,7 @@ enum class InstanceRole {
   Browsing,
   Interaction,
   VoiceModule,
+  VoiceMaker,
 };
 
 enum class DiskKind {
@@ -27,6 +28,7 @@ enum class DiskKind {
   BrowsingPrivate,
   InteractionPrivate,
   VoiceModulePrivate,
+  VoiceMakerPrivate,
 };
 
 inline bool IsPrivateDiskKind(DiskKind kind) {
@@ -36,7 +38,8 @@ inline bool IsPrivateDiskKind(DiskKind kind) {
          kind == DiskKind::SkillsPrivate ||
          kind == DiskKind::BrowsingPrivate ||
          kind == DiskKind::InteractionPrivate ||
-         kind == DiskKind::VoiceModulePrivate;
+         kind == DiskKind::VoiceModulePrivate ||
+         kind == DiskKind::VoiceMakerPrivate;
 }
 
 inline bool IsNodeLocalDiskKind(DiskKind kind) {
@@ -50,7 +53,8 @@ inline bool InstanceNeedsSharedDiskMount(InstanceRole role) {
          role == InstanceRole::Skills ||
          role == InstanceRole::Browsing ||
          role == InstanceRole::Interaction ||
-         role == InstanceRole::VoiceModule;
+         role == InstanceRole::VoiceModule ||
+         role == InstanceRole::VoiceMaker;
 }
 
 inline bool InstanceNeedsPrivateDisk(InstanceRole role) {
@@ -59,7 +63,8 @@ inline bool InstanceNeedsPrivateDisk(InstanceRole role) {
          role == InstanceRole::Skills ||
          role == InstanceRole::Browsing ||
          role == InstanceRole::Interaction ||
-         role == InstanceRole::VoiceModule;
+         role == InstanceRole::VoiceModule ||
+         role == InstanceRole::VoiceMaker;
 }
 
 struct PublishedPort {
@@ -360,6 +365,16 @@ struct VoiceListenerFeatureSpec {
   std::optional<std::string> image;
 };
 
+struct VoiceMakerFeatureSpec {
+  bool enabled = false;
+  std::string language = "auto";
+  std::string voice_mode = "design";
+  std::string instruct = "neutral, clear voice, medium pitch, calm style";
+  std::string output_format = "wav";
+  AppModelMountSpec model;
+  std::optional<std::string> image;
+};
+
 struct SecuredConnectionFeatureSpec {
   bool enabled = false;
   std::vector<std::string> user_ids;
@@ -391,6 +406,7 @@ struct DesiredState {
   std::optional<TurboQuantFeatureSpec> turboquant;
   std::optional<ContextCompressionFeatureSpec> context_compression;
   std::optional<VoiceListenerFeatureSpec> voice_listener;
+  std::optional<VoiceMakerFeatureSpec> voice_maker;
   std::optional<SecuredConnectionFeatureSpec> secured_connection;
   std::optional<ExternalAppHostConfig> app_host;
   InferenceRuntimeSettings inference;

--- a/common/src/planning/planner.cpp
+++ b/common/src/planning/planner.cpp
@@ -267,18 +267,24 @@ ComposeService BuildComposeService(
     service.environment["NVIDIA_DRIVER_CAPABILITIES"] = "compute,utility";
     service.security_opts.push_back("apparmor=unconfined");
   }
-  service.healthcheck = instance.role == InstanceRole::Infer
-                            ? "CMD-SHELL /runtime/infer/inferctl.sh probe-url "
-                              "http://127.0.0.1:$${NAIM_GATEWAY_PORT:-80}/health || "
-                              "/runtime/infer/inferctl.sh probe-url "
-                              "http://127.0.0.1:$${NAIM_INFERENCE_PORT:-8000}/health"
-                            : (instance.role == InstanceRole::App
-                                   ? "CMD-SHELL curl -fsS http://127.0.0.1:$${PORT:-8080}/health >/dev/null"
-                                   : (instance.role == InstanceRole::VoiceModule
-                                          ? "CMD-SHELL curl -fsS http://127.0.0.1:$${NAIM_VOICE_MODULE_PORT:-18140}/health >/dev/null"
-                                          : (instance.role == InstanceRole::Skills
-                                                 ? "CMD-SHELL test -f /tmp/naim-ready"
-                                                 : "CMD-SHELL test -f /tmp/naim-ready")));
+  if (instance.role == InstanceRole::Infer) {
+    service.healthcheck =
+        "CMD-SHELL /runtime/infer/inferctl.sh probe-url "
+        "http://127.0.0.1:$${NAIM_GATEWAY_PORT:-80}/health || "
+        "/runtime/infer/inferctl.sh probe-url "
+        "http://127.0.0.1:$${NAIM_INFERENCE_PORT:-8000}/health";
+  } else if (instance.role == InstanceRole::App) {
+    service.healthcheck =
+        "CMD-SHELL curl -fsS http://127.0.0.1:$${PORT:-8080}/health >/dev/null";
+  } else if (instance.role == InstanceRole::VoiceModule) {
+    service.healthcheck =
+        "CMD-SHELL curl -fsS http://127.0.0.1:$${NAIM_VOICE_MODULE_PORT:-18140}/health >/dev/null";
+  } else if (instance.role == InstanceRole::VoiceMaker) {
+    service.healthcheck =
+        "CMD-SHELL curl -fsS http://127.0.0.1:$${NAIM_VOICE_MAKER_PORT:-18150}/health >/dev/null";
+  } else {
+    service.healthcheck = "CMD-SHELL test -f /tmp/naim-ready";
+  }
   if (instance.role == InstanceRole::Infer) {
     const int infer_api_port = InferApiPort(state, instance);
     const int infer_gateway_port = InferGatewayPort(state, instance);
@@ -380,6 +386,8 @@ std::string ToString(InstanceRole role) {
       return "interaction";
     case InstanceRole::VoiceModule:
       return "voice-module";
+    case InstanceRole::VoiceMaker:
+      return "voice-maker";
   }
   return "unknown";
 }
@@ -402,6 +410,8 @@ std::string ToString(DiskKind kind) {
       return "interaction-private";
     case DiskKind::VoiceModulePrivate:
       return "voice-module-private";
+    case DiskKind::VoiceMakerPrivate:
+      return "voice-maker-private";
   }
   return "unknown";
 }

--- a/common/src/state/desired_state_sqlite_codec.cpp
+++ b/common/src/state/desired_state_sqlite_codec.cpp
@@ -446,6 +446,9 @@ DiskKind DesiredStateSqliteCodec::ParseDiskKind(const std::string& value) {
   if (value == "voice-module-private") {
     return DiskKind::VoiceModulePrivate;
   }
+  if (value == "voice-maker-private") {
+    return DiskKind::VoiceMakerPrivate;
+  }
   throw std::runtime_error("unknown disk kind '" + value + "'");
 }
 
@@ -473,6 +476,9 @@ InstanceRole DesiredStateSqliteCodec::ParseInstanceRole(const std::string& value
   }
   if (value == "voice-module") {
     return InstanceRole::VoiceModule;
+  }
+  if (value == "voice-maker") {
+    return InstanceRole::VoiceMaker;
   }
   throw std::runtime_error("unknown instance role '" + value + "'");
 }

--- a/common/src/state/desired_state_v2_projector.cpp
+++ b/common/src/state/desired_state_v2_projector.cpp
@@ -21,6 +21,8 @@ using ProjectorSupport = DesiredStateV2ProjectorSupport;
 constexpr int kDefaultSharedDiskSizeGb = ProjectorSupport::kDefaultSharedDiskSizeGb;
 constexpr double kDefaultVoiceModuleGpuFraction = 0.2;
 constexpr int kDefaultVoiceModuleGpuPriority = 50;
+constexpr double kDefaultVoiceMakerGpuFraction = 0.25;
+constexpr int kDefaultVoiceMakerGpuPriority = 45;
 constexpr std::string_view kDefaultInferImage = ProjectorSupport::kDefaultInferImage;
 constexpr std::string_view kDefaultSkillsImage = ProjectorSupport::kDefaultSkillsImage;
 constexpr std::string_view kDefaultWebGatewayImage =
@@ -59,6 +61,7 @@ nlohmann::json DesiredStateV2Projector::ProjectJson() {
   ProjectBrowsing();
   ProjectKnowledge();
   ProjectVoiceListener();
+  ProjectVoiceMaker();
   ProjectResources();
   return value_;
 }
@@ -70,6 +73,7 @@ void DesiredStateV2Projector::CollectInstancesAndDisks() {
   skills_instance_ = FindInstance(InstanceRole::Skills);
   browsing_instance_ = FindInstance(InstanceRole::Browsing);
   voice_module_instance_ = FindInstance(InstanceRole::VoiceModule);
+  voice_maker_instance_ = FindInstance(InstanceRole::VoiceMaker);
   worker_instances_ = FindWorkerInstances();
   shared_disk_ = FindSharedDisk();
 }
@@ -115,7 +119,8 @@ void DesiredStateV2Projector::ProjectPlacement() {
 
 void DesiredStateV2Projector::ProjectFeatures() {
   if (!state_.turboquant.has_value() && !state_.context_compression.has_value() &&
-      !state_.voice_listener.has_value() && !state_.secured_connection.has_value()) {
+      !state_.voice_listener.has_value() && !state_.voice_maker.has_value() &&
+      !state_.secured_connection.has_value()) {
     return;
   }
   nlohmann::json features = nlohmann::json::object();
@@ -174,6 +179,44 @@ void DesiredStateV2Projector::ProjectFeatures() {
       voice_json["image"] = voice_module_instance_->image;
     }
     features["voice_listener"] = std::move(voice_json);
+  }
+  if (state_.voice_maker.has_value()) {
+    const auto& voice = *state_.voice_maker;
+    nlohmann::json source = {
+        {"type", "library"},
+        {"path", voice.model.source_path},
+    };
+    if (!voice.model.source_node_name.empty()) {
+      source["node"] = voice.model.source_node_name;
+    }
+    if (!voice.model.source_paths.empty() &&
+        !(voice.model.source_paths.size() == 1 &&
+          voice.model.source_paths.front() == voice.model.source_path)) {
+      source["paths"] = voice.model.source_paths;
+    }
+    nlohmann::json model = {
+        {"name", voice.model.name.empty() ? std::string("omnivoice") : voice.model.name},
+        {"source", std::move(source)},
+        {"mount_path", voice.model.mount_path},
+        {"env", voice.model.env_var.empty() ? std::string("OMNIVOICE_MODEL_PATH")
+                                             : voice.model.env_var},
+        {"required", voice.model.required},
+    };
+    nlohmann::json voice_json = {
+        {"enabled", voice.enabled},
+        {"language", voice.language},
+        {"voice_mode", voice.voice_mode},
+        {"instruct", voice.instruct},
+        {"format", voice.output_format},
+        {"model", std::move(model)},
+    };
+    if (voice.image.has_value() && !voice.image->empty()) {
+      voice_json["image"] = *voice.image;
+    } else if (voice_maker_instance_ != nullptr &&
+               voice_maker_instance_->image != ProjectorSupport::kDefaultVoiceMakerImage) {
+      voice_json["image"] = voice_maker_instance_->image;
+    }
+    features["voice_maker"] = std::move(voice_json);
   }
   if (state_.secured_connection.has_value()) {
     features["secured_connection"] = {
@@ -706,6 +749,39 @@ void DesiredStateV2Projector::ProjectVoiceListener() {
   }
 }
 
+void DesiredStateV2Projector::ProjectVoiceMaker() {
+  if (!state_.voice_maker.has_value() || voice_maker_instance_ == nullptr) {
+    return;
+  }
+  if (!value_.contains("features") || !value_.at("features").is_object()) {
+    return;
+  }
+  auto& voice_json = value_["features"]["voice_maker"];
+  const auto start = ProjectorSupport::ProjectServiceStart(
+      *voice_maker_instance_,
+      std::string(ProjectorSupport::kDefaultVoiceMakerCommand));
+  if (!start.is_null()) {
+    voice_json["start"] = start;
+  }
+  auto env = ProjectorSupport::ProjectCustomEnv(*voice_maker_instance_, true);
+  env.erase("OMNIVOICE_MODEL_PATH");
+  if (!env.empty()) {
+    voice_json["env"] = env;
+  }
+  const auto publish = ProjectorSupport::ProjectPublishedPorts(*voice_maker_instance_);
+  if (!publish.empty()) {
+    voice_json["publish"] = publish;
+  }
+  if (voice_maker_instance_->node_name != DefaultNodeName()) {
+    voice_json["node"] = voice_maker_instance_->node_name;
+  }
+  const auto storage = ProjectorSupport::ProjectServiceStorage(
+      FindDiskByName(voice_maker_instance_->private_disk_name));
+  if (!storage.is_null()) {
+    voice_json["storage"] = storage;
+  }
+}
+
 void DesiredStateV2Projector::ProjectResources() {
   nlohmann::json resources = nlohmann::json::object();
   if (!worker_instances_.empty()) {
@@ -740,6 +816,29 @@ void DesiredStateV2Projector::ProjectResources() {
         !voice_module_instance_->preemptible &&
         !voice_module_instance_->memory_cap_mb.has_value()) {
       resources["voice_module"] = {{"gpu_enabled", true}};
+    }
+  }
+  if (voice_maker_instance_ != nullptr && voice_maker_instance_->gpu_device.has_value()) {
+    resources["voice_maker"] = {
+        {"gpu_enabled", true},
+        {"share_mode", ToString(voice_maker_instance_->share_mode)},
+        {"gpu_fraction", voice_maker_instance_->gpu_fraction},
+    };
+    if (voice_maker_instance_->priority != kDefaultVoiceMakerGpuPriority) {
+      resources["voice_maker"]["priority"] = voice_maker_instance_->priority;
+    }
+    if (voice_maker_instance_->preemptible) {
+      resources["voice_maker"]["preemptible"] = true;
+    }
+    if (voice_maker_instance_->memory_cap_mb.has_value()) {
+      resources["voice_maker"]["memory_cap_mb"] = *voice_maker_instance_->memory_cap_mb;
+    }
+    if (std::abs(voice_maker_instance_->gpu_fraction - kDefaultVoiceMakerGpuFraction) < 1e-9 &&
+        voice_maker_instance_->share_mode == GpuShareMode::Shared &&
+        voice_maker_instance_->priority == kDefaultVoiceMakerGpuPriority &&
+        !voice_maker_instance_->preemptible &&
+        !voice_maker_instance_->memory_cap_mb.has_value()) {
+      resources["voice_maker"] = {{"gpu_enabled", true}};
     }
   }
   if (shared_disk_ != nullptr) {

--- a/common/src/state/desired_state_v2_projector_support.cpp
+++ b/common/src/state/desired_state_v2_projector_support.cpp
@@ -45,6 +45,8 @@ nlohmann::json DesiredStateV2ProjectorSupport::ProjectServiceStorage(
                       ? disk->size_gb == kDefaultWebGatewayPrivateDiskSizeGb
                       : disk->kind == DiskKind::InteractionPrivate
                           ? disk->size_gb == kDefaultAppPrivateDiskSizeGb
+                          : disk->kind == DiskKind::VoiceMakerPrivate
+                              ? disk->size_gb == kDefaultVoiceMakerPrivateDiskSizeGb
                       : disk->size_gb == kDefaultAppPrivateDiskSizeGb;
   const bool default_mount = disk->container_path == "/naim/private";
   if (default_size && default_mount) {

--- a/common/src/state/desired_state_v2_renderer.cpp
+++ b/common/src/state/desired_state_v2_renderer.cpp
@@ -41,8 +41,14 @@ constexpr int kInteractionPublishedPortSpan = 10000;
 constexpr int kVoiceModuleContainerPort = 18140;
 constexpr int kVoiceModulePublishedPortBase = 54000;
 constexpr int kVoiceModulePublishedPortSpan = 10000;
+constexpr int kDefaultVoiceMakerPrivateDiskSizeGb = 8;
+constexpr int kVoiceMakerContainerPort = 18150;
+constexpr int kVoiceMakerPublishedPortBase = 55000;
+constexpr int kVoiceMakerPublishedPortSpan = 10000;
 constexpr double kDefaultVoiceModuleGpuFraction = 0.2;
 constexpr int kDefaultVoiceModuleGpuPriority = 50;
+constexpr double kDefaultVoiceMakerGpuFraction = 0.25;
+constexpr int kDefaultVoiceMakerGpuPriority = 45;
 constexpr std::string_view kTurboQuantDefaultCacheTypeK = "turbo4";
 constexpr std::string_view kTurboQuantDefaultCacheTypeV = "turbo4";
 
@@ -138,6 +144,11 @@ DesiredStateV2Renderer::DesiredStateV2Renderer(const nlohmann::json& value)
                          resources_json_.at("voice_listener").is_object()
                      ? resources_json_.at("voice_listener")
                      : nlohmann::json::object())),
+      voice_maker_resources_json_(
+          resources_json_.contains("voice_maker") &&
+                  resources_json_.at("voice_maker").is_object()
+              ? resources_json_.at("voice_maker")
+              : nlohmann::json::object()),
       app_json_(nlohmann::json::object()),
       skills_json_(
           value.contains("skills") && value.at("skills").is_object() ? value.at("skills")
@@ -195,6 +206,7 @@ DesiredState DesiredStateV2Renderer::RenderState() {
   RenderWebGatewayInstance();
   RenderInteractionInstance();
   RenderVoiceModuleInstance();
+  RenderVoiceMakerInstance();
   return state_;
 }
 
@@ -388,6 +400,45 @@ void DesiredStateV2Renderer::RenderFeatures() {
         voice_listener.model.required = model_json.value("required", true);
       }
       state_.voice_listener = std::move(voice_listener);
+    }
+  }
+  if (features_json_.contains("voice_maker") &&
+      features_json_.at("voice_maker").is_object()) {
+    const auto& voice_json = features_json_.at("voice_maker");
+    if (voice_json.value("enabled", false)) {
+      VoiceMakerFeatureSpec voice_maker;
+      voice_maker.enabled = true;
+      voice_maker.language = voice_json.value("language", voice_maker.language);
+      voice_maker.voice_mode = voice_json.value("voice_mode", voice_maker.voice_mode);
+      voice_maker.instruct = voice_json.value("instruct", voice_maker.instruct);
+      voice_maker.output_format = voice_json.value("format", voice_maker.output_format);
+      if (voice_json.contains("image") && voice_json.at("image").is_string()) {
+        voice_maker.image = voice_json.at("image").get<std::string>();
+      }
+      if (voice_json.contains("model") && voice_json.at("model").is_object()) {
+        const auto& model_json = voice_json.at("model");
+        const nlohmann::json source_json =
+            model_json.contains("source") && model_json.at("source").is_object()
+                ? model_json.at("source")
+                : nlohmann::json::object();
+        voice_maker.model.name = model_json.value("name", std::string("omnivoice"));
+        voice_maker.model.source_path = source_json.value("path", std::string{});
+        voice_maker.model.source_node_name = source_json.value("node", std::string{});
+        if (source_json.contains("paths") && source_json.at("paths").is_array()) {
+          voice_maker.model.source_paths =
+              source_json.at("paths").get<std::vector<std::string>>();
+        }
+        if (voice_maker.model.source_paths.empty() &&
+            !voice_maker.model.source_path.empty()) {
+          voice_maker.model.source_paths.push_back(voice_maker.model.source_path);
+        }
+        voice_maker.model.mount_path =
+            model_json.value("mount_path", std::string("/models/omnivoice"));
+        voice_maker.model.env_var =
+            model_json.value("env", std::string("OMNIVOICE_MODEL_PATH"));
+        voice_maker.model.required = model_json.value("required", true);
+      }
+      state_.voice_maker = std::move(voice_maker);
     }
   }
   if (features_json_.contains("secured_connection") &&
@@ -903,6 +954,12 @@ void DesiredStateV2Renderer::RenderAppInstance() {
           std::to_string(kVoiceModuleContainerPort) + "/v1";
       app.environment["NAIM_VOICE_LISTENER_WAKE_PHRASE"] = state_.voice_listener->wake_phrase;
     }
+    if (state_.voice_maker.has_value() && state_.voice_maker->enabled) {
+      app.depends_on.push_back(BuildVoiceMakerInstanceName());
+      app.environment["NAIM_VOICE_MAKER_BASE"] =
+          "http://" + BuildVoiceMakerInstanceName() + ":" +
+          std::to_string(kVoiceMakerContainerPort) + "/v1";
+    }
     if (app_entry.contains("env") && app_entry.at("env").is_object()) {
       const auto app_env = app_entry.at("env").get<std::map<std::string, std::string>>();
       app.environment.insert(app_env.begin(), app_env.end());
@@ -1268,6 +1325,133 @@ void DesiredStateV2Renderer::RenderVoiceModuleInstance() {
   state_.disks.push_back(std::move(voice_private_disk));
 }
 
+void DesiredStateV2Renderer::RenderVoiceMakerInstance() {
+  if (!state_.voice_maker.has_value() || !state_.voice_maker->enabled) {
+    return;
+  }
+
+  const auto& config = *state_.voice_maker;
+  const bool gpu_enabled = VoiceMakerGpuEnabled();
+  const auto voice_gpu_host = gpu_enabled ? SelectVoiceGpuHost(state_) : std::nullopt;
+  if (gpu_enabled && !voice_gpu_host.has_value()) {
+    throw std::runtime_error(
+        "desired-state v2 resources.voice_maker requires at least one worker with gpu_device");
+  }
+  InstanceSpec voice;
+  voice.name = BuildVoiceMakerInstanceName();
+  voice.role = InstanceRole::VoiceMaker;
+  voice.plane_name = state_.plane_name;
+  voice.node_name = voice_gpu_host.has_value() ? voice_gpu_host->node_name : ResolveAppNodeName();
+  voice.image = config.image.has_value() && !config.image->empty()
+                    ? *config.image
+                    : std::string("naim/voice-maker:dev");
+  const nlohmann::json voice_json =
+      features_json_.contains("voice_maker") &&
+              features_json_.at("voice_maker").is_object()
+          ? features_json_.at("voice_maker")
+          : nlohmann::json::object();
+  voice.command = BuildCommandFromStartSpec(
+      voice_json.value("start", nlohmann::json::object()),
+      "python3 /runtime/voice-maker/server.py");
+  voice.private_disk_name = voice.name + "-private";
+  voice.shared_disk_name =
+      InstanceNeedsSharedDiskMount(voice.role) ? state_.plane_shared_disk_name : "";
+  voice.private_disk_size_gb =
+      ExtractPrivateDiskSizeGb(voice_json, kDefaultVoiceMakerPrivateDiskSizeGb, "storage");
+  if (voice_gpu_host.has_value()) {
+    const auto& resources = VoiceMakerResources();
+    voice.gpu_device = voice_gpu_host->gpu_device;
+    voice.placement_mode = PlacementMode::Manual;
+    voice.share_mode =
+        ParseGpuShareMode(resources.value("share_mode", std::string("shared")));
+    voice.gpu_fraction =
+        resources.value("gpu_fraction", kDefaultVoiceMakerGpuFraction);
+    voice.priority = resources.value("priority", kDefaultVoiceMakerGpuPriority);
+    voice.preemptible =
+        resources.value("preemptible", voice.share_mode == GpuShareMode::BestEffort);
+    voice.memory_cap_mb = resources.contains("memory_cap_mb")
+                              ? std::optional<int>(resources.at("memory_cap_mb").get<int>())
+                              : std::nullopt;
+  }
+  voice.environment = {
+      {"NAIM_PLANE_NAME", state_.plane_name},
+      {"NAIM_INSTANCE_NAME", voice.name},
+      {"NAIM_INSTANCE_ROLE", "voice-maker"},
+      {"NAIM_NODE_NAME", voice.node_name},
+      {"NAIM_PRIVATE_DISK_PATH", "/naim/private"},
+      {"NAIM_VOICE_MAKER_PORT", std::to_string(kVoiceMakerContainerPort)},
+      {"NAIM_VOICE_MAKER_RUNTIME_STATUS_PATH", "/naim/private/voice-maker-runtime-status.json"},
+      {"OMNIVOICE_LANGUAGE", config.language},
+      {"OMNIVOICE_VOICE_MODE", config.voice_mode},
+      {"OMNIVOICE_INSTRUCT", config.instruct},
+      {"OMNIVOICE_OUTPUT_FORMAT", config.output_format},
+      {"HOST", "0.0.0.0"},
+      {"PORT", std::to_string(kVoiceMakerContainerPort)},
+      {"NAIM_CONTROLLER_URL", "http://controller.internal:18080"},
+      {"NAIM_CONTROL_ROOT", state_.control_root},
+  };
+  if (voice_json.contains("env") && voice_json.at("env").is_object()) {
+    const auto custom_env = voice_json.at("env").get<std::map<std::string, std::string>>();
+    for (const auto& [key, value] : custom_env) {
+      voice.environment[key] = value;
+    }
+  }
+  AppModelMountSpec model_mount = config.model;
+  if (model_mount.name.empty()) {
+    model_mount.name = "omnivoice";
+  }
+  if (model_mount.mount_path.empty()) {
+    model_mount.mount_path = "/models/omnivoice";
+  }
+  if (model_mount.env_var.empty()) {
+    model_mount.env_var = "OMNIVOICE_MODEL_PATH";
+  }
+  if (model_mount.source_paths.empty() && !model_mount.source_path.empty()) {
+    model_mount.source_paths.push_back(model_mount.source_path);
+  }
+  model_mount.host_path = BuildAppModelHostPath(
+      voice.name,
+      model_mount.name,
+      model_mount.mount_path,
+      model_mount.source_path);
+  voice.environment[model_mount.env_var] = model_mount.mount_path;
+  voice.app_model_mounts.push_back(std::move(model_mount));
+  voice.labels = {
+      {"naim.plane", state_.plane_name},
+      {"naim.role", "voice-maker"},
+      {"naim.node", voice.node_name},
+  };
+  if (voice_json.contains("publish") && voice_json.at("publish").is_array()) {
+    for (const auto& port_json : voice_json.at("publish")) {
+      voice.published_ports.push_back(PublishedPort{
+          port_json.value("host_ip", std::string("127.0.0.1")),
+          port_json.value("host_port", 0),
+          port_json.value("container_port", 0),
+      });
+    }
+  }
+  if (voice.published_ports.empty()) {
+    voice.published_ports.push_back(PublishedPort{
+        "127.0.0.1",
+        BuildVoiceMakerHostPort(),
+        kVoiceMakerContainerPort,
+    });
+  }
+  state_.instances.push_back(voice);
+
+  DiskSpec voice_private_disk;
+  voice_private_disk.name = voice.private_disk_name;
+  voice_private_disk.kind = DiskKind::VoiceMakerPrivate;
+  voice_private_disk.plane_name = state_.plane_name;
+  voice_private_disk.owner_name = voice.name;
+  voice_private_disk.node_name = voice.node_name;
+  voice_private_disk.host_path = BuildInstancePrivateHostPath(voice.name);
+  voice_private_disk.container_path =
+      ExtractPrivateMountPath(voice_json, "/naim/private", "storage");
+  voice_private_disk.size_gb = voice.private_disk_size_gb;
+  state_.disks.push_back(std::move(voice_private_disk));
+}
+
 void DesiredStateV2Renderer::RenderInteractionInstance() {
   if (state_.plane_mode != PlaneMode::Llm) {
     return;
@@ -1360,6 +1544,26 @@ const nlohmann::json& DesiredStateV2Renderer::VoiceModuleResources() const {
 
 bool DesiredStateV2Renderer::VoiceModuleGpuEnabled() const {
   const auto& resources = VoiceModuleResources();
+  if (resources.empty()) {
+    return false;
+  }
+  if (resources.contains("gpu_enabled")) {
+    return resources.value("gpu_enabled", false);
+  }
+  if (resources.contains("enabled")) {
+    return resources.value("enabled", false);
+  }
+  return resources.contains("share_mode") || resources.contains("gpu_fraction") ||
+      resources.contains("memory_cap_mb") || resources.contains("priority") ||
+      resources.contains("preemptible");
+}
+
+const nlohmann::json& DesiredStateV2Renderer::VoiceMakerResources() const {
+  return voice_maker_resources_json_;
+}
+
+bool DesiredStateV2Renderer::VoiceMakerGpuEnabled() const {
+  const auto& resources = VoiceMakerResources();
   if (resources.empty()) {
     return false;
   }
@@ -1618,6 +1822,10 @@ std::string DesiredStateV2Renderer::BuildVoiceModuleInstanceName() const {
   return "voice-module-" + state_.plane_name;
 }
 
+std::string DesiredStateV2Renderer::BuildVoiceMakerInstanceName() const {
+  return "voice-maker-" + state_.plane_name;
+}
+
 std::string DesiredStateV2Renderer::BuildPlaneSharedHostPath() const {
   return "/var/lib/naim/disks/planes/" + state_.plane_name + "/shared";
 }
@@ -1738,6 +1946,13 @@ int DesiredStateV2Renderer::BuildVoiceModuleHostPort() const {
       StablePortHash(state_.plane_name + ":" + BuildVoiceModuleInstanceName()) %
       kVoiceModulePublishedPortSpan;
   return kVoiceModulePublishedPortBase + static_cast<int>(offset);
+}
+
+int DesiredStateV2Renderer::BuildVoiceMakerHostPort() const {
+  const uint32_t offset =
+      StablePortHash(state_.plane_name + ":" + BuildVoiceMakerInstanceName()) %
+      kVoiceMakerPublishedPortSpan;
+  return kVoiceMakerPublishedPortBase + static_cast<int>(offset);
 }
 
 std::string DesiredStateV2Renderer::DefaultInferRuntimeBackend() const {

--- a/common/src/state/desired_state_v2_validator.cpp
+++ b/common/src/state/desired_state_v2_validator.cpp
@@ -174,6 +174,48 @@ void ValidateVoiceListenerModel(const nlohmann::json& model) {
   }
 }
 
+void ValidateVoiceMakerModel(const nlohmann::json& model) {
+  if (!model.is_object()) {
+    throw std::runtime_error("desired-state v2 features.voice_maker.model must be an object");
+  }
+  if (!model.contains("source") || !model.at("source").is_object()) {
+    throw std::runtime_error("desired-state v2 features.voice_maker.model.source must be an object");
+  }
+  const auto& source = model.at("source");
+  if (source.value("type", std::string{}) != "library") {
+    throw std::runtime_error("desired-state v2 features.voice_maker.model.source.type must be library");
+  }
+  if (!IsAbsolutePath(source.value("path", std::string{}))) {
+    throw std::runtime_error("desired-state v2 features.voice_maker.model.source.path must be an absolute path");
+  }
+  if (source.contains("paths")) {
+    if (!source.at("paths").is_array()) {
+      throw std::runtime_error("desired-state v2 features.voice_maker.model.source.paths must be an array");
+    }
+    for (const auto& path : source.at("paths")) {
+      if (!path.is_string() || !IsAbsolutePath(path.get<std::string>())) {
+        throw std::runtime_error("desired-state v2 features.voice_maker.model.source.paths items must be absolute paths");
+      }
+    }
+  }
+  if (source.contains("node") && !source.at("node").is_string()) {
+    throw std::runtime_error("desired-state v2 features.voice_maker.model.source.node must be a string");
+  }
+  if (!IsAbsolutePath(model.value("mount_path", std::string{}))) {
+    throw std::runtime_error("desired-state v2 features.voice_maker.model.mount_path must be an absolute path");
+  }
+  if (model.contains("env") && !model.at("env").is_string()) {
+    throw std::runtime_error("desired-state v2 features.voice_maker.model.env must be a string");
+  }
+  const std::string env_name = model.value("env", std::string("OMNIVOICE_MODEL_PATH"));
+  if (!env_name.empty() && !IsValidEnvName(env_name)) {
+    throw std::runtime_error("desired-state v2 features.voice_maker.model.env must be a valid environment variable name");
+  }
+  if (model.contains("required") && !model.at("required").is_boolean()) {
+    throw std::runtime_error("desired-state v2 features.voice_maker.model.required must be a boolean");
+  }
+}
+
 }  // namespace
 
 void DesiredStateV2Validator::ValidateOrThrow(const nlohmann::json& value) {
@@ -513,6 +555,42 @@ void DesiredStateV2Validator::ValidateFeatures() const {
           "desired-state v2 features.secured_connection requires at least one user_id when enabled");
     }
   }
+  if (features.contains("voice_maker")) {
+    if (!features.at("voice_maker").is_object()) {
+      throw std::runtime_error("desired-state v2 features.voice_maker must be an object");
+    }
+    const auto& voice_maker = features.at("voice_maker");
+    if (voice_maker.contains("enabled") && !voice_maker.at("enabled").is_boolean()) {
+      throw std::runtime_error("desired-state v2 features.voice_maker.enabled must be a boolean");
+    }
+    const bool enabled = voice_maker.value("enabled", false);
+    if (voice_maker.contains("language") && !voice_maker.at("language").is_string()) {
+      throw std::runtime_error("desired-state v2 features.voice_maker.language must be a string");
+    }
+    if (voice_maker.contains("voice_mode") && !voice_maker.at("voice_mode").is_string()) {
+      throw std::runtime_error("desired-state v2 features.voice_maker.voice_mode must be a string");
+    }
+    if (voice_maker.contains("instruct") && !voice_maker.at("instruct").is_string()) {
+      throw std::runtime_error("desired-state v2 features.voice_maker.instruct must be a string");
+    }
+    if (voice_maker.contains("format") && !voice_maker.at("format").is_string()) {
+      throw std::runtime_error("desired-state v2 features.voice_maker.format must be a string");
+    }
+    if (voice_maker.contains("image") && !voice_maker.at("image").is_string()) {
+      throw std::runtime_error("desired-state v2 features.voice_maker.image must be a string");
+    }
+    if (enabled) {
+      if (plane_mode != "llm") {
+        throw std::runtime_error("desired-state v2 features.voice_maker requires plane_mode=llm");
+      }
+      if (!voice_maker.contains("model")) {
+        throw std::runtime_error("desired-state v2 features.voice_maker requires model when enabled");
+      }
+      ValidateVoiceMakerModel(voice_maker.at("model"));
+    } else if (voice_maker.contains("model")) {
+      ValidateVoiceMakerModel(voice_maker.at("model"));
+    }
+  }
 }
 
 void DesiredStateV2Validator::ValidateRuntime() const {
@@ -797,6 +875,9 @@ void DesiredStateV2Validator::ValidateVoiceModuleResources() const {
   }
   if (resources.contains("voice_listener")) {
     ValidateGpuResourceBlock(resources.at("voice_listener"), "resources.voice_listener", true);
+  }
+  if (resources.contains("voice_maker")) {
+    ValidateGpuResourceBlock(resources.at("voice_maker"), "resources.voice_maker", true);
   }
 }
 

--- a/common/src/state/desired_state_v2_validator_tests.cpp
+++ b/common/src/state/desired_state_v2_validator_tests.cpp
@@ -2173,6 +2173,80 @@ int main() {
       std::cout << "ok: gpu-voice-listener-plane" << '\n';
     }
 
+    {
+      const json voice_maker_plane{
+          {"version", 2},
+          {"plane_name", "voice-maker-plane"},
+          {"plane_mode", "llm"},
+          {"model",
+           {
+               {"source", {{"type", "local"}, {"path", "/models/qwen"}}},
+               {"materialization", {{"mode", "reference"}, {"local_path", "/models/qwen"}}},
+               {"served_model_name", "qwen-voice-maker"},
+           }},
+          {"runtime",
+           {{"engine", "llama.cpp"}, {"distributed_backend", "llama_rpc"}, {"workers", 1}}},
+          {"topology",
+           {{"nodes",
+             json::array(
+                 {{{"name", "local-hostd"},
+                   {"execution_mode", "mixed"},
+                   {"gpu_memory_mb", {{"0", 24576}}}}})}}},
+          {"worker",
+           {{"assignments",
+             json::array({{{"node", "local-hostd"}, {"gpu_device", "0"}}})}}},
+          {"infer", {{"replicas", 1}}},
+          {"app", {{"enabled", true}, {"image", "example/app:dev"}}},
+          {"features",
+           {{"voice_maker",
+             {{"enabled", true},
+              {"language", "auto"},
+              {"voice_mode", "design"},
+              {"instruct", "neutral, clear voice"},
+              {"model",
+               {{"name", "omnivoice-neutral"},
+                {"source",
+                 {{"type", "library"},
+                  {"path", "/models/tts/omnivoice-neutral"},
+                  {"node", "storage1"},
+                  {"paths", json::array({"/models/tts/omnivoice-neutral"})}}},
+                {"mount_path", "/models/omnivoice"},
+                {"env", "OMNIVOICE_MODEL_PATH"},
+                {"required", true}}}}}}},
+          {"resources",
+           {{"voice_maker",
+             {{"gpu_enabled", true},
+              {"share_mode", "shared"},
+              {"gpu_fraction", 0.25},
+              {"memory_cap_mb", 4096}}}}},
+      };
+      const auto state = RenderValid(voice_maker_plane, "voice-maker-plane");
+      const auto voice = FindInstance(state, "voice-maker-voice-maker-plane");
+      Expect(voice.role == naim::InstanceRole::VoiceMaker,
+             "voice-maker-plane: voice maker role mismatch");
+      Expect(voice.node_name == "local-hostd",
+             "voice-maker-plane: voice maker should colocate with a GPU worker");
+      Expect(voice.gpu_device == std::optional<std::string>("0"),
+             "voice-maker-plane: voice maker gpu device mismatch");
+      Expect(voice.environment.at("NAIM_VOICE_MAKER_PORT") == "18150",
+             "voice-maker-plane: voice maker port env mismatch");
+      Expect(voice.environment.at("OMNIVOICE_MODEL_PATH") == "/models/omnivoice",
+             "voice-maker-plane: OmniVoice model env mismatch");
+      Expect(voice.app_model_mounts.size() == 1,
+             "voice-maker-plane: voice maker should mount OmniVoice model");
+      const auto app = FindInstance(state, "app-voice-maker-plane");
+      Expect(app.environment.at("NAIM_VOICE_MAKER_BASE") ==
+                 "http://voice-maker-voice-maker-plane:18150/v1",
+             "voice-maker-plane: primary app should receive voice maker base");
+      const auto projected = naim::DesiredStateV2Projector::Project(state);
+      Expect(projected.at("features").at("voice_maker").at("instruct") ==
+                 "neutral, clear voice",
+             "voice-maker-plane: projector should preserve voice instruction");
+      Expect(projected.at("resources").at("voice_maker").at("gpu_enabled") == true,
+             "voice-maker-plane: projector should preserve voice maker GPU enablement");
+      std::cout << "ok: voice-maker-plane" << '\n';
+    }
+
     ExpectInvalid(
         json{
             {"version", 2},

--- a/common/src/state/state_json.cpp
+++ b/common/src/state/state_json.cpp
@@ -184,6 +184,42 @@ json ToJson(const VoiceListenerFeatureSpec& voice_listener) {
   return result;
 }
 
+json ToJson(const VoiceMakerFeatureSpec& voice_maker) {
+  json source = {
+      {"type", "library"},
+      {"path", voice_maker.model.source_path},
+  };
+  if (!voice_maker.model.source_node_name.empty()) {
+    source["node"] = voice_maker.model.source_node_name;
+  }
+  if (!voice_maker.model.source_paths.empty() &&
+      !(voice_maker.model.source_paths.size() == 1 &&
+        voice_maker.model.source_paths.front() == voice_maker.model.source_path)) {
+    source["paths"] = voice_maker.model.source_paths;
+  }
+  json model = {
+      {"name", voice_maker.model.name.empty() ? std::string("omnivoice")
+                                               : voice_maker.model.name},
+      {"source", std::move(source)},
+      {"mount_path", voice_maker.model.mount_path},
+      {"env", voice_maker.model.env_var.empty() ? std::string("OMNIVOICE_MODEL_PATH")
+                                                 : voice_maker.model.env_var},
+      {"required", voice_maker.model.required},
+  };
+  json result = {
+      {"enabled", voice_maker.enabled},
+      {"language", voice_maker.language},
+      {"voice_mode", voice_maker.voice_mode},
+      {"instruct", voice_maker.instruct},
+      {"format", voice_maker.output_format},
+      {"model", std::move(model)},
+  };
+  if (voice_maker.image.has_value() && !voice_maker.image->empty()) {
+    result["image"] = *voice_maker.image;
+  }
+  return result;
+}
+
 json ToJson(const SecuredConnectionFeatureSpec& secured_connection) {
   return json{
       {"enabled", secured_connection.enabled},
@@ -266,7 +302,8 @@ json DesiredStateToJson(const DesiredState& state) {
     result["knowledge"] = SettingsCodecs::ToJson(*state.knowledge);
   }
   if (state.turboquant.has_value() || state.context_compression.has_value() ||
-      state.voice_listener.has_value() || state.secured_connection.has_value()) {
+      state.voice_listener.has_value() || state.voice_maker.has_value() ||
+      state.secured_connection.has_value()) {
     json features = json::object();
     if (state.turboquant.has_value()) {
       features["turboquant"] = ToJson(*state.turboquant);
@@ -276,6 +313,9 @@ json DesiredStateToJson(const DesiredState& state) {
     }
     if (state.voice_listener.has_value()) {
       features["voice_listener"] = ToJson(*state.voice_listener);
+    }
+    if (state.voice_maker.has_value()) {
+      features["voice_maker"] = ToJson(*state.voice_maker);
     }
     if (state.secured_connection.has_value()) {
       features["secured_connection"] = ToJson(*state.secured_connection);
@@ -414,6 +454,44 @@ DesiredState DesiredStateFromJson(const json& value) {
         voice_listener.model.required = model_json.value("required", true);
       }
       state.voice_listener = std::move(voice_listener);
+    }
+    if (features.contains("voice_maker") &&
+        features.at("voice_maker").is_object()) {
+      VoiceMakerFeatureSpec voice_maker;
+      const auto& voice_maker_json = features.at("voice_maker");
+      voice_maker.enabled = voice_maker_json.value("enabled", voice_maker.enabled);
+      voice_maker.language = voice_maker_json.value("language", voice_maker.language);
+      voice_maker.voice_mode = voice_maker_json.value("voice_mode", voice_maker.voice_mode);
+      voice_maker.instruct = voice_maker_json.value("instruct", voice_maker.instruct);
+      voice_maker.output_format = voice_maker_json.value("format", voice_maker.output_format);
+      if (voice_maker_json.contains("image") &&
+          voice_maker_json.at("image").is_string()) {
+        voice_maker.image = voice_maker_json.at("image").get<std::string>();
+      }
+      if (voice_maker_json.contains("model") &&
+          voice_maker_json.at("model").is_object()) {
+        const auto& model_json = voice_maker_json.at("model");
+        const json source_json = model_json.contains("source") && model_json.at("source").is_object()
+                                     ? model_json.at("source")
+                                     : json::object();
+        voice_maker.model.name = model_json.value("name", std::string("omnivoice"));
+        voice_maker.model.source_path = source_json.value("path", std::string{});
+        voice_maker.model.source_node_name = source_json.value("node", std::string{});
+        if (source_json.contains("paths") && source_json.at("paths").is_array()) {
+          voice_maker.model.source_paths =
+              source_json.at("paths").get<std::vector<std::string>>();
+        }
+        if (voice_maker.model.source_paths.empty() &&
+            !voice_maker.model.source_path.empty()) {
+          voice_maker.model.source_paths.push_back(voice_maker.model.source_path);
+        }
+        voice_maker.model.mount_path =
+            model_json.value("mount_path", std::string("/models/omnivoice"));
+        voice_maker.model.env_var =
+            model_json.value("env", std::string("OMNIVOICE_MODEL_PATH"));
+        voice_maker.model.required = model_json.value("required", true);
+      }
+      state.voice_maker = std::move(voice_maker);
     }
     if (features.contains("secured_connection") &&
         features.at("secured_connection").is_object()) {

--- a/common/src/state/state_json_runtime_codecs.cpp
+++ b/common/src/state/state_json_runtime_codecs.cpp
@@ -38,6 +38,9 @@ DiskKind StateJsonRuntimeCodecs::ParseDiskKind(const std::string& value) {
   if (value == "voice-module-private") {
     return DiskKind::VoiceModulePrivate;
   }
+  if (value == "voice-maker-private") {
+    return DiskKind::VoiceMakerPrivate;
+  }
   throw std::runtime_error("unknown disk kind '" + value + "'");
 }
 
@@ -66,6 +69,9 @@ InstanceRole StateJsonRuntimeCodecs::ParseInstanceRole(
   }
   if (value == "voice-module") {
     return InstanceRole::VoiceModule;
+  }
+  if (value == "voice-maker") {
+    return InstanceRole::VoiceMaker;
   }
   throw std::runtime_error("unknown instance role '" + value + "'");
 }

--- a/controller/include/voice/plane_voice_service.h
+++ b/controller/include/voice/plane_voice_service.h
@@ -35,4 +35,27 @@ class PlaneVoiceService final {
       std::string* error_message) const;
 };
 
+class PlaneVoiceMakerService final {
+ public:
+  bool IsEnabled(const DesiredState& desired_state) const;
+
+  std::optional<ControllerEndpointTarget> ResolveTarget(
+      const DesiredState& desired_state) const;
+
+  nlohmann::json BuildStatusPayload(
+      const std::string& db_path,
+      const DesiredState& desired_state,
+      const std::optional<std::string>& plane_state) const;
+
+  std::optional<HttpResponse> ProxyPlaneVoiceMakerRequest(
+      const std::string& db_path,
+      const DesiredState& desired_state,
+      const std::string& method,
+      const std::string& path_suffix,
+      const std::string& body,
+      const std::vector<std::pair<std::string, std::string>>& headers,
+      std::string* error_code,
+      std::string* error_message) const;
+};
+
 }  // namespace naim::controller

--- a/controller/src/http/controller_http_router.cpp
+++ b/controller/src/http/controller_http_router.cpp
@@ -98,6 +98,10 @@ bool IsPlaneVoiceRequest(const std::string& path) {
   return ExtractPlaneFeatureRequestName(path, "/voice-listener").has_value();
 }
 
+bool IsPlaneVoiceMakerRequest(const std::string& path) {
+  return ExtractPlaneFeatureRequestName(path, "/voice-maker").has_value();
+}
+
 bool IsPlaneSkillsRootRequest(
     const std::string& path,
     const std::string& plane_name) {
@@ -798,6 +802,7 @@ HttpResponse ControllerHttpRouter::HandleRequest(
     const bool skills_request = IsPlaneSkillsRequest(request.path);
     const bool browsing_request = IsPlaneBrowsingRequest(request.path);
     const bool voice_request = IsPlaneVoiceRequest(request.path);
+    const bool voice_maker_request = IsPlaneVoiceMakerRequest(request.path);
     if (browsing_request && !webgateway_routes_enabled_) {
       return deps_.build_json_response(
           404,
@@ -806,7 +811,8 @@ HttpResponse ControllerHttpRouter::HandleRequest(
                {"method", request.method}},
           {});
     }
-    if (!interaction_request && !skills_request && !browsing_request && !voice_request) {
+    if (!interaction_request && !skills_request && !browsing_request && !voice_request &&
+        !voice_maker_request) {
       try {
         naim::ControllerStore store(db_path_);
         store.Initialize();
@@ -828,7 +834,7 @@ HttpResponse ControllerHttpRouter::HandleRequest(
                  {"path", request.path}},
             {});
       }
-    } else if (skills_request || browsing_request || voice_request) {
+    } else if (skills_request || browsing_request || voice_request || voice_maker_request) {
       try {
         naim::ControllerStore store(db_path_);
         store.Initialize();
@@ -837,8 +843,10 @@ HttpResponse ControllerHttpRouter::HandleRequest(
           plane_name = ExtractPlaneFeatureRequestName(request.path, "/skills");
         } else if (browsing_request) {
           plane_name = ExtractPlaneFeatureRequestName(request.path, "/webgateway");
-        } else {
+        } else if (voice_request) {
           plane_name = ExtractPlaneFeatureRequestName(request.path, "/voice-listener");
+        } else {
+          plane_name = ExtractPlaneFeatureRequestName(request.path, "/voice-maker");
         }
         if (plane_name.has_value()) {
           const auto desired_state = store.LoadDesiredState(*plane_name);

--- a/controller/src/model/model_conversion_service.cpp
+++ b/controller/src/model/model_conversion_service.cpp
@@ -23,6 +23,7 @@ namespace {
 
 constexpr std::string_view kFormatGguf = "gguf";
 constexpr std::string_view kFormatSafetensors = "safetensors";
+constexpr std::string_view kFormatTtsOmniVoice = "tts/omnivoice";
 constexpr std::string_view kFormatWhisperCpp = "whisper.cpp";
 constexpr std::string_view kFormatUnknown = "unknown";
 constexpr std::array<std::string_view, 5> kKnownQuantizations = {
@@ -140,6 +141,10 @@ std::string ModelConversionService::NormalizeOutputFormat(const std::string& val
   }
   if (normalized == kFormatSafetensors) {
     return std::string(kFormatSafetensors);
+  }
+  if (normalized == kFormatTtsOmniVoice || normalized == "omnivoice" ||
+      normalized == "omni-voice") {
+    return std::string(kFormatTtsOmniVoice);
   }
   if (normalized == kFormatWhisperCpp || normalized == "whisper" ||
       normalized == "whisper.cpp-bin") {

--- a/controller/src/model/model_library_service.cpp
+++ b/controller/src/model/model_library_service.cpp
@@ -498,7 +498,7 @@ HttpResponse ModelLibraryService::EnqueueDownload(
              {"message", "source_url or source_urls is required"}},
         {});
   }
-  if (detected_source_format == "unknown") {
+  if (detected_source_format == "unknown" && desired_output_format != "tts/omnivoice") {
     return support_.build_json_response(
         400,
         json{{"status", "bad_request"},
@@ -506,21 +506,23 @@ HttpResponse ModelLibraryService::EnqueueDownload(
         {});
   }
   if (desired_output_format != "gguf" && desired_output_format != "safetensors" &&
-      desired_output_format != "whisper.cpp") {
+      desired_output_format != "whisper.cpp" && desired_output_format != "tts/omnivoice") {
     return support_.build_json_response(
         400,
         json{{"status", "bad_request"},
-             {"message", "format must be gguf, safetensors, whisper.cpp, or source"}},
+             {"message", "format must be gguf, safetensors, whisper.cpp, tts/omnivoice, or source"}},
         {});
   }
-  if (detected_source_format == "gguf" && desired_output_format != "gguf") {
+  if (detected_source_format == "gguf" && desired_output_format != "gguf" &&
+      desired_output_format != "tts/omnivoice") {
     return support_.build_json_response(
         400,
         json{{"status", "bad_request"},
              {"message", "gguf sources can only retain GGUF output format"}},
         {});
   }
-  if (detected_source_format == "whisper.cpp" && desired_output_format != "whisper.cpp") {
+  if (detected_source_format == "whisper.cpp" && desired_output_format != "whisper.cpp" &&
+      desired_output_format != "tts/omnivoice") {
     return support_.build_json_response(
         400,
         json{{"status", "bad_request"},

--- a/controller/src/plane/plane_http_service.cpp
+++ b/controller/src/plane/plane_http_service.cpp
@@ -481,6 +481,96 @@ HttpResponse PlaneHttpService::HandlePlanePath(
     }
   }
 
+  const auto voice_maker_pos = remainder.find("/voice-maker");
+  if (voice_maker_pos != std::string::npos) {
+    const bool voice_maker_suffix_valid =
+        voice_maker_pos + std::string("/voice-maker").size() == remainder.size() ||
+        remainder.at(voice_maker_pos + std::string("/voice-maker").size()) == '/';
+    if (voice_maker_suffix_valid) {
+      const std::string plane_name = remainder.substr(0, voice_maker_pos);
+      const std::string path_suffix =
+          remainder.substr(voice_maker_pos + std::string("/voice-maker").size());
+      try {
+        naim::ControllerStore store(db_path);
+        store.Initialize();
+        const auto desired_state = store.LoadDesiredState(plane_name);
+        if (!desired_state.has_value()) {
+          return support_.build_json_response(
+              404,
+              json{{"status", "not_found"},
+                   {"message", "plane '" + plane_name + "' not found"},
+                   {"path", request.path}},
+              {});
+        }
+        const auto plane = store.LoadPlane(plane_name);
+        const std::optional<std::string> plane_state =
+            plane.has_value() ? std::optional<std::string>(plane->state) : std::nullopt;
+        const bool plane_runtime_ready =
+            plane.has_value() && plane->state == "running";
+        const naim::controller::PlaneVoiceMakerService voice_service;
+        if (path_suffix.empty() || path_suffix == "/" || path_suffix == "/status") {
+          if (request.method != "GET") {
+            return support_.build_json_response(
+                405, json{{"status", "method_not_allowed"}}, {});
+          }
+          return support_.build_json_response(
+              200,
+              voice_service.BuildStatusPayload(db_path, *desired_state, plane_state),
+              {});
+        }
+        if (!plane_runtime_ready) {
+          return support_.build_json_response(
+              409,
+              json{{"status", "error"},
+                   {"message", "voice maker plane runtime is not ready"},
+                   {"error",
+                    {{"code", "voice_maker_plane_not_ready"},
+                     {"message", "voice maker plane runtime is not ready"}}},
+                   {"path", request.path}},
+              {});
+        }
+
+        std::vector<std::pair<std::string, std::string>> upstream_headers;
+        for (const auto& [key, value] : request.headers) {
+          if (key == "content-type" || key == "Content-Type") {
+            upstream_headers.emplace_back("Content-Type", value);
+          }
+        }
+        if (upstream_headers.empty()) {
+          upstream_headers.emplace_back("Content-Type", "application/json");
+        }
+
+        std::string error_code;
+        std::string error_message;
+        const auto proxied = voice_service.ProxyPlaneVoiceMakerRequest(
+            db_path,
+            *desired_state,
+            request.method,
+            path_suffix,
+            request.body,
+            upstream_headers,
+            &error_code,
+            &error_message);
+        if (!proxied.has_value()) {
+          const int status_code = error_code == "voice_maker_disabled" ? 409 : 503;
+          return support_.build_json_response(
+              status_code,
+              json{{"status", "error"},
+                   {"message", error_message},
+                   {"error", {{"code", error_code}, {"message", error_message}}},
+                   {"path", request.path}},
+              {});
+        }
+        return *proxied;
+      } catch (const std::exception& error) {
+        return support_.build_json_response(
+            500,
+            json{{"status", "internal_error"}, {"message", error.what()}, {"path", request.path}},
+            {});
+      }
+    }
+  }
+
   const auto knowledge_vault_pos = remainder.find("/knowledge-vault");
   if (knowledge_vault_pos != std::string::npos) {
     const bool knowledge_vault_suffix_valid =

--- a/controller/src/voice/plane_voice_service.cpp
+++ b/controller/src/voice/plane_voice_service.cpp
@@ -42,6 +42,19 @@ const InstanceSpec* FindVoiceInstance(const DesiredState& desired_state) {
   return &*it;
 }
 
+const InstanceSpec* FindVoiceMakerInstance(const DesiredState& desired_state) {
+  const auto it = std::find_if(
+      desired_state.instances.begin(),
+      desired_state.instances.end(),
+      [](const InstanceSpec& instance) {
+        return instance.role == InstanceRole::VoiceMaker;
+      });
+  if (it == desired_state.instances.end()) {
+    return nullptr;
+  }
+  return &*it;
+}
+
 std::string NormalizeVoicePathSuffix(const std::string& path_suffix) {
   if (path_suffix.empty() || path_suffix == "/" || path_suffix == "/transcribe") {
     return "/v1/transcribe";
@@ -49,6 +62,20 @@ std::string NormalizeVoicePathSuffix(const std::string& path_suffix) {
   if (path_suffix == "/health" || path_suffix == "/v1/transcribe" ||
       path_suffix == "/api/asr/transcribe") {
     return path_suffix;
+  }
+  if (path_suffix.front() == '/') {
+    return path_suffix;
+  }
+  return "/" + path_suffix;
+}
+
+std::string NormalizeVoiceMakerPathSuffix(const std::string& path_suffix) {
+  if (path_suffix.empty() || path_suffix == "/" || path_suffix == "/synthesize") {
+    return "/v1/synthesize";
+  }
+  if (path_suffix == "/health" || path_suffix == "/status" ||
+      path_suffix == "/v1/status" || path_suffix == "/v1/synthesize") {
+    return path_suffix == "/status" ? "/v1/status" : path_suffix;
   }
   if (path_suffix.front() == '/') {
     return path_suffix;
@@ -118,6 +145,8 @@ HttpResponse SendPlaneVoiceRequest(
     const std::string& db_path,
     const std::string& plane_name,
     const ControllerEndpointTarget& target,
+    const std::string& feature_name,
+    const std::string& policy_name,
     const std::string& method,
     const std::string& path,
     const std::string& body,
@@ -141,10 +170,10 @@ HttpResponse SendPlaneVoiceRequest(
   ControllerStore store(db_path);
   store.Initialize();
   const std::string request_id =
-      "voice-" + plane_name + "-" +
+      feature_name + "-" + plane_name + "-" +
       std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
   const std::string proxy_plane_name =
-      "runtime-http-proxy:voice-listener:" + plane_name + ":" + request_id;
+      "runtime-http-proxy:" + feature_name + ":" + plane_name + ":" + request_id;
 
   HostAssignment assignment;
   assignment.node_name = target.node_name;
@@ -161,7 +190,7 @@ HttpResponse SendPlaneVoiceRequest(
           {"body_base64", EncodeBodyBase64(body)},
           {"headers", BuildHeaderArray(headers)},
           {"request_id", request_id},
-          {"policy", "voice-listener"},
+          {"policy", policy_name},
       }
           .dump();
   assignment.artifacts_root = "";
@@ -218,7 +247,9 @@ bool ProbeVoiceTargetOk(
     const ControllerEndpointTarget& target) {
   try {
     const auto response =
-        SendPlaneVoiceRequest(db_path, plane_name, target, "GET", "/health", "", {});
+        SendPlaneVoiceRequest(
+            db_path, plane_name, target, "voice-listener", "voice-listener",
+            "GET", "/health", "", {});
     return response.status_code >= 200 && response.status_code < 300;
   } catch (...) {
     return false;
@@ -323,6 +354,8 @@ nlohmann::json PlaneVoiceService::BuildStatusPayload(
           db_path,
           desired_state.plane_name,
           *target,
+          "voice-listener",
+          "voice-listener",
           "GET",
           "/health",
           "",
@@ -373,6 +406,8 @@ std::optional<HttpResponse> PlaneVoiceService::ProxyPlaneVoiceRequest(
         db_path,
         desired_state.plane_name,
         *target,
+        "voice-listener",
+        "voice-listener",
         method,
         NormalizeVoicePathSuffix(path_suffix),
         body,
@@ -380,6 +415,189 @@ std::optional<HttpResponse> PlaneVoiceService::ProxyPlaneVoiceRequest(
   } catch (const std::exception& error) {
     if (error_code != nullptr) {
       *error_code = "voice_listener_upstream_failed";
+    }
+    if (error_message != nullptr) {
+      *error_message = error.what();
+    }
+    return std::nullopt;
+  }
+}
+
+bool PlaneVoiceMakerService::IsEnabled(const DesiredState& desired_state) const {
+  return desired_state.voice_maker.has_value() &&
+         desired_state.voice_maker->enabled;
+}
+
+std::optional<ControllerEndpointTarget> PlaneVoiceMakerService::ResolveTarget(
+    const DesiredState& desired_state) const {
+  const auto* voice = FindVoiceMakerInstance(desired_state);
+  if (voice == nullptr) {
+    return std::nullopt;
+  }
+  const auto published = std::find_if(
+      voice->published_ports.begin(),
+      voice->published_ports.end(),
+      [](const PublishedPort& port) { return port.host_port > 0; });
+  if (published == voice->published_ports.end()) {
+    return std::nullopt;
+  }
+  ControllerEndpointTarget target;
+  target.host = NormalizeControllerTargetHost(*published);
+  target.port = published->host_port;
+  target.raw = "http://" + target.host + ":" + std::to_string(target.port);
+  target.node_name = voice->node_name;
+  if (!IsControllerLocalNode(target.node_name) && IsLoopbackTargetHost(target.host)) {
+    target.route_via_hostd_proxy = true;
+    target.route_mode = "hostd-runtime-proxy";
+  }
+  return target;
+}
+
+nlohmann::json PlaneVoiceMakerService::BuildStatusPayload(
+    const std::string& db_path,
+    const DesiredState& desired_state,
+    const std::optional<std::string>& plane_state) const {
+  const bool enabled = IsEnabled(desired_state);
+  const auto* voice_instance = FindVoiceMakerInstance(desired_state);
+  const auto target = ResolveTarget(desired_state);
+  const bool running_plane = plane_state.has_value() && *plane_state == "running";
+  const bool should_probe_runtime =
+      enabled && running_plane && target.has_value() && !target->route_via_hostd_proxy;
+  bool ready = enabled && running_plane && target.has_value() && target->route_via_hostd_proxy;
+  if (should_probe_runtime) {
+    try {
+      const auto response = SendPlaneVoiceRequest(
+          db_path,
+          desired_state.plane_name,
+          *target,
+          "voice-maker",
+          "voice-maker",
+          "GET",
+          "/health",
+          "",
+          {});
+      ready = response.status_code >= 200 && response.status_code < 300;
+    } catch (...) {
+      ready = false;
+    }
+  }
+
+  std::string reason = "ready";
+  if (!enabled) {
+    reason = "voice_maker_disabled";
+  } else if (!running_plane) {
+    reason = "plane_not_running";
+  } else if (!target.has_value()) {
+    reason = "target_missing";
+  } else if (!ready) {
+    reason = "target_unreachable";
+  }
+
+  nlohmann::json payload = {
+      {"status", "ok"},
+      {"voice_maker_enabled", enabled},
+      {"voice_maker_ready", ready},
+      {"reason", reason},
+      {"plane_name", desired_state.plane_name},
+      {"plane_state", plane_state.has_value() ? nlohmann::json(*plane_state)
+                                               : nlohmann::json(nullptr)},
+      {"voice_maker_container_name",
+       voice_instance != nullptr ? nlohmann::json(voice_instance->name)
+                                  : nlohmann::json(nullptr)},
+      {"voice_maker_target", target.has_value() ? nlohmann::json(target->raw)
+                                                 : nlohmann::json(nullptr)},
+      {"voice_maker_node_name",
+       target.has_value() && !target->node_name.empty()
+           ? nlohmann::json(target->node_name)
+           : nlohmann::json(nullptr)},
+      {"voice_maker_route_mode",
+       target.has_value() ? nlohmann::json(target->route_mode)
+                           : nlohmann::json(nullptr)},
+      {"language",
+       desired_state.voice_maker.has_value()
+           ? nlohmann::json(desired_state.voice_maker->language)
+           : nlohmann::json(nullptr)},
+      {"voice_mode",
+       desired_state.voice_maker.has_value()
+           ? nlohmann::json(desired_state.voice_maker->voice_mode)
+           : nlohmann::json(nullptr)},
+      {"format",
+       desired_state.voice_maker.has_value()
+           ? nlohmann::json(desired_state.voice_maker->output_format)
+           : nlohmann::json(nullptr)},
+      {"model_mount_path",
+       desired_state.voice_maker.has_value()
+           ? nlohmann::json(desired_state.voice_maker->model.mount_path)
+           : nlohmann::json(nullptr)},
+  };
+
+  if (ready && should_probe_runtime) {
+    try {
+      const auto response = SendPlaneVoiceRequest(
+          db_path,
+          desired_state.plane_name,
+          *target,
+          "voice-maker",
+          "voice-maker",
+          "GET",
+          "/v1/status",
+          "",
+          {});
+      if (!response.body.empty()) {
+        const auto runtime_status = nlohmann::json::parse(response.body, nullptr, false);
+        if (runtime_status.is_object()) {
+          payload["runtime"] = runtime_status;
+        }
+      }
+    } catch (...) {
+    }
+  }
+  return payload;
+}
+
+std::optional<HttpResponse> PlaneVoiceMakerService::ProxyPlaneVoiceMakerRequest(
+    const std::string& db_path,
+    const DesiredState& desired_state,
+    const std::string& method,
+    const std::string& path_suffix,
+    const std::string& body,
+    const std::vector<std::pair<std::string, std::string>>& headers,
+    std::string* error_code,
+    std::string* error_message) const {
+  if (!IsEnabled(desired_state)) {
+    if (error_code != nullptr) {
+      *error_code = "voice_maker_disabled";
+    }
+    if (error_message != nullptr) {
+      *error_message = "voice maker is not enabled for this plane";
+    }
+    return std::nullopt;
+  }
+  const auto target = ResolveTarget(desired_state);
+  if (!target.has_value()) {
+    if (error_code != nullptr) {
+      *error_code = "voice_maker_target_missing";
+    }
+    if (error_message != nullptr) {
+      *error_message = "voice maker service target is not available";
+    }
+    return std::nullopt;
+  }
+
+  try {
+    return SendPlaneVoiceRequest(
+        db_path,
+        desired_state.plane_name,
+        *target,
+        "voice-maker",
+        "voice-maker",
+        method,
+        NormalizeVoiceMakerPathSuffix(path_suffix),
+        body,
+        headers);
+  } catch (const std::exception& error) {
+    if (error_code != nullptr) {
+      *error_code = "voice_maker_upstream_failed";
     }
     if (error_message != nullptr) {
       *error_message = error.what();

--- a/hostd/include/app/hostd_runtime_http_proxy.h
+++ b/hostd/include/app/hostd_runtime_http_proxy.h
@@ -13,6 +13,7 @@ enum class HostdRuntimeProxyPolicy {
   Skills,
   WebGateway,
   Voice,
+  VoiceMaker,
 };
 
 struct HostdRuntimeHttpResponse {

--- a/hostd/src/app/hostd_app_assignment_support.cpp
+++ b/hostd/src/app/hostd_app_assignment_support.cpp
@@ -584,6 +584,8 @@ void HostdAppAssignmentSupport::ExecuteRuntimeHttpProxy(
     policy = HostdRuntimeProxyPolicy::WebGateway;
   } else if (policy_name == "voice-listener") {
     policy = HostdRuntimeProxyPolicy::Voice;
+  } else if (policy_name == "voice-maker") {
+    policy = HostdRuntimeProxyPolicy::VoiceMaker;
   }
   const auto headers = runtime_http_proxy_.ParseProxyHeaders(
       payload.value("headers", nlohmann::json::array()));

--- a/hostd/src/app/hostd_runtime_http_proxy.cpp
+++ b/hostd/src/app/hostd_runtime_http_proxy.cpp
@@ -234,6 +234,15 @@ bool HostdRuntimeHttpProxy::IsAllowedProxyPath(
     }
     return false;
   }
+  if (policy == HostdRuntimeProxyPolicy::VoiceMaker) {
+    if (method == "GET" && (route == "/health" || route == "/v1/status")) {
+      return true;
+    }
+    if (method == "POST" && route == "/v1/synthesize") {
+      return true;
+    }
+    return false;
+  }
   return IsAllowedRuntimeProxyPath(method, path);
 }
 
@@ -249,6 +258,9 @@ std::string HostdRuntimeHttpProxy::PolicyLabel(HostdRuntimeProxyPolicy policy) {
   }
   if (policy == HostdRuntimeProxyPolicy::Voice) {
     return "voice-listener-runtime-http";
+  }
+  if (policy == HostdRuntimeProxyPolicy::VoiceMaker) {
+    return "voice-maker-runtime-http";
   }
   return "runtime-direct-http";
 }

--- a/runtime/voice-maker/Dockerfile
+++ b/runtime/voice-maker/Dockerfile
@@ -1,0 +1,29 @@
+ARG BASE_IMAGE=nvidia/cuda:12.8.1-runtime-ubuntu24.04
+FROM ${BASE_IMAGE}
+
+ENV HOST=0.0.0.0 \
+    PORT=18150 \
+    NAIM_VOICE_MAKER_TMP_DIR=/tmp/naim-voice-maker \
+    NAIM_VOICE_MAKER_FAKE=0 \
+    OMNIVOICE_MODEL_PATH=/models/omnivoice \
+    OMNIVOICE_LANGUAGE=auto \
+    OMNIVOICE_VOICE_MODE=design \
+    OMNIVOICE_INSTRUCT="neutral, clear voice, medium pitch, calm style" \
+    OMNIVOICE_OUTPUT_FORMAT=wav
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl ffmpeg git libsndfile1 python3 python3-pip \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /models /tmp/naim-voice-maker /runtime/voice-maker \
+  && python3 -m pip install --break-system-packages --no-cache-dir \
+    torch==2.8.0+cu128 \
+    torchaudio==2.8.0+cu128 \
+    --extra-index-url https://download.pytorch.org/whl/cu128 \
+  && python3 -m pip install --break-system-packages --no-cache-dir \
+    numpy soundfile git+https://github.com/k2-fsa/OmniVoice.git
+
+COPY runtime/voice-maker/server.py /runtime/voice-maker/server.py
+
+EXPOSE 18150
+
+CMD ["python3", "/runtime/voice-maker/server.py"]

--- a/runtime/voice-maker/server.py
+++ b/runtime/voice-maker/server.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+import base64
+import io
+import json
+import math
+import os
+import time
+import wave
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+HOST = os.environ.get("HOST", "0.0.0.0")
+PORT = int(os.environ.get("PORT", os.environ.get("NAIM_VOICE_MAKER_PORT", "18150")))
+MODEL_PATH = os.environ.get("OMNIVOICE_MODEL_PATH", "/models/omnivoice")
+DEFAULT_LANGUAGE = os.environ.get("OMNIVOICE_LANGUAGE", "auto")
+DEFAULT_VOICE_MODE = os.environ.get("OMNIVOICE_VOICE_MODE", "design")
+DEFAULT_INSTRUCT = os.environ.get(
+    "OMNIVOICE_INSTRUCT", "neutral, clear voice, medium pitch, calm style"
+)
+DEFAULT_FORMAT = os.environ.get("OMNIVOICE_OUTPUT_FORMAT", "wav")
+FAKE_MODE = os.environ.get("NAIM_VOICE_MAKER_FAKE", "0") == "1"
+STATUS_PATH = os.environ.get(
+    "NAIM_VOICE_MAKER_RUNTIME_STATUS_PATH",
+    "/tmp/naim-voice-maker-runtime-status.json",
+)
+
+_model = None
+_model_error = None
+
+
+def _write_status(status, ready, detail=""):
+    payload = {
+        "status": status,
+        "ready": ready,
+        "engine": "omnivoice",
+        "model_path": MODEL_PATH,
+        "fake": FAKE_MODE,
+        "detail": detail,
+        "updated_at_ms": int(time.time() * 1000),
+    }
+    try:
+        os.makedirs(os.path.dirname(STATUS_PATH), exist_ok=True)
+        with open(STATUS_PATH, "w", encoding="utf-8") as output:
+            json.dump(payload, output)
+    except OSError:
+        pass
+
+
+def _json_response(handler, status, payload):
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def _wav_bytes(samples, sample_rate):
+    pcm = bytearray()
+    for sample in samples:
+        clipped = max(-1.0, min(1.0, float(sample)))
+        pcm.extend(int(clipped * 32767.0).to_bytes(2, "little", signed=True))
+    output = io.BytesIO()
+    with wave.open(output, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        wav.writeframes(bytes(pcm))
+    return output.getvalue()
+
+
+def _fake_audio(text):
+    sample_rate = 24000
+    duration = min(3.0, max(0.4, len(text) / 45.0))
+    count = int(sample_rate * duration)
+    freq = 220.0
+    return [
+        0.15 * math.sin(2.0 * math.pi * freq * index / sample_rate)
+        for index in range(count)
+    ], sample_rate
+
+
+def _load_model():
+    global _model, _model_error
+    if FAKE_MODE:
+        return None
+    if _model is not None:
+        return _model
+    if not MODEL_PATH or not os.path.exists(MODEL_PATH):
+        _model_error = "OMNIVOICE_MODEL_PATH does not exist: " + MODEL_PATH
+        raise RuntimeError(_model_error)
+    try:
+        import torch
+        from omnivoice import OmniVoice
+
+        device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        dtype = torch.float16 if device.startswith("cuda") else torch.float32
+        _model = OmniVoice.from_pretrained(MODEL_PATH, device_map=device, dtype=dtype)
+        _model_error = None
+        return _model
+    except Exception as error:
+        _model_error = str(error)
+        raise
+
+
+def _synthesize(payload):
+    text = str(payload.get("text", "")).strip()
+    if not text:
+        raise ValueError("text is required")
+    output_format = str(payload.get("format") or DEFAULT_FORMAT).lower()
+    if output_format != "wav":
+        raise ValueError("only wav output is supported in this runtime contract")
+
+    started = time.monotonic()
+    if FAKE_MODE:
+        samples, sample_rate = _fake_audio(text)
+    else:
+        model = _load_model()
+        kwargs = {"text": text}
+        voice = payload.get("voice") if isinstance(payload.get("voice"), dict) else {}
+        ref_audio = voice.get("reference_audio_path") or payload.get("ref_audio")
+        ref_text = voice.get("reference_text") or payload.get("ref_text")
+        instruct = voice.get("instruct") or payload.get("instruct") or DEFAULT_INSTRUCT
+        if ref_audio:
+            kwargs["ref_audio"] = ref_audio
+            if ref_text:
+                kwargs["ref_text"] = ref_text
+        elif DEFAULT_VOICE_MODE == "design" and instruct:
+            kwargs["instruct"] = instruct
+        for key in ("speed", "duration", "num_step", "language"):
+            if key in payload:
+                kwargs[key] = payload[key]
+        generated = model.generate(**kwargs)
+        samples = generated[0]
+        sample_rate = 24000
+
+    audio = _wav_bytes(samples, sample_rate)
+    duration_ms = int((time.monotonic() - started) * 1000)
+    return {
+        "status": "ok",
+        "format": "wav",
+        "sample_rate": sample_rate,
+        "audio": {"encoding": "base64", "content_base64": base64.b64encode(audio).decode("ascii")},
+        "metrics": {
+            "duration_ms": duration_ms,
+            "input_chars": len(text),
+            "audio_bytes": len(audio),
+        },
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "naim-voice-maker/0.1"
+
+    def do_GET(self):
+        if self.path.split("?", 1)[0] == "/health":
+            ready = FAKE_MODE or (os.path.exists(MODEL_PATH) and _model_error is None)
+            _json_response(
+                self,
+                200,
+                {
+                    "status": "ok",
+                    "engine": "omnivoice",
+                    "model_path": MODEL_PATH,
+                    "ready": ready,
+                    "fake": FAKE_MODE,
+                },
+            )
+            return
+        if self.path.split("?", 1)[0] == "/v1/status":
+            _json_response(
+                self,
+                200,
+                {
+                    "status": "ok",
+                    "engine": "omnivoice",
+                    "model_path": MODEL_PATH,
+                    "loaded": _model is not None,
+                    "fake": FAKE_MODE,
+                    "error": _model_error,
+                    "language": DEFAULT_LANGUAGE,
+                    "voice_mode": DEFAULT_VOICE_MODE,
+                    "format": DEFAULT_FORMAT,
+                },
+            )
+            return
+        _json_response(self, 404, {"status": "error", "message": "not found"})
+
+    def do_POST(self):
+        if self.path.split("?", 1)[0] != "/v1/synthesize":
+            _json_response(self, 404, {"status": "error", "message": "not found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length).decode("utf-8") or "{}")
+            _json_response(self, 200, _synthesize(payload))
+        except ValueError as error:
+            _json_response(self, 400, {"status": "error", "message": str(error)})
+        except Exception as error:
+            _write_status("failed", False, str(error))
+            _json_response(self, 503, {"status": "error", "message": str(error)})
+
+    def log_message(self, fmt, *args):
+        print("voice-maker " + fmt % args, flush=True)
+
+
+if __name__ == "__main__":
+    _write_status("running", FAKE_MODE or os.path.exists(MODEL_PATH))
+    ThreadingHTTPServer((HOST, PORT), Handler).serve_forever()

--- a/scripts/build-runtime-images.sh
+++ b/scripts/build-runtime-images.sh
@@ -102,6 +102,7 @@ controller_tag="${8:-naim/controller:dev}"
 hostd_tag="${9:-naim/hostd:dev}"
 knowledge_tag="${10:-naim/knowledge-runtime:dev}"
 voice_module_tag="${11:-naim/voice-module:dev}"
+voice_maker_tag="${12:-naim/voice-maker:dev}"
 
 build_dir="$("${script_dir}/print-build-dir.sh")"
 turboquant_build_dir="${NAIM_TURBOQUANT_BUILD_DIR:-${repo_root}/build-turboquant/linux/x64}"
@@ -260,6 +261,12 @@ echo "building ${voice_module_tag}"
   -t "${voice_module_tag}" \
   "${image_context}"
 
+echo "building ${voice_maker_tag}"
+"${docker_cmd[@]}" build \
+  -f "${image_context}/runtime/voice-maker/Dockerfile" \
+  -t "${voice_maker_tag}" \
+  "${image_context}"
+
 if [[ "${skip_web_ui}" != "yes" ]]; then
   echo "building ${web_ui_tag}"
   build_web_ui_image
@@ -277,6 +284,7 @@ echo "  knowledge=${knowledge_tag}"
 echo "  webgateway=${webgateway_tag}"
 echo "  interaction=${interaction_tag}"
 echo "  voice_module=${voice_module_tag}"
+echo "  voice_maker=${voice_maker_tag}"
 if [[ "${skip_web_ui}" != "yes" ]]; then
   echo "  web_ui=${web_ui_tag}"
 fi

--- a/scripts/ci/fetch-main-release-report.sh
+++ b/scripts/ci/fetch-main-release-report.sh
@@ -78,6 +78,7 @@ manifest_controller = None
 manifest_web_ui = None
 manifest_knowledge = None
 manifest_voice_module = None
+manifest_voice_maker = None
 try:
     with open(manifest_path, "r", encoding="utf-8") as handle:
         manifest = json.load(handle)
@@ -90,6 +91,7 @@ try:
     manifest_web_ui = (manifest.get("images") or {}).get("web-ui")
     manifest_knowledge = (manifest.get("images") or {}).get("knowledge-runtime")
     manifest_voice_module = (manifest.get("images") or {}).get("voice-module")
+    manifest_voice_maker = (manifest.get("images") or {}).get("voice-maker")
 except FileNotFoundError:
     pass
 
@@ -155,6 +157,8 @@ if manifest_knowledge:
     lines.append(f"- knowledge runtime image: `{manifest_knowledge}`")
 if manifest_voice_module:
     lines.append(f"- voice module image: `{manifest_voice_module}`")
+if manifest_voice_maker:
+    lines.append(f"- voice maker image: `{manifest_voice_maker}`")
 lines.append("")
 lines.append("### Main")
 if docker_lines:

--- a/scripts/ci/main-bootstrap-controller-update.sh
+++ b/scripts/ci/main-bootstrap-controller-update.sh
@@ -119,6 +119,7 @@ print("worker_image=" + shlex.quote(images.get("worker-runtime", "")))
 print("skills_image=" + shlex.quote(images.get("skills-runtime", "")))
 print("webgateway_image=" + shlex.quote(images.get("webgateway-runtime", "")))
 print("interaction_image=" + shlex.quote(images.get("interaction-runtime", "")))
+print("voice_maker_image=" + shlex.quote(images.get("voice-maker", "")))
 PY
 )"
 
@@ -436,6 +437,7 @@ managed_images = {
 }
 interaction_image = images.get("interaction-runtime", "")
 voice_module_image = images.get("voice-module", "")
+voice_maker_image = images.get("voice-maker", "")
 
 def is_managed_image(value: object) -> bool:
     if not isinstance(value, str):
@@ -491,6 +493,14 @@ for row in rows:
             if current is None or is_managed_image(current):
                 if current != voice_module_image:
                     voice_listener["image"] = voice_module_image
+                    changed = True
+    if isinstance(features, dict) and voice_maker_image:
+        voice_maker = features.get("voice_maker")
+        if isinstance(voice_maker, dict) and voice_maker.get("enabled") is True:
+            current = voice_maker.get("image")
+            if current is None or is_managed_image(current):
+                if current != voice_maker_image:
+                    voice_maker["image"] = voice_maker_image
                     changed = True
     if not changed:
         continue

--- a/scripts/release/build-and-push-images.sh
+++ b/scripts/release/build-and-push-images.sh
@@ -216,6 +216,7 @@ knowledge_ref="$(image_ref knowledge-runtime)"
 webgateway_ref="$(image_ref webgateway-runtime)"
 interaction_ref="$(image_ref interaction-runtime)"
 voice_module_ref="$(image_ref voice-module)"
+voice_maker_ref="$(image_ref voice-maker)"
 controller_ref="$(image_ref controller)"
 hostd_ref="$(image_ref hostd)"
 
@@ -231,6 +232,7 @@ build_args=(
   "${hostd_ref}"
   "${knowledge_ref}"
   "${voice_module_ref}"
+  "${voice_maker_ref}"
 )
 
 build_runtime_images "${build_args[@]}"
@@ -246,6 +248,7 @@ declare -a image_names=(
   webgateway-runtime
   interaction-runtime
   voice-module
+  voice-maker
 )
 if [[ "${skip_web_ui}" != "yes" ]]; then
   image_names+=(web-ui)

--- a/ui/operator-react/src/modelLibrary.js
+++ b/ui/operator-react/src/modelLibrary.js
@@ -2,6 +2,7 @@ export const MODEL_LIBRARY_FORMAT_OPTIONS = [
   { value: "source", label: "Source files" },
   { value: "gguf", label: "GGUF" },
   { value: "safetensors", label: "safetensors" },
+  { value: "tts/omnivoice", label: "OmniVoice TTS" },
 ];
 
 export const MODEL_LIBRARY_GGUF_QUANTIZATIONS = [

--- a/ui/operator-react/src/planeV2Form.jsx
+++ b/ui/operator-react/src/planeV2Form.jsx
@@ -22,6 +22,9 @@ const CONTEXT_COMPRESSION_DEFAULT_MEMORY_PRIORITY = "balanced";
 const VOICE_LISTENER_DEFAULT_WAKE_PHRASE = "Hey Jex";
 const VOICE_LISTENER_DEFAULT_LANGUAGE = "auto";
 const VOICE_LISTENER_DEFAULT_MOUNT_PATH = "/models/whisper/model.bin";
+const VOICE_MAKER_DEFAULT_LANGUAGE = "auto";
+const VOICE_MAKER_DEFAULT_MOUNT_PATH = "/models/omnivoice";
+const VOICE_MAKER_DEFAULT_INSTRUCT = "neutral, clear voice, medium pitch, calm style";
 const WEBGATEWAY_DEFAULT_MAX_SEARCH_RESULTS = 8;
 const WEBGATEWAY_DEFAULT_MAX_FETCH_BYTES = 262144;
 const LT_CYPHER_PLANE_NAME = "lt-cypher-ai";
@@ -92,6 +95,8 @@ const FIELD_INFO = {
   voiceListenerModel: "Whisper model artifact used by the Voice Listener. Only whisper.cpp models are selectable here.",
   voiceListenerWakePhrase: "Phrase that activates the listener before a transcript is submitted to chat.",
   voiceListenerLanguage: "Language hint for whisper.cpp. Use auto unless a plane must listen in one fixed language.",
+  voiceMakerEnabled: "Enable a plane-owned Voice Maker service backed by OmniVoice text-to-speech.",
+  voiceMakerModel: "OmniVoice retained artifact used by the Voice Maker. Use a Model Library source bundle.",
   securedConnectionEnabled: "Require HTTPS/TLS plus SSH key authentication for users explicitly selected from User Storage.",
   securedConnectionUserIds: "Select User Storage identities that are allowed to authenticate to this plane.",
   browserSessionEnabled: "Allow approval-gated browser session APIs for this plane. Search and sanitized fetch stay enabled when Isolated Browsing is on.",
@@ -353,6 +358,15 @@ function isWhisperModelLibraryItem(item) {
 function whisperModelMountPath(item) {
   const name = String(item?.name || item?.path?.split("/").pop() || "model.bin").trim() || "model.bin";
   return `/models/whisper/${name}`;
+}
+
+function isOmniVoiceModelLibraryItem(item) {
+  const format = inferModelFormat(item);
+  if (format === "tts/omnivoice" || format === "omnivoice") {
+    return true;
+  }
+  const text = normalizeSearchText([item?.name, item?.model_id, item?.path, ...modelLibraryPaths(item)].join(" "));
+  return text.includes("omnivoice") || text.includes("text-to-speech");
 }
 
 function findLtCypherModelItem(items) {
@@ -793,6 +807,15 @@ export function buildNewPlaneFormState() {
     voiceListenerModelPaths: [],
     voiceListenerModelMountPath: VOICE_LISTENER_DEFAULT_MOUNT_PATH,
     voiceListenerImage: "",
+    voiceMakerEnabled: false,
+    voiceMakerLanguage: VOICE_MAKER_DEFAULT_LANGUAGE,
+    voiceMakerModelPath: "",
+    voiceMakerModelRef: "",
+    voiceMakerModelNodeName: "",
+    voiceMakerModelPaths: [],
+    voiceMakerModelMountPath: VOICE_MAKER_DEFAULT_MOUNT_PATH,
+    voiceMakerImage: "",
+    voiceMakerInstruct: VOICE_MAKER_DEFAULT_INSTRUCT,
     securedConnectionEnabled: false,
     securedConnectionUserIds: [],
     planeMode: "llm",
@@ -932,9 +955,12 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
   const turboquant = value?.features?.turboquant || {};
   const contextCompression = value?.features?.context_compression || {};
   const voiceListener = value?.features?.voice_listener || {};
+  const voiceMaker = value?.features?.voice_maker || {};
   const securedConnection = value?.features?.secured_connection || {};
   const voiceListenerModel = voiceListener?.model || {};
   const voiceListenerModelSource = voiceListenerModel?.source || {};
+  const voiceMakerModel = voiceMaker?.model || {};
+  const voiceMakerModelSource = voiceMakerModel?.source || {};
   const browsing = value?.webgateway && typeof value.webgateway === "object"
     ? value.webgateway
     : (value?.browsing && typeof value.browsing === "object" ? value.browsing : {});
@@ -997,6 +1023,19 @@ export function buildPlaneFormStateFromDesiredStateV2(value) {
     voiceListenerModelMountPath:
       voiceListenerModel?.mount_path || VOICE_LISTENER_DEFAULT_MOUNT_PATH,
     voiceListenerImage: voiceListener?.image || defaults.voiceListenerImage,
+    voiceMakerEnabled: Boolean(voiceMaker?.enabled),
+    voiceMakerLanguage:
+      voiceMaker?.language || VOICE_MAKER_DEFAULT_LANGUAGE,
+    voiceMakerModelPath: voiceMakerModelSource?.path || "",
+    voiceMakerModelRef: voiceMakerModelSource?.ref || voiceMakerModel?.name || "",
+    voiceMakerModelNodeName: voiceMakerModelSource?.node || "",
+    voiceMakerModelPaths: Array.isArray(voiceMakerModelSource?.paths)
+      ? voiceMakerModelSource.paths
+      : [],
+    voiceMakerModelMountPath:
+      voiceMakerModel?.mount_path || VOICE_MAKER_DEFAULT_MOUNT_PATH,
+    voiceMakerImage: voiceMaker?.image || defaults.voiceMakerImage,
+    voiceMakerInstruct: voiceMaker?.instruct || VOICE_MAKER_DEFAULT_INSTRUCT,
     securedConnectionEnabled: Boolean(securedConnection?.enabled),
     securedConnectionUserIds: Array.isArray(securedConnection?.user_ids)
       ? securedConnection.user_ids.filter((item) => typeof item === "string" && item)
@@ -1416,6 +1455,61 @@ export function buildDesiredStateV2FromForm(form) {
         size_gb: 1,
       };
     }
+    if (form.voiceMakerEnabled) {
+      const source = {
+        type: "library",
+        path: String(form.voiceMakerModelPath || "").trim(),
+      };
+      if (String(form.voiceMakerModelNodeName || "").trim()) {
+        source.node = String(form.voiceMakerModelNodeName || "").trim();
+      }
+      const sourcePaths = (Array.isArray(form.voiceMakerModelPaths)
+        ? form.voiceMakerModelPaths
+        : [])
+        .map((path) => String(path || "").trim())
+        .filter(Boolean);
+      if (sourcePaths.length > 0) {
+        source.paths = sourcePaths;
+      }
+      features.voice_maker = {
+        enabled: true,
+        language:
+          String(form.voiceMakerLanguage || "").trim() ||
+          VOICE_MAKER_DEFAULT_LANGUAGE,
+        voice_mode: "design",
+        instruct:
+          String(form.voiceMakerInstruct || "").trim() ||
+          VOICE_MAKER_DEFAULT_INSTRUCT,
+        format: "wav",
+        model: {
+          name: String(form.voiceMakerModelRef || "").trim() || "omnivoice",
+          source,
+          mount_path:
+            String(form.voiceMakerModelMountPath || "").trim() ||
+            VOICE_MAKER_DEFAULT_MOUNT_PATH,
+          env: "OMNIVOICE_MODEL_PATH",
+          required: true,
+        },
+        env: {
+          HOST: "0.0.0.0",
+          PORT: "18150",
+          OMNIVOICE_LANGUAGE:
+            String(form.voiceMakerLanguage || "").trim() ||
+            VOICE_MAKER_DEFAULT_LANGUAGE,
+          OMNIVOICE_VOICE_MODE: "design",
+          OMNIVOICE_INSTRUCT:
+            String(form.voiceMakerInstruct || "").trim() ||
+            VOICE_MAKER_DEFAULT_INSTRUCT,
+        },
+        storage: {
+          mount_path: "/naim/private",
+          size_gb: 8,
+        },
+      };
+      if (String(form.voiceMakerImage || "").trim()) {
+        features.voice_maker.image = String(form.voiceMakerImage || "").trim();
+      }
+    }
     if (form.securedConnectionEnabled) {
       features.secured_connection = {
         enabled: true,
@@ -1437,6 +1531,14 @@ export function buildDesiredStateV2FromForm(form) {
       desiredState.resources.voice_module = {
         gpu_enabled: true,
         gpu_fraction: 0.2,
+        memory_cap_mb: 4096,
+        share_mode: "shared",
+      };
+    }
+    if (form.voiceMakerEnabled) {
+      desiredState.resources.voice_maker = {
+        gpu_enabled: true,
+        gpu_fraction: 0.25,
         memory_cap_mb: 4096,
         share_mode: "shared",
       };
@@ -1676,6 +1778,9 @@ export function validatePlaneV2Form(form) {
       if (!String(form?.voiceListenerModelPath || "").trim()) {
         errors.push("Voice Listener requires a Whisper model.");
       }
+    }
+    if (form?.voiceMakerEnabled && !String(form?.voiceMakerModelPath || "").trim()) {
+      errors.push("Voice Maker requires an OmniVoice model.");
     }
     if (Number(form?.inferReplicas || 0) <= 0) {
       errors.push("Infer replicas must be a positive integer for llm planes.");
@@ -2389,6 +2494,7 @@ export function PlaneV2FormBuilder({
           browsingEnabled: nextPlaneMode === "llm" ? current.browsingEnabled : false,
           knowledgeEnabled: nextPlaneMode === "llm" ? current.knowledgeEnabled : false,
           voiceListenerEnabled: nextPlaneMode === "llm" ? current.voiceListenerEnabled : false,
+          voiceMakerEnabled: nextPlaneMode === "llm" ? current.voiceMakerEnabled : false,
           browserSessionEnabled:
             nextPlaneMode === "llm" ? current.browserSessionEnabled : false,
         });
@@ -2522,6 +2628,16 @@ export function PlaneV2FormBuilder({
       voiceListenerModelPaths: Array.isArray(item?.paths) ? item.paths : [],
       voiceListenerModelMountPath: whisperModelMountPath(item),
     }));
+  }
+
+  function selectVoiceMakerModel(item) {
+    updateForm({
+      voiceMakerModelPath: item?.path || "",
+      voiceMakerModelRef: item?.model_id || item?.name || item?.path || "omnivoice",
+      voiceMakerModelNodeName: item?.node_name || "",
+      voiceMakerModelPaths: Array.isArray(item?.paths) ? item.paths : [],
+      voiceMakerModelMountPath: VOICE_MAKER_DEFAULT_MOUNT_PATH,
+    });
   }
 
   function updateTopologyNodes(update) {
@@ -2676,6 +2792,8 @@ export function PlaneV2FormBuilder({
   const factoryTreePaths = collectSkillsFactoryTreePaths(factoryGroupTree);
   const whisperModelLibraryItems = (Array.isArray(modelLibraryItems) ? modelLibraryItems : [])
     .filter(isWhisperModelLibraryItem);
+  const omniVoiceModelLibraryItems = (Array.isArray(modelLibraryItems) ? modelLibraryItems : [])
+    .filter(isOmniVoiceModelLibraryItem);
   const expandedFactoryGroupPathSet = new Set(expandedFactoryGroupPaths);
 
   function renderFactoryGroupNode(node) {
@@ -2897,6 +3015,14 @@ export function PlaneV2FormBuilder({
           disabled={form.planeMode !== "llm"}
           disabledLabel="LLM only"
           onToggle={toggleFeature("voiceListenerEnabled")}
+        />
+        <FeatureToggle
+          title="Voice Maker"
+          info={FIELD_INFO.voiceMakerEnabled}
+          active={form.planeMode === "llm" && form.voiceMakerEnabled}
+          disabled={form.planeMode !== "llm"}
+          disabledLabel="LLM only"
+          onToggle={toggleFeature("voiceMakerEnabled")}
         />
         <FeatureToggle
           title="App"
@@ -3249,6 +3375,82 @@ export function PlaneV2FormBuilder({
               items={whisperModelLibraryItems}
               selectedPath={form.voiceListenerModelPath}
               onSelect={selectVoiceListenerModel}
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {form.planeMode === "llm" && form.voiceMakerEnabled ? (
+        <div className="plane-form-toggle">
+          <div className="plane-form-section-header">
+            <InfoLabel info={FIELD_INFO.voiceMakerEnabled}>Voice Maker</InfoLabel>
+            <p className="plane-form-section-copy">
+              Plane-owned OmniVoice text-to-speech service for spoken assistant replies.
+            </p>
+          </div>
+          <div className="plane-form-grid">
+            <label className="field-label">
+              <InfoLabel info={FIELD_INFO.voiceListenerLanguage}>Language</InfoLabel>
+              <input
+                className="text-input"
+                value={form.voiceMakerLanguage}
+                onChange={bindText("voiceMakerLanguage")}
+              />
+            </label>
+            <label className="field-label">
+              <InfoLabel info={FIELD_INFO.voiceMakerModel}>OmniVoice model path</InfoLabel>
+              <input
+                className={inputClassName(Boolean(fieldError("Voice Maker requires an OmniVoice model.")))}
+                value={form.voiceMakerModelPath}
+                onChange={bindText("voiceMakerModelPath")}
+              />
+              <FieldHint message={fieldError("Voice Maker requires an OmniVoice model.")} />
+            </label>
+            <label className="field-label">
+              <InfoLabel info={FIELD_INFO.sourceStorageNode}>OmniVoice model node</InfoLabel>
+              <input
+                className="text-input"
+                value={form.voiceMakerModelNodeName}
+                onChange={bindText("voiceMakerModelNodeName")}
+              />
+            </label>
+            <label className="field-label">
+              <InfoLabel info={FIELD_INFO.voiceMakerModel}>Container mount path</InfoLabel>
+              <input
+                className="text-input"
+                value={form.voiceMakerModelMountPath}
+                onChange={bindText("voiceMakerModelMountPath")}
+              />
+            </label>
+            <label className="field-label">
+              <InfoLabel info={FIELD_INFO.voiceMakerModel}>Voice image</InfoLabel>
+              <input
+                className="text-input"
+                value={form.voiceMakerImage}
+                onChange={bindText("voiceMakerImage")}
+              />
+            </label>
+            <label className="field-label">
+              <InfoLabel info={FIELD_INFO.voiceMakerEnabled}>Neutral voice instruction</InfoLabel>
+              <textarea
+                className="editor-textarea plane-form-textarea"
+                value={form.voiceMakerInstruct}
+                onChange={bindText("voiceMakerInstruct")}
+                rows={3}
+              />
+            </label>
+          </div>
+          <div className="field-label">
+            <InfoLabel
+              info="Choose one OmniVoice source bundle from Model Library. The selected row becomes the Voice Maker model source."
+              className="field-label-title"
+            >
+              OmniVoice Model Library
+            </InfoLabel>
+            <ModelLibraryPicker
+              items={omniVoiceModelLibraryItems}
+              selectedPath={form.voiceMakerModelPath}
+              onSelect={selectVoiceMakerModel}
             />
           </div>
         </div>

--- a/ui/operator-react/src/skillsFactory.test.js
+++ b/ui/operator-react/src/skillsFactory.test.js
@@ -379,6 +379,63 @@ describe("planeV2Form SkillsFactory mapping", () => {
     expect(reparsed.voiceListenerModelPath).toBe("/models/whisper/ggml-large-v3-turbo-q5_0.bin");
   });
 
+  it("round-trips voice maker capability through desired state v2", () => {
+    const form = buildNewPlaneFormState();
+    form.planeName = "voice-maker-plane";
+    form.modelPath = "/models/qwen";
+    form.voiceMakerEnabled = true;
+    form.voiceMakerLanguage = "auto";
+    form.voiceMakerModelPath = "/models/tts/omnivoice-neutral";
+    form.voiceMakerModelRef = "omnivoice-neutral";
+    form.voiceMakerModelNodeName = "storage1";
+    form.voiceMakerModelPaths = ["/models/tts/omnivoice-neutral"];
+    form.voiceMakerModelMountPath = "/models/omnivoice";
+    form.voiceMakerInstruct = "neutral, clear voice";
+
+    const desiredState = buildDesiredStateV2FromForm(form);
+    expect(desiredState.features.voice_maker).toEqual({
+      enabled: true,
+      language: "auto",
+      voice_mode: "design",
+      instruct: "neutral, clear voice",
+      format: "wav",
+      model: {
+        name: "omnivoice-neutral",
+        source: {
+          type: "library",
+          path: "/models/tts/omnivoice-neutral",
+          node: "storage1",
+          paths: ["/models/tts/omnivoice-neutral"],
+        },
+        mount_path: "/models/omnivoice",
+        env: "OMNIVOICE_MODEL_PATH",
+        required: true,
+      },
+      env: {
+        HOST: "0.0.0.0",
+        PORT: "18150",
+        OMNIVOICE_LANGUAGE: "auto",
+        OMNIVOICE_VOICE_MODE: "design",
+        OMNIVOICE_INSTRUCT: "neutral, clear voice",
+      },
+      storage: {
+        mount_path: "/naim/private",
+        size_gb: 8,
+      },
+    });
+    expect(desiredState.resources.voice_maker).toEqual({
+      gpu_enabled: true,
+      gpu_fraction: 0.25,
+      memory_cap_mb: 4096,
+      share_mode: "shared",
+    });
+
+    const reparsed = buildPlaneFormStateFromDesiredStateV2(desiredState);
+    expect(reparsed.voiceMakerEnabled).toBe(true);
+    expect(reparsed.voiceMakerModelPath).toBe("/models/tts/omnivoice-neutral");
+    expect(reparsed.voiceMakerModelMountPath).toBe("/models/omnivoice");
+  });
+
   it("preserves interaction runtime image through desired state v2 round-trip", () => {
     const desiredState = {
       ...buildDesiredStateV2FromForm(buildNewPlaneFormState()),


### PR DESCRIPTION
Adds the plane-owned Voice Maker capability for OmniVoice TTS, including desired-state rendering/projecting, controller and hostd proxy routes, runtime image, WebUI configuration, Model Library format support, and release image propagation.\n\nLocal checks run:\n- npm test -- --run src/skillsFactory.test.js src/modelLibrary.test.js\n- /tmp/naim-node-voice-maker-build/naim-state-v2-tests\n- /tmp/naim-node-voice-maker-build/naim-state-v2-projector-tests\n- /tmp/naim-node-voice-maker-build/naim-model-library-tests\n- runtime/voice-maker fake-mode health/status/synthesize smoke