### PR TITLE
Preserve assigned worker GPU in compose env

### DIFF
--- a/common/src/planning/compose_renderer_tests.cpp
+++ b/common/src/planning/compose_renderer_tests.cpp
@@ -110,6 +110,18 @@ int main() {
     Expect(
         visible_devices != infer_it->environment.end() && visible_devices->second == "0",
         "planner should expose inherited gpu devices through NVIDIA_VISIBLE_DEVICES");
+    const auto worker_it = std::find_if(
+        llama_rpc_plans.front().services.begin(),
+        llama_rpc_plans.front().services.end(),
+        [](const naim::ComposeService& compose_service) {
+          return compose_service.name == "worker-a";
+        });
+    Expect(worker_it != llama_rpc_plans.front().services.end(),
+           "planner should include worker service in llama-rpc compose plan");
+    const auto assigned_gpu = worker_it->environment.find("NAIM_GPU_DEVICE");
+    Expect(
+        assigned_gpu != worker_it->environment.end() && assigned_gpu->second == "0",
+        "planner should preserve assigned host gpu through NAIM_GPU_DEVICE");
 
 #if defined(_WIN32)
     _putenv_s("NAIM_CONTROLLER_INTERNAL_HOST", "");

--- a/common/src/planning/planner.cpp
+++ b/common/src/planning/planner.cpp
@@ -256,6 +256,7 @@ ComposeService BuildComposeService(
   }
   if (service.gpu_device.has_value()) {
     service.use_nvidia_runtime = true;
+    service.environment["NAIM_GPU_DEVICE"] = *service.gpu_device;
     service.environment["NVIDIA_DRIVER_CAPABILITIES"] = "compute,utility";
     service.environment["NVIDIA_VISIBLE_DEVICES"] =
         service.gpu_devices.empty() ? *service.gpu_device


### PR DESCRIPTION
## Summary
- pass the assigned host GPU into worker containers via NAIM_GPU_DEVICE
- cover the llama-rpc compose plan so worker status keeps the host GPU assignment instead of relying on container-local CUDA indexes

## Test
- hpc1 shared-storage sandbox: cmake --build build/linux/x64 --target naim-compose-renderer-tests
- hpc1 shared-storage sandbox: ./build/linux/x64/naim-compose-renderer-tests